### PR TITLE
Couple of small changes requested at 2023-02-20 APA DB meeting ...

### DIFF
--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -33,7 +33,11 @@ block content
 
         dt Action ID
         dd
-          a(href = `/action/${action.actionId}`) #{action.actionId}
+          .form-inline
+            a(href = `/action/${action.actionId}`) #{action.actionId}
+
+            .hori-space-x1
+              a.copybutton.btn-sm#copy_id(onclick = 'CopyID(action.actionId)') Copy
 
         - const uuid = MUUID.from(action.componentUuid).toString();
 

--- a/app/pug/search_apasByNonConformance.pug
+++ b/app/pug/search_apasByNonConformance.pug
@@ -25,6 +25,7 @@ block content
           select.form-control#nonConformanceSelection
             option(value = '')
             option(value = 'missingWireSegment') Missing Wire Segment 
+            option(value = 'misplacedWireSegment') Misplaced Wire Segment 
             option(value = 'geometryBoardIssue') Geometry Board Issue 
             option(value = 'combIssue') Comb Issue 
             option(value = 'machiningIssue') Machining Issue 

--- a/app/static/pages/action.js
+++ b/app/static/pages/action.js
@@ -17,6 +17,20 @@ async function populateTypeForm() {
 }
 
 
+// When the 'Copy ID' button is pressed, copy the action ID to the device's clipboard, and change the button's appearance to confirm success
+function CopyID(actionID) {
+  navigator.clipboard.writeText(actionID).then(function () {
+    document.getElementById('copy_id').innerHTML = 'Copied';
+    document.getElementById('copy_id').style.backgroundColor = 'green';
+  }, function (err) {
+    document.getElementById('copy_id').innerHTML = 'ERROR';
+    document.getElementById('copy_id').style.backgroundColor = 'red';
+
+    console.error('Error - could not copy action ID', err);
+  })
+};
+
+
 // When one or more images is selected, display their name(s) in the space between the selection and confirmation buttons
 // Also change the colour and text of the confirmation button to indicate that at least one image has been selected
 function DisplayFileNames(element) {


### PR DESCRIPTION
- added button to copy action ID string to user's clipboard on action information pages (equivalent to current functionality for component UUIDs on component information pages)
- added 'misplaced wire segments' option to Search APAs by Non-Conformance search page dropdown menu (previously added to action type form but missed here)