### PR TITLE
Bug fixes for earlier changes ...

### DIFF
--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -209,8 +209,10 @@ async function list(match_condition, options) {
     if (record.stepResultIDs[0] != '') {
       const component = await Components.retrieve(record.stepResultIDs[0]);
 
-      if (component.data.name) record.componentName = component.data.name;
-      else record.componentName = record.stepResultIDs[0];
+      if (component) {
+        if (component.data.name) record.componentName = component.data.name;
+        else record.componentName = record.stepResultIDs[0];
+      }
     }
   }
 

--- a/app/pug/component_list.pug
+++ b/app/pug/component_list.pug
@@ -34,8 +34,14 @@ block content
 
               tr          
                 td #{component.typeFormName}
-                td
-                  a(href = `/component/${uuid}`) #{component.name}
+
+                if (component.name)
+                  td
+                    a(href = `/component/${uuid}`) #{component.name}
+                else 
+                  td 
+                    a(href = `/component/${uuid}`) #{uuid}
+
                 td
                   +dateFormat(component.lastEditDate)
                 td


### PR DESCRIPTION
- if no component name is available, the UUID will now be shown in the component name column on the list of components page
- fix to account for not finding a component related to a workflow ... in which case, no attempt will be made to find a (non-existent) component name