### PR TITLE
Packages Cleanup (part 1):

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,9 +2,6 @@ const { NODE_ENV, APP_PORT } = require('./lib/constants');
 const { db } = require('./lib/db');
 const logger = require('./lib/logger');
 
-// Set the current directory (from the '__dirname' environment variable) as the base for all future 'require' lines
-require('app-module-path').addPath(__dirname);
-
 var createApp = require('./app');
 let http;
 const options = {};

--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -1,11 +1,11 @@
 const MUUID = require('uuid-mongodb');
 const ObjectID = require('mongodb').ObjectID;
 
-const commonSchema = require('lib/commonSchema.js');
+const commonSchema = require('./commonSchema');
 const { db } = require('./db');
-const dbLock = require('lib/dbLock.js');
-const Forms = require('lib/Forms.js');
-const permissions = require('lib/permissions.js');
+const dbLock = require('./dbLock');
+const Forms = require('./Forms');
+const permissions = require('./permissions');
 
 
 /// Save a new or edited action record

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -3,11 +3,11 @@ const deepmerge = require('deepmerge');
 const MUUID = require('uuid-mongodb');
 const ShortUUID = require('short-uuid');
 
-const commonSchema = require('lib/commonSchema.js');
+const commonSchema = require('./commonSchema');
 const { db } = require('./db');
-const dbLock = require('lib/dbLock.js');
-const Forms = require('lib/Forms.js');
-const permissions = require('lib/permissions.js');
+const dbLock = require('./dbLock');
+const Forms = require('./Forms');
+const permissions = require('./permissions');
 
 
 /// Generate a new component UUID

--- a/app/lib/Forms.js
+++ b/app/lib/Forms.js
@@ -1,7 +1,7 @@
-const commonSchema = require('lib/commonSchema.js');
+const commonSchema = require('./commonSchema');
 const { db } = require('./db');
-const dbLock = require('lib/dbLock.js');
-const permissions = require('lib/permissions.js');
+const dbLock = require('./dbLock');
+const permissions = require('./permissions');
 
 
 /// Save a new or edited type form record

--- a/app/lib/Search.js
+++ b/app/lib/Search.js
@@ -1,6 +1,6 @@
 const MUUID = require('uuid-mongodb');
 
-const Components = require('lib/Components.js');
+const Components = require('./Components');
 const { db } = require('./db');
 
 

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -1,10 +1,10 @@
 const ObjectID = require('mongodb').ObjectID;
 
-const commonSchema = require('lib/commonSchema.js');
+const commonSchema = require('./commonSchema');
 const { db } = require('./db');
-const dbLock = require('lib/dbLock.js');
-const Forms = require('lib/Forms.js');
-const permissions = require('lib/permissions.js');
+const dbLock = require('./dbLock');
+const Forms = require('./Forms');
+const permissions = require('./permissions');
 
 
 /// Save a new or edited workflow record

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -22,7 +22,14 @@ block content
     .vert-space-x1
       dl
         dt Action Type
-        dd #{action.typeFormName}
+        dd 
+          .form-inline
+            a #{action.typeFormName}
+
+            .hori-space-x1
+              a.btn-sm.btn-primary(href = `/action/${action.typeFormId}/unspec`)
+                img.small-icon(src = '/images/run_icon.svg')
+                | &nbsp; Perform a New Action of this Type
 
         dt Action Name
 
