### PR TITLE
Miscellaneous changes relating to APA 8 Executive Summary ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -43,6 +43,27 @@ async function save(input, req) {
   if (input.workflowId) newRecord.workflowId = input.workflowId;
   if (input.images) newRecord.images = input.images;
 
+  // Winding and soldering actions each always contain an array of replaced wires or bad solder joints respectively ...
+  // ... however, depending on the specific action, this array may not itself contain any information (i.e. there were no replaced wires or bad solders)
+  // However, Formio does not allow an empty array - instead, it creates an array with one entry, which is itself full of empty strings
+  // This is incorrect but unavoidable behaviour, since if there are no replaced wires or bad solders, the array should indeed be empty ...
+  // ... so for these types of action, if the array contains a single entry of empty strings, reset the array to be empty (NOT NULL!) 
+  if ((newRecord.typeFormId === 'g_winding') || (newRecord.typeFormId === 'u_winding') || (newRecord.typeFormId === 'v_winding') || (newRecord.typeFormId === 'x_winding')) {
+    if (newRecord.data.replacedWires.length === 1) {
+      if ((newRecord.data.replacedWires[0].side === '') && (newRecord.data.replacedWires[0].layer === '') && (newRecord.data.replacedWires[0].boardLocation === '')) {
+        newRecord.data.replacedWires = [];
+      }
+    }
+  }
+
+  if ((newRecord.typeFormId === 'g_solder') || (newRecord.typeFormId === 'u_solder') || (newRecord.typeFormId === 'v_solder') || (newRecord.typeFormId === 'x_solder')) {
+    if (newRecord.data.badSolderJoints.length === 1) {
+      if ((newRecord.data.badSolderJoints[0].side === '') && (newRecord.data.badSolderJoints[0].layer === '') && (newRecord.data.badSolderJoints[0].boardLocation === '')) {
+        newRecord.data.badSolderJoints = [];
+      }
+    }
+  }
+
   // Generate and add an 'insertion' field to the new record
   newRecord.insertion = commonSchema.insertion(req);
 

--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -278,6 +278,7 @@ async function collateInfo(componentUUID) {
 
   const dictionary_locations = {
     daresbury: 'Daresbury',
+    chicago: 'Chicago',
   };
 
   const dictionary_systems = {

--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -264,6 +264,18 @@ async function collateInfo(componentUUID) {
     usWinder1: 'US Winder 1',
   };
 
+  const dictionary_heads = {
+    uk1: 'UK 1',
+    uk2: 'UK 2',
+    uk3: 'UK 3',
+    uk4: 'UK 4',
+    uk5: 'UK 5',
+    uk6: 'UK 6',
+    uk7: 'UK 7',
+    us1: 'US 1',
+    us1: 'US 2',
+  };
+
   const dictionary_locations = {
     daresbury: 'Daresbury',
   };
@@ -328,7 +340,7 @@ async function collateInfo(componentUUID) {
 
     if (results.length > 0) {
       collatedInfo[dictionaries[i]].winder = dictionary_winders[results[0].winder];
-      collatedInfo[dictionaries[i]].winderHead = results[0].winderHead;
+      collatedInfo[dictionaries[i]].winderHead = dictionary_heads[results[0].winderHead];
       collatedInfo[dictionaries[i]].winderMaintenenceSignoff = results[0].winderMaintenenceSignoff;
       collatedInfo[dictionaries[i]].tensionControlSignoff = results[0].tensionControlSignoff;
       collatedInfo[dictionaries[i]].replacedWires = results[0].replacedWires;

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -68,15 +68,11 @@ block content
 
           .vert-space-x1
 
-        if action.typeFormId == 'x_tension_testing'
-          dt Re-tensioned Wires or Wire Segments (comparing this version and version 1)
+        if (action.typeFormId == 'x_tension_testing') && (action.data.changedTensions_sideA)
+          dt Re-tensioned Wires or Wire Segments (comparing this version [#{action.validity.version}] and version #{action.validity.version - 1}):
 
-          - let numberOfChangedTensions_sideA = 0
-          - let numberOfChangedTensions_sideB = 0
-
-          if action.data.changedTensions_sideA
-            - numberOfChangedTensions_sideA = action.data.changedTensions_sideA.length
-            - numberOfChangedTensions_sideB = action.data.changedTensions_sideB.length
+          - let numberOfChangedTensions_sideA = action.data.changedTensions_sideA.length
+          - let numberOfChangedTensions_sideB = action.data.changedTensions_sideB.length
 
           .row
             .col-md-6
@@ -86,8 +82,8 @@ block content
                 i.chevron.fa.fa-fw 
 
               .collapse#reTensionsBoxA
-                .vert-space-x1.border-success.border.rounded.p-2
-                  if numberOfChangedTensions_sideA > 0
+                if numberOfChangedTensions_sideA > 0
+                  .vert-space-x1.border-success.border.rounded.p-2
                     dd
                       table.table
                         thead
@@ -109,8 +105,8 @@ block content
                 i.chevron.fa.fa-fw 
 
               .collapse#reTensionsBoxB
-                .vert-space-x1.border-success.border.rounded.p-2
-                  if numberOfChangedTensions_sideB > 0
+                if numberOfChangedTensions_sideB > 0
+                  .vert-space-x1.border-success.border.rounded.p-2
                     dd
                       table.table
                         thead

--- a/app/pug/component_execSummary.pug
+++ b/app/pug/component_execSummary.pug
@@ -89,33 +89,43 @@ block allbody
       hr
 
   .vert-space-x2
-    each ncrInfo, index in collatedInfo.apaNCRs_wires
-      - let hideHeader = true;
-      - if (index == 0) hideHeader = false;
+    .entry_apaNCRs_header
+      .form_apaNCRs_header(data-record = [])
 
-      .entry_apaNCRs_wires
-        .form_apaNCRs_wires(data-record = [ncrInfo, hideHeader])
+    if collatedInfo.apaNCRs_wires.length > 0
+      each ncrInfo, index in collatedInfo.apaNCRs_wires
+        .entry_apaNCRs_wires
+          .form_apaNCRs_wires(data-record = [ncrInfo])
+
+        hr
+    else 
+      p [no wire non-conformances reported]
 
       hr
 
   .vert-space-x2
-    each ncrInfo, index in collatedInfo.apaNCRs_other
-      - let hideHeader = true;
-      - if (index == 0) hideHeader = false;
+    .entry_otherNCRs_header 
+      .form_otherNCRs_header(data-record = [])
 
-      .entry_otherNCRs.vert-space-x1
-        .form_otherNCRs(data-record = [ncrInfo, hideHeader])
+    if (collatedInfo.apaNCRs_other.length > 0) || (collatedInfo.frameNCRs.length > 0) || (collatedInfo.meshPanelNCRs > 0)
+      each ncrInfo, index in collatedInfo.apaNCRs_other
+        .entry_otherNCRs.vert-space-x1
+          .form_otherNCRs(data-record = [ncrInfo])
 
-      hr
+        hr
 
-    each ncrInfo, index in collatedInfo.frameNCRs
-      .entry_otherNCRs.vert-space-x1
-        .form_otherNCRs(data-record = [ncrInfo, hideHeader = true])
+      each ncrInfo, index in collatedInfo.frameNCRs
+        .entry_otherNCRs.vert-space-x1
+          .form_otherNCRs(data-record = [ncrInfo])
 
-      hr
+        hr
 
-    each ncrInfo, index in collatedInfo.meshPanelNCRs
-      .entry_otherNCRs.vert-space-x1
-        .form_otherNCRs(data-record = [ncrInfo, hideHeader = true])
+      each ncrInfo, index in collatedInfo.meshPanelNCRs
+        .entry_otherNCRs.vert-space-x1
+          .form_otherNCRs(data-record = [ncrInfo])
+
+        hr
+    else 
+      p [no other non-conformances reported]
 
       hr

--- a/app/static/pages/component_execSummary.js
+++ b/app/static/pages/component_execSummary.js
@@ -341,9 +341,8 @@ function SetEntry_wireLayer(layer, layerInfo) {
         type: 'NumberArray',
         input: false,
         units: 'Tension [N]',
-        specification_nominal: 6.5,
-        specification_toleranceInner: 1,
-        specification_toleranceOuter: 2,
+        specification_nominal: 6.25,
+        specification_toleranceInner: 2.25,
         defaultValue: layerInfo.tensions_A
       }]
     },
@@ -354,9 +353,8 @@ function SetEntry_wireLayer(layer, layerInfo) {
         type: 'NumberArray',
         input: false,
         units: 'Tension [N]',
-        specification_nominal: 6.5,
-        specification_toleranceInner: 1,
-        specification_toleranceOuter: 2,
+        specification_nominal: 6.25,
+        specification_toleranceInner: 2.25,
         defaultValue: layerInfo.tensions_B
       }]
     }],
@@ -365,9 +363,9 @@ function SetEntry_wireLayer(layer, layerInfo) {
   return schema_wireLayer;
 }
 
-// Set up the schema for a single wire-related non-conformance entry
-function SetEntry_apaNCRs_wires(ncrInfo, hideHeader) {
-  const schema_apaNCRs_wires = {
+// Set up the schema for the wire-related non-conformance section header
+function SetEntry_apaNCRs_header() {
+  const schema_apaNCRs_header = {
     components: [{
       label: 'Assembled APA - Wire Non-Conformances',
       key: 'apaNCRs_wires',
@@ -375,9 +373,17 @@ function SetEntry_apaNCRs_wires(ncrInfo, hideHeader) {
       input: false,
       hideLabel: true,
       defaultValue: 'Assembled APA - Wire Non-Conformances',
-      hidden: hideHeader,
-    },
-    {
+    }],
+  }
+
+  return schema_apaNCRs_header;
+}
+
+
+// Set up the schema for a single wire-related non-conformance entry
+function SetEntry_apaNCRs_wires(ncrInfo) {
+  const schema_apaNCRs_wires = {
+    components: [{
       label: 'Columns',
       key: 'columns',
       type: 'columns',
@@ -453,9 +459,9 @@ function SetEntry_apaNCRs_wires(ncrInfo, hideHeader) {
   return schema_apaNCRs_wires;
 }
 
-// Set up the schema for a single non-wire non-conformance entry
-function SetEntry_otherNCRs(ncrInfo, hideHeader) {
-  const schema_otherNCRs = {
+// Set up the schema for the other non-conformance section header
+function SetEntry_otherNCRs_header() {
+  const schema_otherNCRs_header = {
     components: [{
       label: 'Other Non-Conformances',
       key: 'otherNCRs',
@@ -463,9 +469,17 @@ function SetEntry_otherNCRs(ncrInfo, hideHeader) {
       input: false,
       hideLabel: true,
       defaultValue: 'Other Non-Conformances',
-      hidden: hideHeader,
-    },
-    {
+    }],
+  }
+
+  return schema_otherNCRs_header;
+}
+
+
+// Set up the schema for a single non-wire non-conformance entry
+function SetEntry_otherNCRs(ncrInfo) {
+  const schema_otherNCRs = {
+    components: [{
       label: 'Columns',
       key: 'columns',
       type: 'columns',
@@ -547,20 +561,36 @@ async function populateExecutiveSummary() {
     Formio.createForm(form_wireLayers[0], schema_wireLayers, { readOnly: true, });
   })
 
-  // Render forms for the assembled APA wire related non-conformances
+  // Render the assembled APA wire-related non-conformances section header
+  $('div.entry_apaNCRs_header').each(function () {
+    const form_apaNCRs_header = $('.form_apaNCRs_header', this);
+    const schema_apaNCRs_header = SetEntry_apaNCRs_header()
+
+    Formio.createForm(form_apaNCRs_header[0], schema_apaNCRs_header, { readOnly: true, });
+  })
+
+  // Render forms for the assembled APA wire-related non-conformances
   $('div.entry_apaNCRs_wires').each(function () {
     const form_apaNCRs_wires = $('.form_apaNCRs_wires', this);
     const ncrInfo = form_apaNCRs_wires.data('record');
-    const schema_apaNCRs_wires = SetEntry_apaNCRs_wires(ncrInfo[0], ncrInfo[1])
+    const schema_apaNCRs_wires = SetEntry_apaNCRs_wires(ncrInfo[0])
 
     Formio.createForm(form_apaNCRs_wires[0], schema_apaNCRs_wires, { readOnly: true, });
+  })
+
+  // Render the other non-conformances section header
+  $('div.entry_otherNCRs_header').each(function () {
+    const form_otherNCRs_header = $('.form_otherNCRs_header', this);
+    const schema_otherNCRs_header = SetEntry_otherNCRs_header()
+
+    Formio.createForm(form_otherNCRs_header[0], schema_otherNCRs_header, { readOnly: true, });
   })
 
   // Render forms for the other non-conformances ... covering non wire-related assembled APA, frame and mesh panel NCRs
   $('div.entry_otherNCRs').each(function () {
     const form_otherNCRs = $('.form_otherNCRs', this);
     const ncrInfo = form_otherNCRs.data('record');
-    const schema_otherNCRs = SetEntry_otherNCRs(ncrInfo[0], ncrInfo[1])
+    const schema_otherNCRs = SetEntry_otherNCRs(ncrInfo[0])
 
     Formio.createForm(form_otherNCRs[0], schema_otherNCRs, { readOnly: true, });
   })

--- a/m2m/template_upload_tensions.py
+++ b/m2m/template_upload_tensions.py
@@ -15,7 +15,7 @@ apaLayer        = 'X'                                       # Wire layer (must b
 
 # For uploading new tension measurements (i.e. performing a new action), the following information is required:
 apa_uuid        = '49dcac80-4645-11ed-bb7f-0f80f77f8437'    # UUID of the Assembled APA on which the action is being performed (get from DB)
-measurement_loc = 'daresbury'                               # Use one of the following: 'daresbury'
+measurement_loc = 'daresbury'                               # Use one of the following: 'daresbury', 'chicago'
 measurement_sys = 'laser1'                                  # Use one of the following: 'dwa1', 'dwa2, 'dwa3', 'laser1', 'laser2', 'laser3', 'laser4', 'laser5'
 newAction_comms = 'This is a new single layer tension measurements action, uploaded via M2M'
                                                             # Free-form string, additional description or commentary if required

--- a/m2m/template_upload_tensions.py
+++ b/m2m/template_upload_tensions.py
@@ -6,26 +6,25 @@ from tensions import ExtractTensions
 # ##################################
 
 # Set a flag to specify if you are performing a new tension measurements action, or editing an existing one with re-tensioning measurements
-new_tensionMeasurements = True
+new_tensionMeasurements = False
 
 # For extracting the tension measurements (required for BOTH performing new and editing existing actions), the following information is required:
-csvFile         = '~/Desktop/tensions/APA4_U_layer_v1.csv'
+csvFile         = '~/Desktop/tensionMeasurements.csv'
                                                             # Name and location of the input .csv file (must be a string ending in '.csv')
-apaLayer        = 'U'                                       # Wire layer (must be given as one of 'X','U', 'V' or 'G')
+apaLayer        = 'X'                                       # Wire layer (must be given as one of 'X','U', 'V' or 'G')
 
 # For uploading new tension measurements (i.e. performing a new action), the following information is required:
 apa_uuid        = '49dcac80-4645-11ed-bb7f-0f80f77f8437'    # UUID of the Assembled APA on which the action is being performed (get from DB)
-winder_number   = 1                                         # Number
-winder_head     = '1'                                       # Free-form string
+measurement_loc = 'daresbury'                               # Use one of the following: 'daresbury'
 measurement_sys = 'laser1'                                  # Use one of the following: 'dwa1', 'dwa2, 'dwa3', 'laser1', 'laser2', 'laser3', 'laser4', 'laser5'
 newAction_comms = 'This is a new single layer tension measurements action, uploaded via M2M'
                                                             # Free-form string, additional description or commentary if required
 
 # For uploading re-tensioning measurements (i.e. editing an existing action), the following information is required:
-action_id       = '64aeed9e2f0e90764330d588'                # ID of the existing tension measurements action to be edited (get from DB)
-replaced_wires  = 'Some description of the replaced wires or wire segments, if applicable'
+action_id       = '6582feba5fedc88fb468a8d3'                # ID of the existing tension measurements action to be edited (get from DB)
+replaced_wires  = '[none]'
                                                             # Free-form string, additional description or commentary if required
-edtAction_comms = 'This is an edited single layer tension measurements action, uploaded via M2M'
+edtAction_comms = 'This is an existing single layer tension measurements action, edited via M2M'
                                                             # Free-form string, additional description or commentary if required
 
 # ##################################
@@ -57,9 +56,7 @@ if __name__ == '__main__':
         componentUUID = apa_uuid
         actionData = {
             'apaLayer': apaLayer.lower(),
-            'location': 'daresbury',
-            'winderNumber': winder_number,
-            'winderHead': winder_head,
+            'location': measurement_loc,
             'measurementSystem': measurement_sys,
             'measuredTensions_sideA': tensions_sideA,
             'measuredTensions_sideB': tensions_sideB,

--- a/m2m/tensions.py
+++ b/m2m/tensions.py
@@ -9,11 +9,10 @@ columns_X_A = [1,  7,  9, 11, 13, 15]
 columns_X_B = [1, 22, 24, 26, 28, 30]
 columns_U_A = [1, 24, 26, 28, 30, 32, 34]
 columns_U_B = [1, 41, 43, 45, 47, 49, 51]
-columns_V_A = [1, 26, 28, 30, 32, 34, 36]
-columns_V_B = [1, 44, 46, 48, 50, 52, 54]
+columns_V_A = [1, 24, 26, 28, 30, 32, 34]
+columns_V_B = [1, 41, 43, 45, 47, 49, 51]
 columns_G_A = [1,  7,  9, 11, 13, 15]
 columns_G_B = [1, 22, 24, 26, 28, 30]
-chk_colHds  = [['Board #'], ['Board # '], ['Board LS#'], ['Board #']]
 
 
 ########################################################
@@ -33,28 +32,23 @@ def ExtractTensions(csvFile, apaLayer):
     if apaLayer == 'X':
         columns_A = columns_X_A
         columns_B = columns_X_B
-        chk_colHd = chk_colHds[0]
     elif apaLayer == 'U':
         columns_A = columns_U_A
         columns_B = columns_U_B
-        chk_colHd = chk_colHds[1]
     elif apaLayer == 'V':
         columns_A = columns_V_A
         columns_B = columns_V_B
-        chk_colHd = chk_colHds[2]
     else:
         columns_A = columns_G_A
         columns_B = columns_G_B
-        chk_colHd = chk_colHds[3]
     
     # First deal with the tensions on side A
     # # Extract the columns from the .csv file for this side into a Pandas dataframe (columns --> series)
     # Set the row with index = 10 as the first one to store (the 'header row') across all series, since the rows above this always contain some comments, miscellaneous calculations, etc.
     # Immediately replace all zeroes (numerical and string) with 'NaN's ... this is required for the later step of merging the series
     # Finally, drop any rows where there is a 'NaN' in the selected 'check column' ... this indicates that this is most likely a comment row
-    df_sideA = pd.read_csv(csvFile, usecols = columns_A, header = 11, encoding = 'latin1')
+    df_sideA = pd.read_csv(csvFile, usecols = columns_A, header = 10, encoding = 'latin1')
     df_sideA = df_sideA.replace([0.0, '0.00'], np.nan)
-    df_sideA = df_sideA.dropna(subset = chk_colHd)
     
     # The 'U' and 'V' layer data always contains certain rows at the start and end which never contain tension measurements, so remove these (i.e. slice the dataframe)
     if apaLayer == 'U':
@@ -78,9 +72,8 @@ def ExtractTensions(csvFile, apaLayer):
     list_sideA = tensions_sideA.fillna(0.0).to_list()
     
     # Repeat the above for side B
-    df_sideB = pd.read_csv(csvFile, usecols = columns_B, header = 11, encoding = 'latin1')
+    df_sideB = pd.read_csv(csvFile, usecols = columns_B, header = 10, encoding = 'latin1')
     df_sideB = df_sideB.replace([0.0, '0.00'], np.nan)
-    df_sideB = df_sideB.dropna(subset = chk_colHd)
     
     if apaLayer == 'U':
         df_sideB = df_sideB[7 : -4]


### PR DESCRIPTION
- added dictionary to convert winding head field value from unformatted to formatted
- made it more clear when there are no wire-related NCRs (as opposed to if that section of the summary has just failed to generate)
- same as above for the other NCR sections as well
- fixed the incorrectly shown tension measurement threshold lines
- fixed a bug that prevented a tension measurements action being edited if no previous tensions were recorded  ... library function now calculates re-tensionings if previous version of the record contains tension measurements
- renamed certain variables to make it clear that re-tensionings are done by comparing current and immediately previous versions of the action
- action information page now shows re-tensioning comparison tables if such data exists in the record (related to bugfix in library function)
- updated M2M tension measurements upload script and backend function for new layer template spreadsheets ... testing using basic G layer example