### PR TITLE
Component Name Display on Workflow Information Page

### DIFF
--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -9,6 +9,7 @@ block extrascripts
     const workflow = !{JSON.stringify(workflow, null, 4)};
     const workflowVersions = !{JSON.stringify(workflowVersions, null, 4)};
     const workflowTypeForm = !{JSON.stringify(workflowTypeForm, null, 4)};
+    const componentName = !{JSON.stringify(componentName, null, 4)};
     const componentTypeForms = !{JSON.stringify(componentTypeForms, null, 4)};
     const actionTypeForms = !{JSON.stringify(actionTypeForms, null, 4)};
 
@@ -67,7 +68,7 @@ block content
 
                       if componentUuid.length > 0
                         td
-                          a(href = `/component/${componentUuid}`, target = '_blank') #{componentUuid}
+                          a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
                       else 
                         td
                           .form-inline 

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 
+const Components = require('../lib/Components');
 const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
 const permissions = require('../lib/permissions');
@@ -27,6 +28,21 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
 
     if (!workflowTypeForm) return res.status(404).send(`There is no workflow type form with form ID = ${workflow.typeFormId}`);
 
+    // Attempt to retrieve a user-defined 'name' from the record of the component associated with this workflow (only if the component has already been created)
+    let componentName = '';
+
+    if (workflow.path[0].result.length > 0) {
+      const component = await Components.retrieve(workflow.path[0].result);
+
+      if (component) {
+        if (component.data.name) {
+          componentName = component.data.name;
+        } else {
+          componentName = workflow.path[0].result;
+        }
+      }
+    }
+
     // Simultaneously retrieve lists of all component and action type forms that currently exist in their respective collections
     const [componentTypeForms, actionTypeForms] = await Promise.all([
       Forms.list('componentForms'),
@@ -38,6 +54,7 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
       workflow,
       workflowVersions,
       workflowTypeForm,
+      componentName,
       componentTypeForms,
       actionTypeForms,
     });


### PR DESCRIPTION
If it exists, the component name is now displayed in the workflow information page's path table ... if no name exists, the component UUID is displayed as previously.