@@ -88,13 +95,5 @@ block content
         a.btn.btn-secondary(href = `/json/action/${action.actionId}`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; View JSON Record
-
-    .vert-space-x2
-      hr
-
-    .vert-space-x2
-      a.btn.btn-primary(href = `/action/${action.typeFormId}/unspec`)
-        img.small-icon(src = '/images/run_icon.svg')
-        | &nbsp; Perform a New Action of this Type
 
     .vert-space-x2

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -27,16 +27,22 @@ block content
         .col
           dl
             dt Component Type
-            dd #{component.formName}
+            dd
+              .form-inline
+                a #{component.formName}
+
+                .hori-space-x1
+                  a.btn-sm.btn-primary(href = `/component/${component.formId}`)
+                    img.small-icon(src = '/images/run_icon.svg')
+                    | &nbsp; Create a New Component of this Type
 
             dt Component UUID
             dd
               .form-inline
                 a(href = `/component/${component.componentUuid}`) #{component.componentUuid}
 
-                p &nbsp; &nbsp;
-
-                a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
+                .hori-space-x1
+                  a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
 
             dt Component Name
 
@@ -47,6 +53,10 @@ block content
 
             dt Short UUID
             dd #{component.shortUuid}
+
+            if(component.formId == 'GroundingMeshPanel')
+              dt Factory ID
+              dd #{component.data.typeRecordNumber}
 
             if component.workflowId
               dt Part of Workflow:

--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -11,18 +11,35 @@ head
   <meta http-equiv = 'X-UA-Compatible' content = 'IE=edge'>
   <meta name = 'viewport' content = 'width = device-width, initial-scale = 1, shrink-to-fit = no'>
 
+  //- Load internal stylesheets
+  //- Note that internal libraries are loaded at the end of the page, so as to not slow down the page rendering
   link(rel = 'icon', href = '/images/browser_icon.png', type = 'image/png')
   link(rel = 'stylesheet', href = '/css/dashboard.css')
   link(rel = 'stylesheet', href = '/css/custom.scss')
-  link(rel = 'stylesheet', href = '/dist/formiojs/formio.full.min.css')
   link(rel = 'stylesheet', href = '/css/common.css')
   link(rel = 'stylesheet', href = '/css/component.css')
   link(rel = 'stylesheet', href = '/css/component_qrCodes.css')
   link(rel = 'stylesheet', href = '/css/component_summary.css')
+
+  //- Load external stylesheets and libraries
+  //- Note that for the libraries, the 'jQuery' one must be loaded first, since some of the others depend on it
+  link(rel = 'preload', href = 'https://cdn.jsdelivr.net/npm/formiojs@4.13.3/dist/formio.full.min.css', as = 'style', 
+    integrity = 'sha256-s29fAUUeOwl+ddJh9Syk/WJ5CjZiAI6BWG4uPhtKlps=', crossorigin = 'anonymous')
+  link(rel = 'stylesheet', href = 'https://cdn.jsdelivr.net/npm/formiojs@4.13.3/dist/formio.full.min.css', 
+    integrity = 'sha256-s29fAUUeOwl+ddJh9Syk/WJ5CjZiAI6BWG4uPhtKlps=', crossorigin = 'anonymous')
   link(rel = 'preload', href = 'https://fonts.googleapis.com/css2?family=Inconsolata&family=Palanquin&display=swap', as = 'style')
   link(rel = 'stylesheet', href = 'https://fonts.googleapis.com/css2?family=Inconsolata&family=Palanquin&display=swap')
 
-  script(src = '/dist/jquery/jquery.min.js')
+  script(src = 'https://code.jquery.com/jquery-3.6.0.min.js', 
+    integrity = 'sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=', crossorigin = 'anonymous')
+  script(src = 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js', 
+    integrity = 'sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct', crossorigin = 'anonymous')
+  script(src = 'https://cdn.jsdelivr.net/npm/bootstrap-autocomplete@2.3.5/dist/latest/bootstrap-autocomplete.min.js', 
+    integrity = 'sha256-2CNWY27yrzaMaN0z20KTdau9frXTl5aBOZ3E7rSGOSo=', crossorigin = 'anonymous')
+  script(src = 'https://cdn.jsdelivr.net/npm/formiojs@4.13.3/dist/formio.full.min.js', 
+    integrity = 'sha256-VvJv52ezJBJcslMJon3iRdmJAUZjNXqcm8S+smOYhho=', crossorigin = 'anonymous')
+  script(src = 'https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js', 
+    integrity = 'sha384-2EBe4bOCAHoiyZtAsgW2cgo3crpM072svgIIV2pYxOQWejDaa1rMJA9NH6LCkVQb', crossorigin = 'anonymous')
 
 mixin navlink
   if(attributes.href == route)
@@ -145,21 +162,11 @@ body(class = `deployment-${NODE_ENV}`)
         block content 
 
 
-//- Bootstrap core JavaScript
-//- ==========================================================
-//- Placed at the end of the document so the pages load faster
-
+//- Load internal libraries and set any global parameters and settings
 script(src = '/pages/dashboard.js')
-
-script(src = '/dist/bootstrap/js/bootstrap.bundle.min.js')
-script(src = '/dist/bootstrap-autocomplete/latest/bootstrap-autocomplete.min.js')
-script(src = '/dist/formiojs/formio.full.js')
 
 script.
   Formio.setBaseUrl('!{base_url}');
-
-script(src = '/dist/jsqr/jsQR.js')
-script(src = '/dist/moment/moment.min.js')
 
 script(src = '/formio/ActionID.js')
 script(src = '/formio/BetterDataGrid.js')

--- a/app/pug/splash.pug
+++ b/app/pug/splash.pug
@@ -4,7 +4,10 @@ head
   title DUNE APA Construction DB
 
   link(rel = 'stylesheet', href = '/css/splash.css')
-  link(rel = 'stylesheet', href = '/dist/bootstrap/css/bootstrap.min.css')
+  link(rel = 'preload', href = 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css', as = 'style', 
+    integrity = 'sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N', crossorigin = 'anonymous')
+  link(rel = 'stylesheet', href = 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css', 
+    integrity = 'sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N', crossorigin = 'anonymous')
   link(rel = 'preload', href = 'https://fonts.googleapis.com/css2?family=Inconsolata&family=Palanquin&display=swap', as = 'style')
   link(rel = 'stylesheet', href = 'https://fonts.googleapis.com/css2?family=Inconsolata&family=Palanquin&display=swap')
 

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -1,11 +1,11 @@
 const router = require('express').Router();
 
-const Actions = require('lib/Actions.js');
-const Components = require('lib/Components.js');
-const Forms = require('lib/Forms.js');
+const Actions = require('../lib/Actions');
+const Components = require('../lib/Components');
+const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
-const permissions = require('lib/permissions.js');
-const utils = require('lib/utils.js');
+const permissions = require('../lib/permissions');
+const utils = require('../lib/utils');
 
 
 /// View a single action record

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -181,7 +181,7 @@ router.get('/actions/list', permissions.checkPermission('actions:view'), async f
   try {
     // Retrieve records of all actions across all action types
     // The first argument should be 'null' in order to match to any type form ID
-    const actions = await Actions.list(null, { limit: 100 });
+    const actions = await Actions.list(null, { limit: 200 });
 
     // Retrieve a list of all action type forms that currently exist in the 'actionForms' collection
     const allActionTypeForms = await Forms.list('actionForms');
@@ -205,7 +205,7 @@ router.get('/actions/:typeFormId/list', permissions.checkPermission('actions:vie
   try {
     // Retrieve records of all actions with the specified action type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const actions = await Actions.list({ typeFormId: req.params.typeFormId }, { limit: 100 });
+    const actions = await Actions.list({ typeFormId: req.params.typeFormId }, { limit: 200 });
 
     // Retrieve the action type form corresponding to the specified type form ID
     const actionTypeForm = await Forms.retrieve('actionForms', req.params.typeFormId);

--- a/app/routes/api/actions.js
+++ b/app/routes/api/actions.js
@@ -1,8 +1,8 @@
 const router = require('express').Router();
 
-const Actions = require('lib/Actions.js');
+const Actions = require('../../lib/Actions');
 const logger = require('../../lib/logger');
-const permissions = require('lib/permissions.js');
+const permissions = require('../../lib/permissions');
 
 
 /// Retrieve the most recent version of a single action record

--- a/app/routes/api/components.js
+++ b/app/routes/api/components.js
@@ -1,10 +1,10 @@
 const router = require('express').Router();
 const ShortUUID = require('short-uuid');
 
-const Components = require('lib/Components.js');
+const Components = require('../../lib/Components');
 const logger = require('../../lib/logger');
-const permissions = require('lib/permissions.js');
-const utils = require('lib/utils.js');
+const permissions = require('../../lib/permissions');
+const utils = require('../../lib/utils');
 
 
 /// Retrieve the most recent version of a single component record

--- a/app/routes/api/forms.js
+++ b/app/routes/api/forms.js
@@ -1,8 +1,8 @@
 const router = require('express').Router();
 
-const Forms = require('lib/Forms.js');
+const Forms = require('../../lib/Forms');
 const logger = require('../../lib/logger');
-const permissions = require('lib/permissions.js');
+const permissions = require('../../lib/permissions');
 
 
 /// List all type forms in a specified type form collection

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -1,8 +1,8 @@
 const router = require('express').Router();
 
 const logger = require('../../lib/logger');
-const Search = require('lib/Search.js');
-const utils = require('lib/utils.js');
+const Search = require('../../lib/Search');
+const utils = require('../../lib/utils');
 
 
 /// Search for geometry boards that have been received at a specified location

--- a/app/routes/api/users.js
+++ b/app/routes/api/users.js
@@ -3,7 +3,7 @@ const router = require('express').Router();
 
 const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = require('../../lib/constants');
 const logger = require('../../lib/logger');
-const permissions = require('lib/permissions.js');
+const permissions = require('../../lib/permissions');
 
 /// To ensure the manager below works:
 ///    - go to Auth0 Dashboard -> Applications -> APIs -> Auth0ManagementAPI

--- a/app/routes/api/workflows.js
+++ b/app/routes/api/workflows.js
@@ -1,8 +1,8 @@
 const router = require('express').Router();
 
 const logger = require('../../lib/logger');
-const permissions = require('lib/permissions.js');
-const Workflows = require('lib/Workflows.js');
+const permissions = require('../../lib/permissions');
+const Workflows = require('../../lib/Workflows');
 
 
 /// Retrieve the most recent version of a single workflow record

--- a/app/routes/autocomplete.js
+++ b/app/routes/autocomplete.js
@@ -1,8 +1,8 @@
 const router = require('express').Router();
 
-const Actions = require('lib/Actions.js');
-const Components = require('lib/Components.js');
-const Workflows = require('lib/Workflows.js');
+const Actions = require('../lib/Actions');
+const Components = require('../lib/Components');
+const Workflows = require('../lib/Workflows');
 
 
 /// Autocomplete a component UUID as it is being typed

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -357,7 +357,7 @@ router.get('/components/list', permissions.checkPermission('components:view'), a
   try {
     // Retrieve records of all components across all component types
     // The first argument should be 'null' in order to match to any type form ID
-    const components = await Components.list(null, { limit: 100 });
+    const components = await Components.list(null, { limit: 200 });
 
     // Retrieve a list of all component type forms that currently exist in the 'componentForms' collection
     const allComponentTypeForms = await Forms.list('componentForms');
@@ -381,7 +381,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
   try {
     // Retrieve records of all components with the specified component type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const components = await Components.list({ formId: req.params.typeFormId }, { limit: 100 });
+    const components = await Components.list({ formId: req.params.typeFormId }, { limit: 200 });
 
     // Retrieve the component type form corresponding to the specified type form ID
     const componentTypeForm = await Forms.retrieve('componentForms', req.params.typeFormId);

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -2,12 +2,12 @@ const deepmerge = require('deepmerge');
 const router = require('express').Router();
 const ShortUUID = require('short-uuid');
 
-const Actions = require('lib/Actions.js');
-const Components = require('lib/Components.js');
-const Forms = require('lib/Forms.js');
+const Actions = require('../lib/Actions');
+const Components = require('../lib/Components');
+const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
-const permissions = require('lib/permissions.js');
-const utils = require('lib/utils.js');
+const permissions = require('../lib/permissions');
+const utils = require('../lib/utils');
 
 
 /// View a single component record

--- a/app/routes/tags.js
+++ b/app/routes/tags.js
@@ -1,6 +1,6 @@
 const router = require('express').Router();
 
-const Forms = require('lib/Forms.js');
+const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
 
 

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -3,7 +3,7 @@ const router = require('express').Router();
 
 const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = require('../lib/constants');
 const logger = require('../lib/logger');
-const permissions = require('lib/permissions.js');
+const permissions = require('../lib/permissions');
 
 /// To ensure the manager below works:
 ///    - go to Auth0 Dashboard -> Applications -> APIs -> Auth0ManagementAPI

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -1,9 +1,9 @@
 const router = require('express').Router();
 
-const Forms = require('lib/Forms.js');
+const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
-const permissions = require('lib/permissions.js');
-const Workflows = require('lib/Workflows.js');
+const permissions = require('../lib/permissions');
+const Workflows = require('../lib/Workflows');
 
 
 /// View a single workflow record

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -211,7 +211,7 @@ router.get('/workflows/list', permissions.checkPermission('workflows:view'), asy
 
     // Retrieve records of all workflows across all workflow types
     // The first argument should be 'null' in order to match to any type form ID
-    const workflows = await Workflows.list(null, { limit: 100 });
+    const workflows = await Workflows.list(null, { limit: 200 });
 
     // Retrieve a list of all workflow type forms that currently exist in the 'workflowForms' collection
     const allWorkflowTypeForms = await Forms.list('workflowForms');
@@ -235,7 +235,7 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermission('workflows
   try {
     // Retrieve records of all workflows with the specified workflow type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const workflows = await Workflows.list({ typeFormId: req.params.typeFormId }, { limit: 100 });
+    const workflows = await Workflows.list({ typeFormId: req.params.typeFormId }, { limit: 200 });
 
     // Retrieve the workflow type form corresponding to the specified type form ID
     const workflowTypeForm = await Forms.retrieve('workflowForms', req.params.typeFormId);

--- a/app/static/pages/template_editTypeForm.js
+++ b/app/static/pages/template_editTypeForm.js
@@ -109,7 +109,7 @@ function ChangeRecordData(record) {
 
   // Increment the type form's version number and set the type form's validity start date to be now
   record.validity.version += 1;
-  record.validity.startDate = moment().toISOString();
+  record.validity.startDate = (new Date()).toISOString();
 
   // Populate the metadata form's submission object with the current form's contents
   metaForm.submission = { data: record };


### PR DESCRIPTION
- changed all library and route files to use relative internal paths (from absolute), and removed corresponding use of the 'app-modules-path' package
- removed use of 'moment' package from page JS file, since a standard JS date object functions exactly the same
- changed all package libraries and stylesheets that were previously imported via a static 'dist' filepath to use external CDN sources instead
- removed all usage of static 'dist' filepaths from the DB code