### PR TITLE
Extending geometry board search by order number ...

### DIFF
--- a/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
+++ b/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
@@ -49,7 +49,7 @@ block content
             p Select a visual inspection issue from the options below.
 
           select.form-control#issueSelection
-            option(value = '') (all)         
+            option(value = '') (any)         
             option(value = 'packagingDamaged') Packaging damaged 
             option(value = 'scratches') Scratches 
             option(value = 'exposedCopper') Exposed copper 


### PR DESCRIPTION
- search now includes order numbers associated with batches of returned boards
- extended library function to search returned board batches if no match is found in intake board batches
- for each geometry board in a matching batch, search now returns action data about the single latest visual inspection (since boards may now have multiple inspections performed ... one on intake and one on return)
- reverted displayed 'all' back to 'any' in issue selection on inspection search page ... the former makes more sense in context