### PR TITLE
Cleanup of QR code related code ...

### DIFF
--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -35,11 +35,7 @@ block content
                 div.copybutton(class = "btn-sm", id = "copyButton", type = "button", onclick = "CopyConfirm(component.componentUuid)") Copy
             
             dt Short UUID
-            
-            if component.shortUuid
-              dd #{component.shortUuid}
-            else
-              dd Not Available
+            dd #{component.shortUuid}
             
             dt Type
             dd #{component.formName || component.formId}
@@ -108,10 +104,7 @@ block content
           
         .col-md-3
           div#qr-code
-            if component.shortUuid
-              +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-            else
-              +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
     
     div.vert-space-x2
       hr

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -6,52 +6,30 @@ block vars
 
 block allbody
   div.vert-space-x2.form-inline.noprint
-    div.hori-space-x1.switchToggle
-      input#qr-error-safe(type = "checkbox", checked = "checked")
-      label.label-primary(for = 'qr-error-safe')
-    
-    div.hori-space-x2
+    div.hori-space-x1
       a.btn.btn-primary(onclick = "window.print(); return false;" href = '#print') Print QR Codes
   
   div.vert-space-x2(style = 'clear: both;')
     .container
       .row.qr-row
         div.col-sm-6(style = "border: 1px solid #EEE")
-          if component.shortUuid
-            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-          else
-            +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+          +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
         
         div.col-sm-6(style = "border: 1px solid #EEE")
-          if component.shortUuid
-            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-          else
-            +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+          +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
       
       .row.qr-row
         div.col-sm-6(style = "border: 1px solid #EEE")
-          if component.shortUuid
-            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-          else
-            +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+          +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
         
         div.col-sm-6(style = "border: 1px solid #EEE")
-          if component.shortUuid
-            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-          else
-            +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+          +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
       
       .row.qr-row
         div.col-sm-6(style = "border: 1px solid #EEE")
-          if component.shortUuid
-            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-          else
-            +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+          +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
         
         div.col-sm-6(style = "border: 1px solid #EEE")
-          if component.shortUuid
-            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-          else
-            +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+          +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
   
   div.vert-space-x2

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -107,10 +107,7 @@ block allbody
         
         .col-md-3
           div#qr-code
-            if component.shortUuid
-              +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
-            else
-              +qr-panel(base_url + '/component/' + component.componentUuid.toString(), component.data.name)
+            +qr-panel(base_url + '/c/' + component.shortUuid.toString(), component.data.name)
       
       div.pagebreak
       

--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -192,7 +192,6 @@ script(src = '/components/ComponentArray.js')
 script(src = '/components/ComponentSpecNumber.js')
 script(src = '/components/Components_misc.js')
 script(src = '/components/DatabaseImage.js')
-script(src = '/components/DatabaseFile.js')
 
 script(src = '/js/AnnotationCanvas.js')
 script(src = '/components/ImageAnnotator.js')

