### PR TITLE
Small display fixes:

### DIFF
--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -76,7 +76,7 @@ block content
               .vert-space-x1.border-success.border.rounded.p-2
                 #typeform
 
-            if(component.formId == 'BoardShipment')
+            if component.formId == 'BoardShipment'
               .vert-space-x1.border-success.border.rounded.p-2
                 dt Boards in Shipment
                 dd
@@ -98,6 +98,15 @@ block content
                           td #{info[1]}
 
             if component.data.subComponent_fullUuids
+              - let columnHeader = ''
+
+              if component.data.subComponent_formId == 'GeometryBoard'
+                - columnHeader = 'UK ID'
+              else if component.data.subComponent_formId == 'CRBoard' || component.data.subComponent_formId == 'GBiasBoard'
+                - columnHeader = 'UW ID'
+              else 
+                - columnHeader = 'Factory ID'
+
               .vert-space-x1.border-success.border.rounded.p-2
                 dt Sub Components
                 dd
@@ -105,7 +114,7 @@ block content
                     thead
                       tr
                         th.col-md-3 UUID
-                        th.col-md-2 UK ID
+                        th.col-md-2 #{columnHeader}
                         th.col-md-3 QR Code Link
 
                     tbody

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -61,6 +61,8 @@ block content
         br
         | In either scenario, a summary of the found non-conformance actions will be displayed in the search results panel below the selection boxes.
 
+      hr
+
     .vert-space-x2
       h4
         a(href = '/search/geoBoardsByLocationOrPartNumber') Geometry Boards By Location or Part Number
@@ -127,7 +129,5 @@ block content
         |  If there is no such APA, i.e. the information does not match an existing APA record, a message will be displayed to the right of the input boxes to that effect.
 
       p It should not be possible for multiple APA records to match against all three provided pieces of information, since they should uniquely identify a single APA.  However, in the unlikely case of this situation occurring, a message will also be displayed indicating so.
-
-      hr
 
     .vert-space-x2 


### PR DESCRIPTION
- sub-component table column header on batch component information pages now shows either 'UK ID' or 'UW ID' depending on the type of sub-component
- small fix for misplaced horizontal line on search description page (left over from previous commit)