### PR TITLE
Requested changes to M2M scripts and Perform Action page ...

### DIFF
--- a/app/pug/action_specComponent.pug
+++ b/app/pug/action_specComponent.pug
@@ -8,6 +8,7 @@ block extrascripts
     const action = !{JSON.stringify((action || {}), null, 4)}; 
     const actionTypeForm = !{JSON.stringify(actionTypeForm, null, 4)}; 
     const componentUuid = !{JSON.stringify(componentUuid)};
+    const componentName = !{JSON.stringify(componentName), null, 4};
     const workflowId = !{JSON.stringify(workflowId, null, 4)};
 
   block workscripts
@@ -26,6 +27,13 @@ block content
         dt Component UUID
         dd
           a(href = `/component/${componentUuid}`) #{componentUuid}
+
+        dt Component Name
+
+        if componentName
+          dd #{componentName}
+        else
+          dd (none)
 
     .vert-space-x1
       hr

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -74,6 +74,11 @@ router.get('/action/:typeFormId/' + utils.uuid_regex, permissions.checkPermissio
 
     if (!actionTypeForm) return res.status(404).send(`There is no action type form with form ID = ${req.params.typeFormId}`);
 
+    // Retrieve the most recent version of the record corresponding to the specified component UUID, and throw an error if there is no such record
+    const component = await Components.retrieve(req.params.uuid);
+
+    if (!component) return res.status(404).send(`There is no component record with component UUID = ${req.params.uuid}`);
+
     // Set the workflow ID if one is provided
     let workflowId = '';
 
@@ -83,6 +88,7 @@ router.get('/action/:typeFormId/' + utils.uuid_regex, permissions.checkPermissio
     res.render('action_specComponent.pug', {
       actionTypeForm,
       componentUuid: req.params.uuid,
+      componentName: component.data.name,
       workflowId,
     });
   } catch (err) {
@@ -105,11 +111,15 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})/edit', permissions.checkPermissio
 
     if (!actionTypeForm) return res.status(404).send(`There is no action type form with form ID = ${action.typeFormId}`);
 
+    // Retrieve the record of the component that the action was performed on, using its component UUID (found in the action record)
+    const component = await Components.retrieve(action.componentUuid);
+
     // Render the interface page
     res.render('action_specComponent.pug', {
       action,
       actionTypeForm,
       componentUuid: action.componentUuid,
+      componentName: component.data.name,
       workflowId: '',
     });
   } catch (err) {

--- a/m2m/README.md
+++ b/m2m/README.md
@@ -32,24 +32,32 @@ However, users will still need to call the various backend functions in their ow
     * `shortUUID` (string) : an existing short UUID, must be between 20 and 22 alphanumeric characters
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `CreateComponent(componentTypeFormID, componentData, connection, headers)` : create a new component
+* `CreateComponent(componentTypeFormID, componentData, connection, headers)` : create a new component, returning the full UUID as a string
     * `componentTypeFormID` (string) : the type form ID of the component to be created
     * `componentData` (Python dictionary) : the data to be entered into the new component record's `component.data` section, arranged as a dictionary of `field: value` pairs  ... this is the same data that would be entered into the component's type form through the web interface
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `EditComponent(componentUUID, componentData_fields, componentData_values, connection, headers)` : edit an existing component
+* `GetComponent(componentUUID, connection, headers)` : get the latest version of an existing component record, returning the record as a Python dictionary
+    * `componentUUID` (string) : the UUID of the component to be retrieved
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
+
+* `EditComponent(componentUUID, componentData_fields, componentData_values, connection, headers)` : edit an existing component record, returning the component's full UUID as a string
     * `componentUUID` (string) : the UUID of the component to be edited
     * `componentData_fields` (list of strings) : the component's type form field names which will have their values edited
     * `componentData_values` (list) : the new values of the fields specified in the `componentData_fields` list
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `PerformAction(actionTypeFormID, componentUUID, actionData, connection, headers)` : perform a new action on a specified component
+* `PerformAction(actionTypeFormID, componentUUID, actionData, connection, headers)` : perform a new action on a specified component, returning the action ID as a string
     * `actionTypeFormID` (string) : the type form ID of the action to be created
     * `componentUUID` (string) : the UUID of the component on which the new action is to be performed
     * `actionData` (Python dictionary) : the data to be entered into the new action record's `action.data` section, arranged as a dictionary of `field: value` pairs  ... this is the same data that would be entered into the action's type form through the web interface
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `EditAction(actionID, actionData_fields, actionData_values, connection, headers)` : edit an existing action
+* `GetAction(actionID, connection, headers)` : get the latest version of an existing action record, returning the record as a Python dictionary
+    * `actionID` (string) : the ID of the action to be retrieved
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
+
+* `EditAction(actionID, actionData_fields, actionData_values, connection, headers)` : edit an existing action record, returning the action ID as a string
     * `actionID` (string) : the ID of the action to be edited
     * `actionData_fields` (list of strings) : the action's type form field names which will have their values edited
     * `actionData_values` (list) : the new values of the fields specified in the `actionData_fields` list

--- a/m2m/common.py
+++ b/m2m/common.py
@@ -137,15 +137,19 @@ def CreateComponent(componentTypeFormID, componentData, connection, headers):
             connection.request('POST', '/api/component',
                                body=componentJSON, headers=headers)
 
-            # Depending on the submission response (success = 200, or failure = anything else), print an appropriate message to screen
-            # The success response from the route is simply the submitted component's UUID
+            # The route returns a different string based on success (response code = 200) or failure (response code = anything else)
+            #  - if successful, the full UUID of the submitted component is returned and set to the result string
+            #  - if not successful, an error is returned and displayed on screen, and the result string is set to an 'invalid' indicator
             submissionResponse = connection.getresponse()
+            result = 'none'
 
             if submissionResponse.status == 200:
-                print(
-                    f" CreateComponent() - successfully submitted component with UUID: {submissionResponse.read().decode('utf-8')}")
+                result = submissionResponse.read().decode('utf-8')
             else:
                 print(submissionResponse.status, submissionResponse.reason)
+
+            # Return the result string
+            return result
         except http.client.HTTPException as e2:
             print(
                 f" CreateComponent() [POST /api/component] - HTTP EXCEPTION: {e2} \n")
@@ -160,11 +164,40 @@ def CreateComponent(componentTypeFormID, componentData, connection, headers):
             f" CreateComponent() [GET /api/newComponentUUID] - SOCKET TIMEOUT: {s1} \n")
 
 
