### PR TITLE
Adding ability to track board installation ...

### DIFF
--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -164,7 +164,7 @@ async function tensionMeasurementsByUUID(componentUUID) {
 /// Retrieve a list of board installation actions that reference a single component, specified by its UUID
 async function boardInstallByReferencedComponent(componentUUID) {
   // Set up a list of type form IDs which correspond to 'board installation' type actions
-  let actionTypeFormIDs = [
+  const actionTypeFormIDs = [
     'g_foot_board_install', 'g_head_board_install_sideA', 'g_head_board_install_sideB',
     'u_foot_boards_install', 'u_head_board_install_sideA', 'u_head_board_installation_sideB', 'u_side_board_install_HSB', 'u_side_board_install_LSB',
     'v_foot_board_install', 'v_head_board_install_sideA', 'v_head_board_install_sideB', 'v_side_board_install_HSB', 'v_side_board_install_LSB',

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -34,6 +34,7 @@ block content
             option(value = 'williamAndMary') William and Mary 
             option(value = 'uwPsl') UW / PSL 
             option(value = 'chicago') Chicago
+            option(value = 'installed_on_APA') Installed on APA
 
           .vert-space-x2
             hr

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -130,6 +130,42 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})/edit', permissions.checkPermissio
 });
 
 
+/// Update the location information of all geometry boards in a board installation action
+/// This is an internal route - it should not be accessed directly by a user through their browser ...
+/// ... instead, it is automatically called during submission of any type of board installation action
+router.get('/action/:actionId([A-Fa-f0-9]{24})/updateBoardLocations/:location/:date', permissions.checkPermission('components:edit'), async function (req, res, next) {
+  try {
+    // Retrieve the most recent version of the record corresponding to the specified action ID, and throw an error if there is no such record
+    const action = await Actions.retrieve(req.params.actionId);
+
+    if (!action) return res.status(404).send(`There is no board installation action with action UUID = ${req.params.actionId}`);
+
+    // For each board UUID in the 'data.boardXUuid' key/value pairs, where X = 1 -> 10 or 21, update the reception location and date to those inherited from the installation action
+    // If successful, the updating function returns 'result = 1', but we don't actually need this value for anything
+    const uuid_format = new RegExp(/[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}/);
+
+    for (const [key, value] of Object.entries(action.data)) {
+      if (uuid_format.test(value)) {
+        const result = await Components.updateLocation(value, req.params.location, req.params.date);
+      }
+    }
+
+    // Depending on if the originating board installation action was part of a workflow or not, redirect to an appropriate page
+    // If the action originated from a workflow (and therefore a workflow ID has been provided), go to the page for updating the workflow path step results
+    // On the other hand, if it was a standalone action, go to the page for viewing the action record
+    // Note that these redirections are identical to those performed after submitting ANY action (see '/app/static/pages/action_specComponent.js')
+    if (req.query.workflowId) {
+      res.redirect(`/workflow/${req.query.workflowId}/action/${req.params.actionId}`);
+    } else {
+      res.redirect(`/action/${req.params.actionId}`);
+    }
+  } catch (err) {
+    logger.error(err);
+    res.status(500).send(err.toString());
+  }
+});
+
+
 /// Create a new action type form
 router.get('/actionTypes/:typeFormId/new', permissions.checkPermission('forms:edit'), async function (req, res) {
   try {

--- a/app/static/pages/action_specComponent.js
+++ b/app/static/pages/action_specComponent.js
@@ -78,9 +78,17 @@ function SubmitData(submission) {
 
     // Redirect the user to the appropriate post-submission page (where 'result' is the action record's action ID)
     // If the action is a 'Board Reception' type, we must first update the board information (and further redirection will be handled from there)
-    // If not, then we can simply proceed with standard post-submission redirection:
+    // Similarly, if the action is one of the board installation types, we must also first update the board information (in a different way)
+    // If neither of these is the case, then we can simply proceed with standard post-submission redirection:
     //   - if the action originates from a workflow, go to the page for updating the workflow path step results
     //   - if this is a standalone action, go to the page for viewing the action record 
+    const installation_typeFormIDs = [
+      'g_foot_board_install', 'g_head_board_install_sideA', 'g_head_board_install_sideB',
+      'u_foot_boards_install', 'u_head_board_install_sideA', 'u_head_board_installation_sideB', 'u_side_board_install_HSB', 'u_side_board_install_LSB',
+      'v_foot_board_install', 'v_head_board_install_sideA', 'v_head_board_install_sideB', 'v_side_board_install_HSB', 'v_side_board_install_LSB',
+      'x_foot_board_install', 'x_head_board_install_sideA', 'x_head_board_install_sideB',
+    ];
+
     if (submission.typeFormId === 'BoardReception') {
       const shipmentUUID = submission.componentUuid;
       const receptionLocation = submission.data.receptionLocation;
@@ -88,6 +96,17 @@ function SubmitData(submission) {
 
       let url = `/component/${shipmentUUID}/updateBoardLocations/${receptionLocation}/${receptionDate}`;
       url += `?actionId=${result}`;
+
+      if (!(workflowId === '')) url += `?workflowId=${workflowId}`;
+
+      window.location.href = url;
+    } else if (installation_typeFormIDs.includes(submission.typeFormId)) {
+      const receptionLocation = 'installed_on_APA';
+
+      const currentDT = new Date();
+      const receptionDate = `${currentDT.getFullYear()}-${currentDT.getMonth() + 1}-${currentDT.getDate()}`;
+
+      let url = `/action/${result}/updateBoardLocations/${receptionLocation}/${receptionDate}`;
 
       if (!(workflowId === '')) url += `?workflowId=${workflowId}`;
 


### PR DESCRIPTION
- geometry board location is now set to 'installed on APA' for all boards in a board installation action, upon submission of such actions
- new backend actions route and associated page level JS function
- added new 'location' to available locations when searching for boards by location