### PR TITLE
Edge case fix for shipment with no boards ...

### DIFF
--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -82,8 +82,12 @@ block content
                     tbody
                       each info in shipmentDetails
                         tr
-                          td
-                            a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+                          if info[0] == 'none'
+                            td  #{info[0]}
+                          else
+                            td
+                              a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
                           td #{info[1]}
 
             if component.data.subComponent_fullUuids

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -45,9 +45,16 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
 
     if (component.formId === 'BoardShipment') {
       for (const info of component.data.boardUuiDs) {
-        const boardRecord = await Components.retrieve(info.component_uuid);
+        let uuid = info.component_uuid;
+        let ukid = 'none';
 
-        shipmentDetails.push([info.component_uuid, boardRecord.data.typeRecordNumber]);
+        if (uuid === '') uuid = 'none';
+        else {
+          const boardRecord = await Components.retrieve(uuid);
+          ukid = boardRecord.data.typeRecordNumber;
+        }
+
+        shipmentDetails.push([uuid, ukid]);
       }
     }
 
@@ -131,9 +138,16 @@ router.get('/component/' + utils.uuid_regex + '/summary', permissions.checkPermi
 
     if (component.formId === 'BoardShipment') {
       for (const info of component.data.boardUuiDs) {
-        const boardRecord = await Components.retrieve(info.component_uuid);
+        let uuid = info.component_uuid;
+        let ukid = 'none';
 
-        shipmentDetails.push([info.component_uuid, boardRecord.data.typeRecordNumber]);
+        if (uuid === '') uuid = 'none';
+        else {
+          const boardRecord = await Components.retrieve(uuid);
+          ukid = boardRecord.data.typeRecordNumber;
+        }
+
+        shipmentDetails.push([uuid, ukid]);
       }
     }
 


### PR DESCRIPTION
- where a board shipment has a board entry but no board UUID, UUID and UKID are now set to 'none' and displayed as such
- why would you make a shipment that doesn't have any boards ... why not just wait until you have at least one to put in