### PR TITLE
Miscellaneous requested changes:

### DIFF
--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -22,7 +22,14 @@ block content
     .vert-space-x1
       dl
         dt Action Type
-        dd #{action.typeFormName}
+        dd 
+          .form-inline
+            a #{action.typeFormName}
+
+            .hori-space-x1
+              a.btn-sm.btn-primary(href = `/action/${action.typeFormId}/unspec`)
+                img.small-icon(src = '/images/run_icon.svg')
+                | &nbsp; Perform a New Action of this Type
 
         dt Action Name
 
@@ -88,13 +95,5 @@ block content
         a.btn.btn-secondary(href = `/json/action/${action.actionId}`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; View JSON Record
-
-    .vert-space-x2
-      hr
-
-    .vert-space-x2
-      a.btn.btn-primary(href = `/action/${action.typeFormId}/unspec`)
-        img.small-icon(src = '/images/run_icon.svg')
-        | &nbsp; Perform a New Action of this Type
 
     .vert-space-x2

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -27,16 +27,22 @@ block content
         .col
           dl
             dt Component Type
-            dd #{component.formName}
+            dd
+              .form-inline
+                a #{component.formName}
+
+                .hori-space-x1
+                  a.btn-sm.btn-primary(href = `/component/${component.formId}`)
+                    img.small-icon(src = '/images/run_icon.svg')
+                    | &nbsp; Create a New Component of this Type
 
             dt Component UUID
             dd
               .form-inline
                 a(href = `/component/${component.componentUuid}`) #{component.componentUuid}
 
-                p &nbsp; &nbsp;
-
-                a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
+                .hori-space-x1
+                  a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
 
             dt Component Name
 
@@ -47,6 +53,10 @@ block content
 
             dt Short UUID
             dd #{component.shortUuid}
+
+            if(component.formId == 'GroundingMeshPanel')
+              dt Factory ID
+              dd #{component.data.typeRecordNumber}
 
             if component.workflowId
               dt Part of Workflow:

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -181,7 +181,7 @@ router.get('/actions/list', permissions.checkPermission('actions:view'), async f
   try {
     // Retrieve records of all actions across all action types
     // The first argument should be 'null' in order to match to any type form ID
-    const actions = await Actions.list(null, { limit: 100 });
+    const actions = await Actions.list(null, { limit: 200 });
 
     // Retrieve a list of all action type forms that currently exist in the 'actionForms' collection
     const allActionTypeForms = await Forms.list('actionForms');
@@ -205,7 +205,7 @@ router.get('/actions/:typeFormId/list', permissions.checkPermission('actions:vie
   try {
     // Retrieve records of all actions with the specified action type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const actions = await Actions.list({ typeFormId: req.params.typeFormId }, { limit: 100 });
+    const actions = await Actions.list({ typeFormId: req.params.typeFormId }, { limit: 200 });
 
     // Retrieve the action type form corresponding to the specified type form ID
     const actionTypeForm = await Forms.retrieve('actionForms', req.params.typeFormId);

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -357,7 +357,7 @@ router.get('/components/list', permissions.checkPermission('components:view'), a
   try {
     // Retrieve records of all components across all component types
     // The first argument should be 'null' in order to match to any type form ID
-    const components = await Components.list(null, { limit: 100 });
+    const components = await Components.list(null, { limit: 200 });
 
     // Retrieve a list of all component type forms that currently exist in the 'componentForms' collection
     const allComponentTypeForms = await Forms.list('componentForms');
@@ -381,7 +381,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
   try {
     // Retrieve records of all components with the specified component type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const components = await Components.list({ formId: req.params.typeFormId }, { limit: 100 });
+    const components = await Components.list({ formId: req.params.typeFormId }, { limit: 200 });
 
     // Retrieve the component type form corresponding to the specified type form ID
     const componentTypeForm = await Forms.retrieve('componentForms', req.params.typeFormId);

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -211,7 +211,7 @@ router.get('/workflows/list', permissions.checkPermission('workflows:view'), asy
 
     // Retrieve records of all workflows across all workflow types
     // The first argument should be 'null' in order to match to any type form ID
-    const workflows = await Workflows.list(null, { limit: 100 });
+    const workflows = await Workflows.list(null, { limit: 200 });
 
     // Retrieve a list of all workflow type forms that currently exist in the 'workflowForms' collection
     const allWorkflowTypeForms = await Forms.list('workflowForms');
@@ -235,7 +235,7 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermission('workflows
   try {
     // Retrieve records of all workflows with the specified workflow type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const workflows = await Workflows.list({ typeFormId: req.params.typeFormId }, { limit: 100 });
+    const workflows = await Workflows.list({ typeFormId: req.params.typeFormId }, { limit: 200 });
 
     // Retrieve the workflow type form corresponding to the specified type form ID
     const workflowTypeForm = await Forms.retrieve('workflowForms', req.params.typeFormId);


### PR DESCRIPTION
- increased number of displayed components, actions and workflows on list pages from 100 to 200
- moved 'Perform a New Action of this Type' button from bottom of action information page to be inline with action type at top
- added a 'Create a New Component of this Type' button to component information page, inline with component type at top
- added display section for the 'data.typeRecordNumber' field (as 'Factory ID') for 'Grounding Mesh Panel' type components (no display for other types)