+###############################
+## Get an existing component ##
+###############################
+def GetComponent(componentUUID, connection, headers):
+    # Request a response from the API route that retrieves the latest version of an existing component record via its UUID
+    # If the request is successful, continue with the function ... otherwise print any raised exceptions
+    try:
+        connection.request('GET', '/api/component/' +
+                           componentUUID, headers=headers)
+
+        # The route response is the component record as a JSON document, but when decoded it becomes a standard string containing the JSON document
+        # Therefore, deserialise the string to a Python dictionary so that it can be easily edited
+        component = json.loads(connection.getresponse().read().decode('utf-8'))
+
+        # If the provided UUID doesn't correspond to an existing component record, print an error and exit the function immediately
+        if component == None:
+            sys.exit(
+                f" GetComponent() - ERROR: there is no component record with component UUID = {componentUUID} \n")
+
+        # Return the Python dictionary containing the component record
+        return component
+    except http.client.HTTPException as e:
+        print(
+            f" GetComponent() [GET /api/component/componentUuid] - HTTP EXCEPTION: {e} \n")
+    except socket.timeout as s:
+        print(
+            f" GetComponent() [GET /api/component/componentUuid] - SOCKET TIMEOUT: {s} \n")
+
+
 ################################
 ## Edit an existing component ##
 ################################
 def EditComponent(componentUUID, componentData_fields, componentData_values, connection, headers):