--- a/app/static/components/ComponentUUID_Component.js
+++ b/app/static/components/ComponentUUID_Component.js
@@ -100,16 +100,10 @@ class ComponentUUID_Component extends QR_Component{
 
   cameraCallback(index,qrcode)
   {
-    // do the match thing
-    var match_long = qrcode.match(".*/([A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12})");
-    if(match_long) {
-      this.setValueAt(index,match_long[1]);
-    }
-
-    var match_short = qrcode.match(".*/([123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ-]{22})");
-    if(match_short) {
-      var txt = match_short[1].match('[^\-]*')[0];
-      var uuid = ShortUUID().toUUID(txt);
+    var match_address = qrcode.match(".*/([123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ-]{22})");
+    if(match_address) {
+      var shortuuid = match_address[1].match('[^\-]*')[0];
+      var uuid = ShortUUID().toUUID(shortuuid);
       this.setValueAt(index,uuid);
       return true;
     }

--- a/app/static/js/generate_qr_code.js
+++ b/app/static/js/generate_qr_code.js
@@ -1,149 +1,54 @@
-$(function(){
-  DrawQRCodes();
-  $('#qr-error-safe').on("change",DrawQRCodes);
-  ResizeQrText();
-  $( window ).resize(ResizeQrText);
 
+// Main function for generating and displaying a QR code canvas
+$(function() {
+  DrawQRCode();
+  ResizeQRText();
+  $( window ).resize(ResizeQRText);
 })
- 
 
-function ResizeQrText() {
-    $('div.qr').each(function(){
-      $(this).css('font-size',15*$(this).width()/500);
-     })
-}
-// This function to redraw all QR canvases.
-function DrawQRCodes(){
-  // lowres = false means lots of error correction, 
-  // lowres = true means low-res, easier to see
-  var lowres = $('#qr-error-safe').is(":not(:checked)");
-  var short = true;
-  canvases = $("canvas.qr-code");
-
-  // newer version: no text in canvas, use CSS to do that instead.
-  console.log("DrawQRCode",...arguments);
-  $(canvases).each(function(){
-      var canvas = this;
-      var text = $(canvas).data('qr-text');
-      var desc = $(canvas).data('qr-desc');
-
-      // if using short code, then reformat the text for the QR.
-      if(short) {
-        var regex_match = text.match(/(([A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}))/);
-        if(regex_match && regex_match[0]) {
-          var uuid = regex_match[0];
-          // this uses base58 encoding, which usually will yield 21 to 22 characters.
-          var short_uuid = ShortUUID().fromUUID(uuid);
-          // pad the short code to 22 characters, to ensure matching.
-          var padded = short_uuid.padEnd(22,'-'); 
-          text = text.substr(0,regex_match.index) + short_uuid + text.substr(regex_match.index+regex_match[0].length);
-
-        } else {
-          // Whaaaaat?
-          console.error('couldnt find the UUID')
-        }
-
-      }
-      console.log("Drawing QR code",text,desc,lowres);
-
-      var segs = qrcodegen.QrSegment.makeSegments(text);
-
-      var ecl = qrcodegen.QrCode.Ecc.HIGH;
-      var minVersion = 8; // 8; // Determines size, but adds correction bits.
-      if(short) {
-        minVersion = 1; // not quite so many bits.
-      }
-     if(lowres){
-        ecl = qrcodegen.QrCode.Ecc.LOW;
-        minVersion = 1; // 8; // Determines size, but adds correction bits.
-      }
-      var qr = qrcodegen.QrCode.encodeSegments(segs, ecl, minVersion);
-      gqr = qr;
-      console.log(qr);
-      var w = canvas.width;
-      var scale = 8;//Math.Round(w/12*8);
-      var border = 0; //w/12*4;
-
-      var ctx = canvas.getContext("2d");
-      qr.drawCanvas(scale, border, canvas);
+// Resize the displayed QR code canvas text based on the window size
+function ResizeQRText() {
+  $('div.qr').each(function() {
+    $(this).css('font-size', 15 * $(this).width() / 500);
   })
+}
 
-
- //  // This is the older version that puts in the text in the canvas.
- //  console.log("DrawQRCode",...arguments);
-	// $(canvases).each(function(){
-	// 		var canvas = this;
- //      var text = $(canvas).data('qr-text');
- //      var desc = $(canvas).data('qr-desc');
-
-	// 		var segs = qrcodegen.QrSegment.makeSegments(text);
-
-	// 		var ecl = qrcodegen.QrCode.Ecc.HIGH;
- //      var minVersion = 8; // 8; // Determines size, but adds correction bits.
-
- //      console.log("Drawing QR code",text,desc,lowres);
-
- //     if(lowres){
- //        ecl = qrcodegen.QrCode.Ecc.LOW;
-	//   		minVersion = 1; // 8; // Determines size, but adds correction bits.
- //      }
-	// 		var qr = qrcodegen.QrCode.encodeSegments(segs, ecl, minVersion);
- //      gqr = qr;
-	//     console.log(qr);
- //      var w = canvas.width;
- //      var scale = 12;//Math.Round(w/12*8);
- //      var border = 8; //w/12*4;
-
- //  	// 	var scale = 8; // pixels per module
-	// 		// var border = 8;//4; // modules
-	// 		// var svg = document.getElementById("qrcode-svg");
-	// 		// canvas.style.display = "none";
-	// 		// svg.style.display = "none";
-
-	// 		var ctx = canvas.getContext("2d");
-	// 		qr.drawCanvas(scale, border, canvas);
-	// 		ctx.font = "16px Inconsolata";
-	// 		ctx.fillStyle = "black";
-	// 		var width = canvas.width;
-	// 		var height = canvas.height;
-	// 		ctx.save();
-	// 		ctx.translate(width/2,height/2);
-
-	// 		ctx.save();
-	// 		ctx.translate(-width/2,-height/2);
-
- //        ctx.scale(width/520,width/520);
- //  			ctx.fillText(text,14,14);
- //  			if(desc) ctx.fillText(desc,14,31);
-
-	// 		ctx.restore();
-
-	// 		ctx.rotate(90*Math.PI/180.)
-	// 		ctx.save();
-	// 		ctx.translate(-width/2,-height/2);
- //        ctx.scale(width/520,width/520);
- //        ctx.fillText(text,14,14);
- //        if(desc) ctx.fillText(desc,14,31);
-	// 		ctx.restore();
-
-	// 		ctx.rotate(90*Math.PI/180.)
-	// 		ctx.save();
-	// 		ctx.translate(-width/2,-height/2);
- //        ctx.scale(width/520,width/520);
- //        ctx.fillText(text,14,14);
- //        if(desc) ctx.fillText(desc,14,31);
-	// 		ctx.restore();
-
-	// 		ctx.rotate(90*Math.PI/180.)
-	// 		ctx.save();
-	// 		ctx.translate(-width/2,-height/2);
- //        ctx.scale(width/520,width/520);
- //        ctx.fillText(text,14,14);
- //        if(desc) ctx.fillText(desc,14,31);
-	// 		ctx.restore();
-
-	// 		ctx.restore();
-	// })
-
+// Draw (or redraw) a single QR code canvas
+function DrawQRCode() {
+  
+  // Each individual QR code points to a web address like the following: [base_url]/c/[short_uuid]
+  // where:  [base_url]   = http://localhost:12313 for development deployments, or https://apa.dunedb.org for the production deployment
+  //         [short_uuid] = the 22 character-length short component UUID
+  // QR codes DO NOT use the full (36 character-length) component UUID
+  
+  // Set up one or more canvases onto which to (re)draw QR codes
+  canvases = $("canvas.qr-code");
+  
+  // For each canvas being (re)drawn ...
+  $(canvases).each(function() {
+    
+    // Retrieve the canvas, as well as the text and description to write on each side of the QR code
+    // The 'text' will always be the full web address that the QR code is to point to
+    // The 'desc' will always be the component name
+    var canvas = this;
+    var text = $(canvas).data('qr-text');
+    var desc = $(canvas).data('qr-desc');
+    
+    // Generate the QR code segments representing the 'text' string
+    var segs = qrcodegen.QrSegment.makeSegments(text);
+    
+    // Set the error correction level 
+    var ecl = qrcodegen.QrCode.Ecc.HIGH;
+    
+    // Create the overall QR code using the segments and error correction level
+    var qr = qrcodegen.QrCode.encodeSegments(segs, ecl);
+    
+    // Set up some canvas parameters
+    var scale  = 8;
+    var border = 0;
+    
+    // Draw the QR code onto the canvas, with the provided canvas parameters
+    qr.drawCanvas(scale, border, canvas);
+  })
 };
 


### PR DESCRIPTION
- removed all instances where the full UUID could be used to generate a QR code, and where a full UUID might attempt to be decoded from a QR code.  (All QR codes always now use the shortened UUID, so any references to full UUIDs are redundant anyway.)
- cleaned up code for actually generating and displaying QR codes ... related to above, there was some code left over that was attempting to use a full UUID, and was failing and throwing an irrelevant console error
- removed a left-over reference in the Dashboard pug to a file that was removed in a previous commit