### PR TITLE
Attempting fix for batch sub-components going missing ...

### DIFF
--- a/app/jest/index.test.js
+++ b/app/jest/index.test.js
@@ -18,7 +18,7 @@ const pino_opts = {
 };
 
 // Declare and initialise variables
-let uuid, actionId, workflowId;
+let uuid, uuidsBatch, actionId, workflowId;
 let routes_toBeTested = {};
 
 // Set up a logger using the defined 'pino' settings and a destination file (in the same directory as this script)
@@ -310,7 +310,7 @@ describe('Private routes', function () {
 
     test('POST /json/component', () => {
       return myrequest(appAuthorized)
-        .post('/json/action')
+        .post('/json/component')
         .send({
           formId: `cform${suffix}`,
           data: { name: 'Dummy Component by JEST', },
@@ -320,6 +320,21 @@ describe('Private routes', function () {
         .then(response => {
           expect(response.body).toBeDefined();
           uuid = response.body;
+        });
+    });
+
+    test('POST /json/componentBatch', () => {
+      return myrequest(appAuthorized)
+        .post('/json/componentBatch')
+        .send({
+          formId: `cform${suffix}`,
+          data: { name: 'Dummy Batch of Components by JEST', },
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then(response => {
+          expect(response.body).toBeDefined();
+          uuidsBatch = response.body;
         });
     });
 

--- a/app/routes/api/components.js
+++ b/app/routes/api/components.js
@@ -74,6 +74,29 @@ router.post('/component', permissions.checkPermissionJson('components:edit'), as
 });
 
 
+/// Save all individual sub-component records from a single batch
+router.post('/componentBatch', permissions.checkPermissionJson('components:edit'), async function (req, res, next) {
+  try {
+    // The 'req.body' contains an array of the individual sub-component submission objects, so loop over these and save them one by one
+    // Save each sub-component's returned component UUID into an array, and additionally display a logger message indicating that each record is being saved via the '/componentBatch' route
+    let componentUuids = [];
+
+    req.body.forEach(function (subComponent) {
+      logger.info(subComponent, 'Submission to /componentBatch');
+
+      const componentUuid = Components.save(subComponent, req);
+      componentUuids.push(componentUuid);
+    });
+
+    // Return the array of sub-component component UUIDs
+    return res.json(componentUuids);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
 /// Generate a new component UUID
 router.get('/newComponentUUID', async function (req, res, next) {
   try {


### PR DESCRIPTION
- changed component creation/editing page so that all sub-component data is sent to the server in one go, and the server now handles submitting each one individually to the DB
- this should reduce the frequency of API calls to the DB pod
- added new corresponding route specifically for submitting sub-components, and added route to JEST script (still doesn't actually work, but may as well keep it updated)