-    # Request a response from the API route that retrieves the record of an existing component via its UUID
+    # Request a response from the API route that retrieves the latest version of an existing component record via its UUID
     # If the request is successful, continue with the function ... otherwise print any raised exceptions
     try:
         connection.request('GET', '/api/component/' +
@@ -194,15 +227,19 @@ def EditComponent(componentUUID, componentData_fields, componentData_values, con
             connection.request('POST', '/api/component',
                                body=componentJSON, headers=headers)
 
-            # Depending on the submission response (success = 200, or failure = anything else), print an appropriate message to screen
-            # The success response from the route is simply the submitted component's UUID
+            # The route returns a different string based on success (response code = 200) or failure (response code = anything else)
+            #  - if successful, the full UUID of the submitted component is returned and set to the result string
+            #  - if not successful, an error is returned and displayed on screen, and the result string is set to an 'invalid' indicator
             submissionResponse = connection.getresponse()
+            result = 'none'
 
             if submissionResponse.status == 200:
-                print(
-                    f" EditComponent() - successfully edited component with UUID: {submissionResponse.read().decode('utf-8')}")
+                result = submissionResponse.read().decode('utf-8')
             else:
                 print(submissionResponse.status, submissionResponse.reason)
+
+            # Return the result string
+            return result
         except http.client.HTTPException as e2:
             print(
                 f" EditComponent() [POST /api/component] - HTTP EXCEPTION: {e2} \n")
@@ -242,15 +279,19 @@ def PerformAction(actionTypeFormID, componentUUID, actionData, connection, heade
         connection.request('POST', '/api/action',
                            body=actionJSON, headers=headers)
 
-        # Depending on the submission response (success = 200, or failure = anything else), print an appropriate message to screen
-        # The success response from the route is simply the submitted action's ID
+        # The route returns a different string based on success (response code = 200) or failure (response code = anything else)
+        #  - if successful, the ID of the submitted action is returned and set to the result string
+        #  - if not successful, an error is returned and displayed on screen, and the result string is set to an 'invalid' indicator
         submissionResponse = connection.getresponse()
+        result = 'none'
 
         if submissionResponse.status == 200:
-            print(
-                f" PerformAction() - successfully submitted action with ID: {submissionResponse.read().decode('utf-8')}")
+            result = submissionResponse.read().decode('utf-8')
         else:
             print(submissionResponse.status, submissionResponse.reason)
+
+        # Return the result string
+        return result
     except http.client.HTTPException as e:
         print(
             f" PerformAction() [POST /api/action] - HTTP EXCEPTION: {e} \n")
@@ -259,11 +300,39 @@ def PerformAction(actionTypeFormID, componentUUID, actionData, connection, heade
             f" PerformAction() [POST /api/action] - SOCKET TIMEOUT: {s} \n")
 
 
+############################
+## Get an existing action ##
+############################
+def GetAction(actionID, connection, headers):
+    # Request a response from the API route that retrieves the latest version of an existing action record via its ID
+    # If the request is successful, continue with the function ... otherwise print any raised exceptions
+    try:
+        connection.request('GET', '/api/action/' + actionID, headers=headers)
+
+        # The route response is the action record as a JSON document, but when decoded it becomes a standard string containing the JSON document
+        # Therefore, deserialise the string to a Python dictionary so that it can be easily edited
+        action = json.loads(connection.getresponse().read().decode('utf-8'))
+
+        # If the provided ID doesn't correspond to an existing action record, print an error and exit the function immediately
+        if action == None:
+            sys.exit(
+                f" GetAction() - ERROR: there is no action record with action ID = {actionID} \n")
+
+        # Return the Python dictionary containing the action record
+        return action
+    except http.client.HTTPException as e:
+        print(
+            f" GetAction() [GET /api/action/actionId] - HTTP EXCEPTION: {e} \n")
+    except socket.timeout as s:
+        print(
+            f" GetAction() [GET /api/action/actionId] - SOCKET TIMEOUT: {s} \n")
+
+
 #############################
 ## Edit an existing action ##
 #############################
 def EditAction(actionID, actionData_fields, actionData_values, connection, headers):
-    # Request a response from the API route that retrieves the record of an existing action via its ID
+    # Request a response from the API route that retrieves the latest version of an existing action record via its ID
     # If the request is successful, continue with the function ... otherwise print any raised exceptions
     try:
         connection.request('GET', '/api/action/' + actionID, headers=headers)
@@ -292,15 +361,19 @@ def EditAction(actionID, actionData_fields, actionData_values, connection, heade
             connection.request('POST', '/api/action',
                                body=actionJSON, headers=headers)
 
-            # Depending on the submission response (success = 200, or failure = anything else), print an appropriate message to screen
-            # The success response from the route is simply the submitted action's ID
+            # The route returns a different string based on success (response code = 200) or failure (response code = anything else)
+            #  - if successful, the ID of the submitted action is returned and set to the result string
+            #  - if not successful, an error is returned and displayed on screen, and the result string is set to an 'invalid' indicator
             submissionResponse = connection.getresponse()
+            result = 'none'
 
             if submissionResponse.status == 200:
-                print(
-                    f" EditAction() - successfully edited action with ID: {submissionResponse.read().decode('utf-8')}")
+                result = submissionResponse.read().decode('utf-8')
             else:
                 print(submissionResponse.status, submissionResponse.reason)
+
+            # Return the result string
+            return result
         except http.client.HTTPException as e2:
             print(
                 f" EditAction() [POST /api/action] - HTTP EXCEPTION: {e2} \n")

--- a/m2m/template_create_component.py
+++ b/m2m/template_create_component.py
@@ -22,7 +22,10 @@ if __name__ == '__main__':
 
     # Call the component creation function, which takes the type form ID and data as its first two arguments
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
-    CreateComponent(componentTypeFormID, componentData, connection, headers)
+    # If successful, the function returns the UUID of the created component (if not, an error message is automatically displayed)
+    uuid = CreateComponent(componentTypeFormID,
+                           componentData, connection, headers)
+    print(f" Successfully submitted component with UUID: {uuid}")
 
     ########################################
 

--- a/m2m/template_edit_action.py
+++ b/m2m/template_edit_action.py
@@ -21,8 +21,10 @@ if __name__ == '__main__':
 
     # Call the action editing function, which takes the ID, data field names and new field values as its first three arguments
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
-    EditAction(actionID, actionData_fields,
-               actionData_values, connection, headers)
+    # If successful, the function returns the ID of the edited action (if not, an error message is automatically displayed)
+    id = EditAction(actionID, actionData_fields,
+                    actionData_values, connection, headers)
+    print(f" Successfully edited action with ID: {id}")
 
     ########################################
 

--- a/m2m/template_edit_component.py
+++ b/m2m/template_edit_component.py
@@ -22,8 +22,10 @@ if __name__ == '__main__':
 
     # Call the component editing function, which takes the UUID, data field names and new field values as its first three arguments
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
-    EditComponent(componentUUID, componentData_fields,
-                  componentData_values, connection, headers)
+    # If successful, the function returns the UUID of the edited component (if not, an error message is automatically displayed)
+    uuid = EditComponent(componentUUID, componentData_fields,
+                         componentData_values, connection, headers)
+    print(f" Successfully edited component with UUID: {uuid}")
 
     ########################################
 

--- a/m2m/template_get_record.py
+++ b/m2m/template_get_record.py
@@ -1,0 +1,39 @@
+# Local Python imports
+from common import ConnectToAPI, GetComponent, GetAction
+
+
+# Main script function
+if __name__ == '__main__':
+    # Set up a connection to the database API and get the connection request headers
+    # This must be done at the beginning of this main script function, but ONLY ONCE
+    connection, headers = ConnectToAPI()
+
+    ########################################
+    # User-defined script functionality goes here
+
+    # Retrieving an existing component record requires only the UUID
+    componentUUID = '5f9ea420-3e88-11ed-9114-03f8483882ff'
+
+    # Call the component retrieval function, which take the UUID as its first argument
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    # If successful, the function returns the latest version of the component record as a Python dictionary (if not, an error message is automatically displayed)
+    component = GetComponent(componentUUID, connection, headers)
+    print(component)
+
+    print()
+
+    # Retrieving an existing action record requires only the ID
+    actionID = '63340ac79708eb30e6403cb9'
+
+    # Call the action retrieval function, which take the ID as its first argument
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    # If successful, the function returns the latest version of the action record as a Python dictionary (if not, an error message is automatically displayed)
+    action = GetAction(actionID, connection, headers)
+    print(action)
+
+    ########################################
+
+    print()
+
+    # Once all records have been retrieved, close the connection to the database API
+    connection.close()

--- a/m2m/template_perform_action.py
+++ b/m2m/template_perform_action.py
@@ -25,8 +25,10 @@ if __name__ == '__main__':
 
     # Call the action performance function, which takes the action type form ID, component UUID and action data as its first three arguments
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
-    PerformAction(actionTypeFormID, componentUUID,
-                  actionData, connection, headers)
+    # If successful, the function returns the ID of the performed action (if not, an error message is automatically displayed)
+    id = PerformAction(actionTypeFormID, componentUUID,
+                       actionData, connection, headers)
+    print(f" Successfully performed action with ID: {id}")
 
     ########################################
 


### PR DESCRIPTION
- component name is now displayed at the top of the 'Perform Action (Specified Component)' page, in addition to the existing action type and component UUID
- added client-side M2M functions for retrieving component and action records
- added new template for retrieving records
- component creation, action performance and record editing client-side M2M functions now all return the entity UUID or ID
- updated M2M README