### PR TITLE
Requested changes to Geometry Board Shipment search ...

### DIFF
--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -66,14 +66,14 @@ block content
 
       p This page may be used to search specifically for <b>geometry board shipments</b> that match <b>one or more</b> of the following user-specified record details:
         ul
+          li <b>shipment status</b>: whether the shipment has been recorded as received or not
           li <b>origin location</b>: the location from which the shipment was sent
           li <b>destination location</b>: the location at which the shipment is to be (or has been) received
           li <b>earliest reception date</b>: the earliest date on which the shipment could have been received (if not specified, 1st of January 2000 is used)
           li <b>latest reception date</b>: the latest date on which the shipment could have been received (if not specified, today's date is used)
+          li <b>reception comment</b>: the presence of any comments noted in the shipment reception record
 
-      p Users may select any combination of the locations and dates from the respective lists (all four pieces of information are <b>not</b> required for the search to be performed), and a summary of information about each found shipment will be displayed in the search results panel below the selection boxes.
-
-      p Please note that <b>all</b> shipments in the database may be queried using this search, regardless of if they have been recorded as received at a particular location or not.  In the case of shipments that have not yet been received, a reception date will of course not be displayed, but all other information will still be shown.
+      p The 'shipment status' is the only <b>required</b> parameter for any search - users may use any combination of the other parameters from their respective lists, and a summary of information about each found shipment will be displayed in the search results panel below the selection boxes.  In the case of shipments that have not been received, reception information will of course be left blank in the results.
 
       hr
 

--- a/app/pug/search_boardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_boardShipmentsByReceptionDetails.pug
@@ -16,6 +16,19 @@ block content
       hr
 
       .row
+        .col-md-3 
+          h4 Select Shipment Status
+
+          .vert-space-x1
+            p Select a status from the options below.
+              br
+              | &nbsp 
+
+          select.form-control#shipmentStatusSelection
+            option(value = '') (please select)
+            option(value = 'unreceived') Unreceived Shipments
+            option(value = 'received') Received Shipments
+
         .col-md-3
           h4 Select Origin Location
 
@@ -58,6 +71,11 @@ block content
             option(value = 'uwPsl') UW / PSL 
             option(value = 'chicago') Chicago
 
+        .col-md-3 
+
+      .row.vert-space-x2
+        .col-md-3 
+
         .col-md-3
           h4 Select Earliest Reception Date
 
@@ -77,6 +95,19 @@ block content
               | The search match reception <b><u>on and before</u></b> this date.
 
             #latestdateform
+
+        .col-md-3
+          h4 Select Reception Comment
+
+          .vert-space-x1
+            p Indicate if you would like to query against reception comments.
+              br
+              | &nbsp 
+
+          select.form-control#receptionCommentSelection
+            option(value = '') All shipments 
+            option(value = 'noComment') Only shipments received with no comments 
+            option(value = 'comment') Only shipments received with comments 
 
     .vert-space-x2
       hr

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -68,12 +68,15 @@ router.get('/search/geoBoardsByOrderNumber/:orderNumber', async function (req, r
 /// Search for geometry board shipments using various shipment reception details
 router.get('/search/boardShipmentsByReceptionDetails', async function (req, res, next) {
   try {
-    // This search query can take up to 4 query strings, any or all of which are optional
+    // This search query can multiple query strings, most of which are optional
     // So first, parse out the strings which have actually been provided (as non-empty strings), and set the rest to 'null'
+    // The only required query string is the 'shipment status', which will always have a valid value provided
+    const status = req.query.shipmentStatus;
     const origin = (req.query.originLocation !== '') ? req.query.originLocation : null;
     const destination = (req.query.destinationLocation !== '') ? req.query.destinationLocation : null;
     let earliest = (req.query.earliestDate !== '') ? req.query.earliestDate : null;
     let latest = (req.query.latestDate !== '') ? req.query.latestDate : null;
+    const comment = (req.query.receptionComment !== '') ? req.query.receptionComment : null;
 
     // The timestamp part of both date/time strings is supposed to be of the format: 'T00:00:00+01:00', but the '+' character is replaced with a space when they are passed as query strings
     // So replace the space in each string with a '+' to recover the original, correctly formatted timestamp (so that the format matches that of the timestamps in the shipment records)
@@ -81,7 +84,7 @@ router.get('/search/boardShipmentsByReceptionDetails', async function (req, res,
     if (latest) latest = latest.replace(' ', '+');
 
     // Retrieve a list of geometry boards shipments that match the specified reception details
-    const shipments = await Search.boardShipmentsByReceptionDetails(origin, destination, earliest, latest);
+    const shipments = await Search.boardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment);
 
     // Return the list in JSON format
     return res.json(shipments);

--- a/app/static/pages/search_boardShipmentsByReceptionDetails.js
+++ b/app/static/pages/search_boardShipmentsByReceptionDetails.js
@@ -1,8 +1,10 @@
 // Declare variables to hold the (initially empty) user-specified board shipment reception details
+let shipmentStatus = '';
 let originLocation = '';
 let destinationLocation = '';
 let earliestDate = '';
 let latestDate = '';
+let receptionComment = '';
 
 
 // Run a specific function when the page is loaded
@@ -11,6 +13,14 @@ window.addEventListener('load', renderSearchForms);
 
 // Function to run when the page is loaded
 async function renderSearchForms() {
+  // When the selected shipment status is changed, get the newly selected status
+  // If the status has a non-empty value (i.e. an option has actually been selected), perform the search using the current values of the reception details variables
+  $('#shipmentStatusSelection').on('change', async function () {
+    shipmentStatus = $('#shipmentStatusSelection').val();
+
+    if (shipmentStatus !== '') performSearch();
+  });
+
   // When the selected origin location is changed, get the newly selected location if it has a value, or otherwise reset the string
   // Then perform the search using the current values of the reception details variables
   $('#originLocationSelection').on('change', async function () {
@@ -86,6 +96,18 @@ async function renderSearchForms() {
 
     performSearch();
   });
+
+  // When the shipment reception comment is changed, get the newly indicated comment if it has a value, or otherwise reset the string
+  // Then perform the search using the current values of the reception details variables
+  $('#receptionCommentSelection').on('change', async function () {
+    if ($('#receptionCommentSelection').val()) {
+      receptionComment = $('#receptionCommentSelection').val();
+    } else {
+      receptionComment = '';
+    }
+
+    performSearch();
+  });
 }
 
 
@@ -94,7 +116,7 @@ function performSearch() {
   $.ajax({
     contentType: 'application/json',
     method: 'GET',
-    url: `/json/search/boardShipmentsByReceptionDetails?originLocation=${originLocation}&destinationLocation=${destinationLocation}&earliestDate=${earliestDate}&latestDate=${latestDate}`,
+    url: `/json/search/boardShipmentsByReceptionDetails?shipmentStatus=${shipmentStatus}&originLocation=${originLocation}&destinationLocation=${destinationLocation}&earliestDate=${earliestDate}&latestDate=${latestDate}&receptionComment=${receptionComment}`,
     dataType: 'json',
     success: postSuccess,
   }).fail(postFail);
@@ -146,9 +168,9 @@ function postSuccess(result) {
         <th scope = 'col' width = '7%'>Boards</th>
         <th scope = 'col' width = '9%'>Origin</th>
         <th scope = 'col' width = '9%'>Destination</th>
-        <th scope = 'col' width = '8%'>Date</th>
-        <th scope = 'col' width = '36%'>Comments</th>
-        <th scope = 'col' width = '13%'>Search Comments</th>
+        <th scope = 'col' width = '9%'>Reception Date</th>
+        <th scope = 'col' width = '36%'>Shipment Reception Comment</th>
+        <th scope = 'col' width = '12%'>Search Comment</th>
       </tr>`;
 
     $('#results').append(tableStart);


### PR DESCRIPTION
- added option to query against presence or lack of shipment comment
- split search more explicitly into received vs. unreceived shipments ... makes the library function a little easier to handle
- added corresponding new query box to interface page, and associated logic and argument to page-level JS