### PR TITLE
Removing use of caches ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -2,7 +2,6 @@ const Binary = require('mongodb').Binary;
 const MUUID = require('uuid-mongodb');
 const shortuuid = require('short-uuid')();
 
-const Cache = require('lib/Cache.js');
 const commonSchema = require('lib/commonSchema.js');
 const { db } = require('./db');
 const dbLock = require('lib/dbLock.js');
@@ -88,8 +87,6 @@ async function save(input, req) {
   // Make a copy of the inserted record, and convert the 'componentUuid' from binary to string format, for better readability and consistent display
   let record = { ...result.ops[0] };
   record.componentUuid = MUUID.from(newRecord.componentUuid).toString();
-
-  Cache.invalidate('componentCountsByType');
 
   // Return the record as proof that it has been saved successfully
   return record;
@@ -223,8 +220,8 @@ async function list(match_condition, options) {
 }
 
 
-/// (Re)generate the cache of component counts by type
-Cache.add('componentCountsByType', async function () {
+/// Get the currently cached component counts by type
+async function componentCountsByTypes() {
   // Set up the 'aggregation stages' of the database query - these are the query steps in sequence
   let aggregation_stages = [];
 
@@ -265,13 +262,6 @@ Cache.add('componentCountsByType', async function () {
 
   // Return the final results
   return returnedValues;
-});
-
-
-/// Get the currently cached component counts by type
-async function componentCountsByTypes() {
-  const currentCache = Cache.current('componentCountsByType');
-  return currentCache;
 }
 
 

--- a/app/lib/Forms.js
+++ b/app/lib/Forms.js
@@ -58,7 +58,6 @@ async function save(input, collection, req) {
   if (result.insertedCount !== 1) throw new Error(`Forms::save() - failed to insert a new type form record into the database!`);
 
   Cache.invalidate(`formlist_${collection}`);
-  Cache.invalidate('typeFormTags');
 
   // Return the record as proof that it has been saved successfully
   return result.ops[0];
@@ -167,8 +166,8 @@ async function list(collection) {
 }
 
 
-/// (Re)generate the cache of type form tags
-Cache.add('typeFormTags', async function () {
+/// Get a list of all currently used type form tags
+async function tags() {
   // Simultaneously get lists of type form tags from each type form collection
   // This returns a list containing three sub-lists, one for each collection
   const tags_lists = await Promise.all([
@@ -188,13 +187,6 @@ Cache.add('typeFormTags', async function () {
 
   // Return an object containing the set of tags, but as keys that can be more easily utilised than a simple array of them
   return Object.keys(tokens);
-});
-
-
-/// Get the currently cached type form tags
-async function tags() {
-  const currentCache = Cache.current('typeFormTags');
-  return currentCache;
 }
 
 

--- a/app/pug/tags.pug
+++ b/app/pug/tags.pug
@@ -12,7 +12,7 @@ block content
       p Tags may be assigned to component, action or workflow type forms using their respective 'Edit Type Form' pages.
         br
         | Please note that you must have the correct user permission [forms:edit] to add and modify tags.
-      p The table below lists all currently cached type form tags (apart from the 'Trash' tag), and which component, action and/or workflow type forms each tag is associated with.
+      p The table below lists all currently used type form tags (apart from the 'Trash' tag), and which component, action and/or workflow type forms each tag is associated with.
 
       hr
 


### PR DESCRIPTION
... for retrieving lists of component count by type and type form tags ... might solve the issue of duplicated UKIDs on geometry boards.