### PR TITLE
M2M Client-side Script changes and fixes ...

### DIFF
--- a/app/pug/template_editTypeForm.pug
+++ b/app/pug/template_editTypeForm.pug
@@ -40,7 +40,4 @@ block content
           .vert-space-x1
             a.button.btn.btn-primary(onclick = 'CopySchemaToClipboard()') Copy Schema to Clipboard
 
-          .vert-space-x1
-            a.button.btn.btn-primary(onclick = 'PasteSchemaFromClipboard()') Paste Schema from Clipboard
-
     .vert-space-x2

--- a/app/routes/api/components.js
+++ b/app/routes/api/components.js
@@ -83,19 +83,4 @@ router.get('/newComponentUUID', async function (req, res, next) {
 });
 
 
-/// Convert a short UUID to a full UUID
-router.get('/convertShortUUID/' + utils.short_uuid_regex, async function (req, res, next) {
-  try {
-    // Reconstruct the full UUID from the shortened UUID
-    const componentUuid = ShortUUID().toUUID(req.params.shortuuid);
-
-    // Return the full UUID
-    return res.json(componentUuid);
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
 module.exports = router;

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -50,7 +50,8 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         if (uuid === '') uuid = 'none';
         else {
           const boardRecord = await Components.retrieve(uuid);
-          ukid = boardRecord.data.typeRecordNumber;
+
+          if (boardRecord) ukid = boardRecord.data.typeRecordNumber;
         }
 
         shipmentDetails.push([uuid, ukid]);

--- a/app/static/pages/template_editTypeForm.js
+++ b/app/static/pages/template_editTypeForm.js
@@ -194,23 +194,6 @@ function CopySchemaToClipboard() {
 };
 
 
-// When the 'Paste Schema from Clipboard' button is pressed, paste the current contents of the device's clipboard into the JSON schema box
-// NOTE: by default, this does not work in Firefox (which does not allow the 'readText' function to be called from websites, only via browser extensions)
-// To get around this, please do the following:
-//   - navigate to 'about:config' and 'accept the risk and continue'
-//   - search for 'dom.events.testing.asyncClipboard', and set it to 'true'
-//   - refresh the 'Edit Type Form' page
-function PasteSchemaFromClipboard() {
-  navigator.clipboard.readText().then((schema) => {
-    $('#schema').val(schema);
-    $('#schema').trigger('change');
-  })
-    .catch((err) => {
-      console.error('Error - could not paste schema', err);
-    });
-};
-
-
 // Function to submit the record to the database
 function SubmitData(submission) {
   $.ajax({

--- a/m2m/README.md
+++ b/m2m/README.md
@@ -23,37 +23,43 @@ Upon creating a fresh Git clone of this directory, the `client_credentials.py` f
 
 ## Backend Functions
 
-The *backend* code, located in the `common.py` file, governs the general functioning of the M2M application.  **Users should not attempt to modify any backend code** - doing so could potentially lead to your M2M client becoming non-functional, or corrupt or incorrect data being sent to the DB.
+The *backend* code, located in the `common.py` file, governs the underlying functioning of the M2M application.  **Users should not attempt to modify any backend code** - doing so could potentially lead to your M2M client becoming non-functional, and/or corrupt or incorrect data being sent to the DB.
 
 However, users will still need to call the various backend functions in their own user-created scripts.  The available functions and required arguments are as follows:
 
-* `ConvertShortUUID(shortUUID)` : convert a short UUID into a full one, returning the full UUID as a string
+* `ConnectToAPI()` : establish a connection between the client and the database API, returning the `connection` object and associated `headers`.  **This function must be called once at the start of every user-created script, and the connection must be manually closed at the end of the script.**
+* `ConvertShortUUID(shortUUID, connection, headers)` : convert a short UUID into a full one, and check if the full UUID corresponds to an existing component record, returning the full UUID as a string if so, or an error message if not
     * `shortUUID` (string) : an existing short UUID, must be between 20 and 22 alphanumeric characters
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `CreateComponent(typeFormID, data)` : create a new component
-    * `typeFormID` (string) : the type form ID of the component to be created
-    * `data` (Python dictionary) : the data to be entered into the new component record's `component.data` section, arranged as a dictionary of `field: value` pairs  ... this is the same data that would be entered into the component's type form through the web interface
+* `CreateComponent(componentTypeFormID, componentData, connection, headers)` : create a new component
+    * `componentTypeFormID` (string) : the type form ID of the component to be created
+    * `componentData` (Python dictionary) : the data to be entered into the new component record's `component.data` section, arranged as a dictionary of `field: value` pairs  ... this is the same data that would be entered into the component's type form through the web interface
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `EditComponent(componentUUID, componentData_fields, componentData_values)` : edit an existing component
+* `EditComponent(componentUUID, componentData_fields, componentData_values, connection, headers)` : edit an existing component
     * `componentUUID` (string) : the UUID of the component to be edited
-    * `componentData_fields` (list) : the component's type form field names which will have their values edited
+    * `componentData_fields` (list of strings) : the component's type form field names which will have their values edited
     * `componentData_values` (list) : the new values of the fields specified in the `componentData_fields` list
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `PerformAction(typeFormID, componentUUID, data)` : perform a new action on a specified component
-    * `typeFormID` (string) : the type form ID of the action to be created
+* `PerformAction(actionTypeFormID, componentUUID, actionData, connection, headers)` : perform a new action on a specified component
+    * `actionTypeFormID` (string) : the type form ID of the action to be created
     * `componentUUID` (string) : the UUID of the component on which the new action is to be performed
-    * `data` (Python dictionary) : the data to be entered into the new action record's `action.data` section, arranged as a dictionary of `field: value` pairs  ... this is the same data that would be entered into the action's type form through the web interface
+    * `actionData` (Python dictionary) : the data to be entered into the new action record's `action.data` section, arranged as a dictionary of `field: value` pairs  ... this is the same data that would be entered into the action's type form through the web interface
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `EditAction(actionID, actionData_fields, actionData_values)` : edit an existing action
+* `EditAction(actionID, actionData_fields, actionData_values, connection, headers)` : edit an existing action
     * `actionID` (string) : the ID of the action to be edited
-    * `actionData_fields` (list) : the action's type form field names which will have their values edited
+    * `actionData_fields` (list of strings) : the action's type form field names which will have their values edited
     * `actionData_values` (list) : the new values of the fields specified in the `actionData_fields` list
-
-Each of the backend function is independent and self-contained, and covers the entire process of submitting a record to the DB: establishing a connection between the client and API, creating and populating a new component or action record or retrieving and editing an existing one, and then submitting the record to the DB.
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
 
 ## User-Created Scripts
 
-Users should write their own dedicated scripts that are suited for whatever task they intend to use the M2M application for.  **The only requirement is that <u>your script(s) must call the appropriate backend function as described above</u>, with the correctly ordered and formatted arguments as required.**
+Users should write their own dedicated Python scripts that are suited for whatever task they intend to use the M2M application for.  **The only requirement is that <u>your script(s) must call the appropriate backend functions as described above</u>, with the correctly ordered and formatted arguments as required.**
 
-This directory contains template scripts that show simple examples of how to create a new component, edit an existing component, perform a new action, and edit an existing action.
+Apart from `ConnectToAPI()`, the backend functions may be combined in any order and/or number as required by the user.  For example, if multiple short UUIDs need to be converted and then new components created and submitted using the returned full UUIDs, a single user-created script containing a `for` loop may be used to cover the entire procedure.
+
+This directory contains template scripts that show simple examples of how to convert one and multiple short UUIDs, create a new component, edit an existing component, perform a new action, and edit an existing action.

--- a/m2m/template_convert_shortUUID.py
+++ b/m2m/template_convert_shortUUID.py
@@ -1,0 +1,44 @@
+# Local Python imports
+from common import ConnectToAPI, ConvertShortUUID
+
+
+# Main script function
+if __name__ == '__main__':
+    # Set up a connection to the database API and get the connection request headers
+    # This must be done at the beginning of this main script function, but ONLY ONCE
+    connection, headers = ConnectToAPI()
+
+    ########################################
+    # User-defined script functionality goes here
+
+    # Set the short UUID string to be converted (this must be between 20 and 22 characters long)
+    shortUUID = 'sYYtwWFURzCyHVYavMrQDd'
+
+    # Call the conversion function, which takes the short UUID string as its first argument
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    # The 'result' string returned by the function will either be the full UUID or an error message
+    result = ConvertShortUUID(shortUUID, connection, headers)
+    print(f" Conversion Result: {shortUUID} -> {result}")
+
+    print()
+
+    # If many short UUIDs need to be converted, this can be performed in a loop
+    # Set a list of short UUID strings
+    shortUUIDs = ['sYYtwWFURzCyHVYavMrQDd', '7SA6ENka8QCAVnThtemoWD',
+                  'rjUYvNNz5yB6iiVRtQ9aSS', '7HYqy87RYbfnf7FEPtcCJH']
+
+    # For each short UUID in the list ...
+    for listed_shortUUID in shortUUIDs:
+        # Call the conversion function, which takes the short UUID string as its first argument
+        # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+        # The 'result' string returned by the function will either be the full UUID or an error message
+        listed_result = ConvertShortUUID(
+            listed_shortUUID, connection, headers)
+        print(f" Conversion Result: {listed_shortUUID} -> {listed_result}")
+
+    ########################################
+
+    print()
+
+    # Once all conversions have been performed, close the connection to the database API
+    connection.close()

--- a/m2m/template_create_component.py
+++ b/m2m/template_create_component.py
@@ -1,31 +1,32 @@
 # Local Python imports
-from common import ConvertShortUUID, CreateComponent
+from common import ConnectToAPI, CreateComponent
 
 
 # Main script function
 if __name__ == '__main__':
+    # Set up a connection to the database API and get the connection request headers
+    # This must be done at the beginning of this main script function, but ONLY ONCE
+    connection, headers = ConnectToAPI()
 
-    # If a short UUID is already known, the corresponding full UUID can be determined
-    shortUUID = 'sYYtwWFURzCyHVYavMrQDd'
+    ########################################
+    # User-defined script functionality goes here
 
-    fullUUID = ConvertShortUUID(shortUUID)
-    print(f" Full UUID: {fullUUID}")
-    print()
-
-    # Creating a new component requires 2 pieces of information:
-    #   - the component type form ID (for which a corresponding type form must already exist in the DB)
-    #   - the component data (corresponding to the data to be entered into the type form)
-
-    # Set the component type form ID
-    typeFormID = 'basic_component'
-
-    # Set the component data
-    data = {
-        'name': 'M2M Component',
+    # Creation of a new component requires two pieces of information to be pre-defined:
+    #   - the component's type form ID (a string, for which a corresponding type form must already exist in the DB)
+    #   - the component's data (a Python dictionary, corresponding to the data to be entered into the type form)
+    componentTypeFormID = 'basic_component'
+    componentData = {
+        'name': 'New M2M Component',
         'textField': 'This is a component created through the M2M application'
     }
 
-    # Create and submit the new component
-    CreateComponent(typeFormID, data)
+    # Call the component creation function, which takes the type form ID and data as its first two arguments
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    CreateComponent(componentTypeFormID, componentData, connection, headers)
+
+    ########################################
 
     print()
+
+    # Once all components have been created and submitted, close the connection to the database API
+    connection.close()

--- a/m2m/template_edit_action.py
+++ b/m2m/template_edit_action.py
@@ -1,25 +1,32 @@
 # Local Python imports
-from common import EditAction
+from common import ConnectToAPI, EditAction
 
 
 # Main script function
 if __name__ == '__main__':
+    # Set up a connection to the database API and get the connection request headers
+    # This must be done at the beginning of this main script function, but ONLY ONCE
+    connection, headers = ConnectToAPI()
 
-    # Editing an existing action requires 3 pieces of information:
+    ########################################
+    # User-defined script functionality goes here
+
+    # Editing of an existing action requires three pieces of information to be pre-defined:
     #   - the ID of the action to be edited
     #   - the names of any data fields to be edited
     #   - the new values of any data fields to be edited
-
-    # Set the ID of the action to be edited
-    actionID = '62ea52ad08d4250014a0afe7'
-
-    # Set the names of any data fields to be edited
+    actionID = '63340ac79708eb30e6403cb9'
     actionData_fields = ['name', 'measurement']
+    actionData_values = ['M2M Action (edited)', 19.07]
 
-    # Set the new values of any data fields to be edited
-    actionData_values = ['Edited M2M Action', 1.12358]
+    # Call the action editing function, which takes the ID, data field names and new field values as its first three arguments
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    EditAction(actionID, actionData_fields,
+               actionData_values, connection, headers)
 
-    # Edit and submit the action
-    EditAction(actionID, actionData_fields, actionData_values)
+    ########################################
 
     print()
+
+    # Once all actions have been edited and submitted, close the connection to the database API
+    connection.close()

--- a/m2m/template_edit_component.py
+++ b/m2m/template_edit_component.py
@@ -1,26 +1,33 @@
 # Local Python imports
-from common import EditComponent
+from common import ConnectToAPI, EditComponent
 
 
 # Main script function
 if __name__ == '__main__':
+    # Set up a connection to the database API and get the connection request headers
+    # This must be done at the beginning of this main script function, but ONLY ONCE
+    connection, headers = ConnectToAPI()
 
-    # Editing an existing component requires 3 pieces of information:
+    ########################################
+    # User-defined script functionality goes here
+
+    # Editing of an existing component requires three pieces of information to be pre-defined:
     #   - the UUID of the component to be edited
     #   - the names of any data fields to be edited
     #   - the new values of any data fields to be edited
-
-    # Set the UUID of the component to be edited
-    componentUUID = 'da820f60-130e-11ed-bf0a-f3cd78f73f46'
-
-    # Set the names of any data fields to be edited
+    componentUUID = '5f9ea420-3e88-11ed-9114-03f8483882ff'
     componentData_fields = ['textField']
-
-    # Set the new values of any data fields to be edited
     componentData_values = [
         'This component has been edited through the M2M application']
 
-    # Edit and submit the component
-    EditComponent(componentUUID, componentData_fields, componentData_values)
+    # Call the component editing function, which takes the UUID, data field names and new field values as its first three arguments
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    EditComponent(componentUUID, componentData_fields,
+                  componentData_values, connection, headers)
+
+    ########################################
 
     print()
+
+    # Once all components have been edited and submitted, close the connection to the database API
+    connection.close()

--- a/m2m/template_perform_action.py
+++ b/m2m/template_perform_action.py
@@ -1,29 +1,36 @@
 # Local Python imports
-from common import PerformAction
+from common import ConnectToAPI, PerformAction
 
 
 # Main script function
 if __name__ == '__main__':
+    # Set up a connection to the database API and get the connection request headers
+    # This must be done at the beginning of this main script function, but ONLY ONCE
+    connection, headers = ConnectToAPI()
 
-    # Performing a new action requires 3 pieces of information:
-    #   - the action type form ID (for which a corresponding type form must already exist in the DB)
+    ########################################
+    # User-defined script functionality goes here
+
+    # Performing a new action requires three pieces of information to be pre-defined:
+    #   - the action's type form ID (a string, for which a corresponding type form must already exist in the DB)
     #   - the UUID of the component on which the action is being performed (which must already exist in the DB)
-    #   - the action data (corresponding to the data to be entered into the type form)
-
-    # Set the action type form ID
-    typeFormID = 'my_action'
-
-    # Set the component UUID
-    componentUUID = 'da820f60-130e-11ed-bf0a-f3cd78f73f46'
-
-    # Set the action data
-    data = {
+    #   - the action data (a Python dictionary, corresponding to the data to be entered into the type form)
+    actionTypeFormID = 'my_action'
+    componentUUID = '5f9ea420-3e88-11ed-9114-03f8483882ff'
+    actionData = {
         'name': 'M2M Action',
         'actionPerformedAfterFormsCleanup': True,
-        'measurement': 1.123
+        'measurement': 12.04
     }
 
-    # Perform and submit the new action
-    PerformAction(typeFormID, componentUUID, data)
+    # Call the action performance function, which takes the action type form ID, component UUID and action data as its first three arguments
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    PerformAction(actionTypeFormID, componentUUID,
+                  actionData, connection, headers)
+
+    ########################################
 
     print()
+
+    # Once all actions have been performed and submitted, close the connection to the database API
+    connection.close()


### PR DESCRIPTION
- optimised access token usage ... now a single token can be used for multiple calls to the various DB API routes, rather than one token per call
- changed short UUID conversion to use the more complete API route (which includes checking the full UUID against existing DB records)
- removed the now unused less complete short UUID conversion API route
- updated M2M README and in-code comments
- added new template explicitly for short UUID conversion, and updated existing templates
- fixed bug for non-existent components in board shipment information page
- removed 'Paste JSON Schema from Clipboard' button from editing type form pages ... this no longer works in Firefox, and it will be confusing to keep it available only for other browsers