### PR TITLE
Changes to Action Type Forms list page ...

### DIFF
--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -36,70 +36,80 @@ block content
       h2 Available Action Types
 
     .vert-space-x1
-      table.table
-        thead
-          tr
-            th.col-md-2 Type Name
-            th.col-md-3 Recommended Component Types
-            th.col-md-2
-            th.col-md-2
+      each actionFormsGroup, index in actionTypeForms
+        - let allComponentTypesTrashed = true;
 
-        tbody
-          each typeFormId in Object.keys(actionTypeForms).sort()
-            - const typeForm = actionTypeForms[typeFormId];
+        each typeFormTags in actionFormsGroup.tags
+          if(typeFormTags && !typeFormTags.includes('Trash')) 
+            - allComponentTypesTrashed = false;
 
-            if(typeForm.tags && !typeForm.tags.includes('Trash')) 
-              tr
-                td
-                  a(href = `/actions/${typeFormId}/list`) #{typeForm.formName}
+        if(!allComponentTypesTrashed)
+          - const collapseId = `avail_actionTypeGroup_${index}`;
 
-                if((typeForm.componentTypes) && (typeForm.componentTypes.length > 0))
-                  td 
-                    +arrayFormat(typeForm.componentTypes)
-                else
-                  td (none)
+          .panel.panel-default
+          .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = `#${collapseId}`)
+            h5 #{actionFormsGroup._id.componentType}: 
+              i.chevron.fa.fa-fw 
 
-                td
-                  a.btn-sm.btn-primary(href = `/action/${typeFormId}/unspec`)
-                    img.small-icon(src = '/images/run_icon.svg')
-                    | &nbsp; Perform Action on Component
-                td
-                  a.btn-sm.btn-warning(href = `/actionTypes/${typeFormId}/edit`)
-                    img.small-icon(src = '/images/edit_icon.svg')
-                    | &nbsp; Edit Action Type Form
+          .collapse(id = `${collapseId}`)
+            table.table
+              tbody
+                each typeFormName, i in actionFormsGroup.formName
+                  - const typeFormId = actionFormsGroup.formId[i];
+                  - const typeFormTags = actionFormsGroup.tags[i];
+
+                  if(typeFormTags && !typeFormTags.includes('Trash')) 
+                    tr
+                      td.col-md-4
+                        a(href = `/actions/${typeFormId}/list`) #{typeFormName}
+                      td.col-md-2
+                        a.btn-sm.btn-primary(href = `/action/${typeFormId}/unspec`)
+                          img.small-icon(src = '/images/run_icon.svg')
+                          | &nbsp; Perform Action on Component
+                      td.col-md-2
+                        a.btn-sm.btn-warning(href = `/actionTypes/${typeFormId}/edit`)
+                          img.small-icon(src = '/images/edit_icon.svg')
+                          | &nbsp; Edit Action Type Form
+
+        .vert-space-x1
 
     if(permissions.userHas(user, 'forms:edit'))
       .vert-space-x2
         h2 Trashed Action Types
 
       .vert-space-x1
-        table.table
-          thead
-            tr
-              th.col-md-2 Type Name
-              th.col-md-3 Recommended Component Types
-              th.col-md-2
-              th.col-md-2
+        each actionFormsGroup, index in actionTypeForms
+          - let someComponentTypesTrashed = false;
 
-          tbody
-            each typeFormId in Object.keys(actionTypeForms).sort()
-              - const typeForm = actionTypeForms[typeFormId];
+          each typeFormTags in actionFormsGroup.tags
+            if(typeFormTags && typeFormTags.includes('Trash')) 
+              - someComponentTypesTrashed = true;
 
-              if(typeForm.tags && typeForm.tags.includes('Trash')) 
-                tr
-                  td
-                    a(href = `/actions/${typeFormId}/list`) #{typeForm.formName}
+          if(someComponentTypesTrashed)
+            - const collapseId = `trash_actionTypeGroup_${index}`;
 
-                  if((typeForm.componentTypes) && (typeForm.componentTypes.length > 0))
-                    td
-                      +arrayFormat(typeForm.componentTypes)
-                  else
-                    td (none)
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = `#${collapseId}`)
+              h5 #{actionFormsGroup._id.componentType}: 
+                i.chevron.fa.fa-fw 
 
-                  td
-                  td
-                    a.btn-sm.btn-warning(href = `/actionTypes/${typeFormId}/edit`)
-                      img.small-icon(src = '/images/edit_icon.svg')
-                      | &nbsp; Edit Action Type Form
+            .collapse(id = `${collapseId}`)
+              table.table
+                tbody
+                  each typeFormName, i in actionFormsGroup.formName
+                    - const typeFormId = actionFormsGroup.formId[i];
+                    - const typeFormTags = actionFormsGroup.tags[i];
+
+                    if(typeFormTags && typeFormTags.includes('Trash')) 
+                      tr
+                        td.col-md-4
+                          a(href = `/actions/${typeFormId}/list`) #{typeFormName}
+                        td.col-md-2
+                        td.col-md-2
+                          a.btn-sm.btn-warning(href = `/actionTypes/${typeFormId}/edit`)
+                            img.small-icon(src = '/images/edit_icon.svg')
+                            | &nbsp; Edit Action Type Form
+
+          .vert-space-x1
 
     .vert-space-x2

--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -45,13 +45,17 @@ block content
 
         if(!allComponentTypesTrashed)
           - const collapseId = `avail_actionTypeGroup_${index}`;
+          - let startingDisplay = 'show';
+
+          if ((actionFormsGroup._id.componentType === 'Assembled APA') || (actionFormsGroup._id.componentType === 'APA Frame'))
+            - startingDisplay = ''
 
           .panel.panel-default
           .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = `#${collapseId}`)
             h5 #{actionFormsGroup._id.componentType}: 
               i.chevron.fa.fa-fw 
 
-          .collapse(id = `${collapseId}`)
+          .collapse(id = `${collapseId}`, class = `${startingDisplay}`)
             table.table
               tbody
                 each typeFormName, i in actionFormsGroup.formName

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -174,8 +174,8 @@ router.get('/actionTypes/:typeFormId/edit', permissions.checkPermission('forms:e
 /// List all action types
 router.get('/actionTypes/list', permissions.checkPermission('actions:view'), async function (req, res, next) {
   try {
-    // Retrieve a list of all action type forms that currently exist in the 'actionForms' collection
-    const actionTypeForms = await Forms.list('actionForms');
+    // Retrieve a list of all action type forms that currently exist in the 'actionForms' collection, grouped by their 'recommended component type'
+    const actionTypeForms = await Forms.listGrouped('actionForms');
 
     // Render the interface page
     res.render('action_listTypes.pug', { actionTypeForms });


### PR DESCRIPTION
- type forms are now grouped according to their recommended component type
- removed now unneeded commended component type column
- groups are displayed in collapsible panels, which are collapsed by default
- added new library function for retrieving grouped list of type forms (do not want to modify the existing, non-grouped function because that is used in other places)