### PR TITLE
Semi-freeform Workflows and Executive Summaries

### DIFF
--- a/app/pug/action_specComponent.pug
+++ b/app/pug/action_specComponent.pug
@@ -10,6 +10,7 @@ block extrascripts
     const componentUuid = !{JSON.stringify(componentUuid)};
     const componentName = !{JSON.stringify(componentName), null, 4};
     const workflowId = !{JSON.stringify(workflowId, null, 4)};
+    const stepIndex = !{JSON.stringify(stepIndex, null, 4)};
 
   block workscripts
     script(src = '/pages/action_specComponent.js')

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -7,9 +7,11 @@ block vars
 block extrascripts
   script(type = 'text/javascript').
     const workflow = !{JSON.stringify(workflow, null, 4)};
+    const workflowStatus = !{JSON.stringify(workflowStatus, null, 4)};
     const workflowVersions = !{JSON.stringify(workflowVersions, null, 4)};
     const workflowTypeForm = !{JSON.stringify(workflowTypeForm, null, 4)};
     const componentName = !{JSON.stringify(componentName, null, 4)};
+    const actionsDictionary = !{JSON.stringify(actionsDictionary, null, 4)};
     const componentTypeForms = !{JSON.stringify(componentTypeForms, null, 4)};
     const actionTypeForms = !{JSON.stringify(actionTypeForms, null, 4)};
     const queryDictionary = !{JSON.stringify(queryDictionary, null, 4)};
@@ -32,7 +34,11 @@ block content
           a(href = `/workflow/${workflow.workflowId}`) #{workflow.workflowId}
 
         dt Current Status 
-        dd #{workflow.status}
+
+        if workflowStatus == 'Complete'
+          dd.text-success.font-weight-bold #{workflowStatus}
+        else
+          dd.text-danger.font-weight-bold #{workflowStatus}
 
         dt Workflow Data:
         dd This is version #{workflow.validity.version} of the workflow, and it was last edited on !{' '}
@@ -46,30 +52,31 @@ block content
             #typeform
 
           .vert-space-x1.border-success.border.rounded.p-2
+            - let freeSection_bgn = -2;
+            - let freeSection_end = -1;
+            - let freeSection_complete = true 
+
+            if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
+              if workflow.typeFormId === 'workflow_1'
+                - freeSection_bgn = 2;
+                - freeSection_end = 4;
+              else 
+                - freeSection_bgn = 2;
+                - freeSection_end = 10;
+
+              each step in workflow.path.slice(freeSection_bgn - 1, freeSection_end)
+                if step.result.length === 0
+                  - freeSection_complete = false 
+
             table.table
               thead
                 tr 
                   th.col-md-1 Step
-                  th.col-md-5 Type Form Name
-                  th.col-md-5 Status / Result
+                  th.col-md-3 Type Form Name
+                  th.col-md-3 Result (Component Name or Action ID)
+                  th.col-md-3 Action Status
 
               tbody
-                - let freeSection_bgn = -2;
-                - let freeSection_end = -1;
-                - let freeSection_complete = true 
-
-                if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
-                  if workflow.typeFormId === 'workflow_1'
-                    - freeSection_bgn = 2;
-                    - freeSection_end = 4;
-                  else 
-                    - freeSection_bgn = 2;
-                    - freeSection_end = 10;
-
-                  each step in workflow.path.slice(freeSection_bgn - 1, freeSection_end)
-                    if step.result.length === 0
-                      - freeSection_complete = false 
-
                 each step, index in workflow.path 
                   tr 
                     td #{index + 1}
@@ -95,6 +102,7 @@ block content
                               a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
                                 img.small-icon(src = '/images/run_icon.svg')
                                 | &nbsp; Create Component 
+                      td [n.a.]
                     else
                       each typeFormId in Object.keys(actionTypeForms).sort()
                         if actionTypeForms[typeFormId].formName == step.formName
@@ -106,6 +114,11 @@ block content
                             if step.result.length > 0
                               td 
                                 a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                              if actionsDictionary[index]
+                                td.text-success.font-weight-bold Complete
+                              else
+                                td.text-danger.font-weight-bold Not Complete
                             else 
                               td
                                 .form-inline 
@@ -115,6 +128,7 @@ block content
                                     a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
                                       img.small-icon(src = '/images/run_icon.svg')
                                       | &nbsp; Perform Action
+                              td [n.a.]
                           else 
                             td
                               .form-inline 
@@ -123,6 +137,7 @@ block content
                                 .hori-space-x2
                                   a.btn-sm.btn-danger
                                     | Create Component First
+                            td [n.a.]
                         else
                           if !freeSection_complete
                             td
@@ -132,10 +147,16 @@ block content
                                 .hori-space-x2
                                   a.btn-sm.btn-danger
                                     | Perform Steps #{freeSection_bgn} to #{freeSection_end} First
+                            td [n.a.]
                           else 
                             if step.result.length > 0
                               td 
                                 a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                              if actionsDictionary[index]
+                                td.text-success.font-weight-bold Complete
+                              else
+                                td.text-danger.font-weight-bold Not Complete
                             else 
                               td
                                 .form-inline 
@@ -149,10 +170,16 @@ block content
                                     else 
                                       a.btn-sm.btn-danger
                                         | Perform Previous Steps First
+                              td [n.a.]
                       else
                         if step.result.length > 0
                           td 
                             a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                          if actionsDictionary[index]
+                            td.text-success.font-weight-bold Complete
+                          else
+                            td.text-danger.font-weight-bold Not Complete
                         else 
                           td
                             .form-inline 
@@ -166,6 +193,7 @@ block content
                                 else 
                                   a.btn-sm.btn-danger
                                     | Perform Previous Steps First
+                          td [n.a.]
 
     .vert-space-x1
       .panel.panel-default

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -54,6 +54,22 @@ block content
                   th.col-md-5 Status / Result
 
               tbody
+                - let freeSection_bgn = -2;
+                - let freeSection_end = -1;
+                - let freeSection_complete = true 
+
+                if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
+                  if workflow.typeFormId === 'workflow_1'
+                    - freeSection_bgn = 2;
+                    - freeSection_end = 4;
+                  else 
+                    - freeSection_bgn = 2;
+                    - freeSection_end = 10;
+
+                  each step in workflow.path.slice(freeSection_bgn - 1, freeSection_end)
+                    if step.result.length === 0
+                      - freeSection_complete = false 
+
                 each step, index in workflow.path 
                   tr 
                     td #{index + 1}
@@ -79,28 +95,77 @@ block content
                               a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
                                 img.small-icon(src = '/images/run_icon.svg')
                                 | &nbsp; Create Component 
-
                     else
                       each typeFormId in Object.keys(actionTypeForms).sort()
                         if actionTypeForms[typeFormId].formName == step.formName
                           - stepFormId = actionTypeForms[typeFormId].formId
 
-                      if step.result.length > 0
-                        td 
-                          a(href = `/action/${step.result}`, target = '_blank') #{step.result}
-                      else 
-                        td
-                          .form-inline 
-                            | (step not yet performed)
+                      if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
+                        if index >= freeSection_bgn - 1 && index < freeSection_end
+                          if componentUuid.length > 0
+                            if step.result.length > 0
+                              td 
+                                a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+                            else 
+                              td
+                                .form-inline 
+                                  | (step not yet performed)
 
-                            .hori-space-x2
-                              if workflow.path[index - 1].result.length > 0
-                                a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}`)
-                                  img.small-icon(src = '/images/run_icon.svg')
-                                  | &nbsp; Perform Action
-                              else 
-                                a.btn-sm.btn-danger
-                                  | Perform Previous Steps First
+                                  .hori-space-x2
+                                    a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                                      img.small-icon(src = '/images/run_icon.svg')
+                                      | &nbsp; Perform Action
+                          else 
+                            td
+                              .form-inline 
+                                | (step not yet performed)
+
+                                .hori-space-x2
+                                  a.btn-sm.btn-danger
+                                    | Create Component First
+                        else
+                          if !freeSection_complete
+                            td
+                              .form-inline 
+                                | (step not yet performed)
+
+                                .hori-space-x2
+                                  a.btn-sm.btn-danger
+                                    | Perform Steps #{freeSection_bgn} to #{freeSection_end} First
+                          else 
+                            if step.result.length > 0
+                              td 
+                                a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+                            else 
+                              td
+                                .form-inline 
+                                  | (step not yet performed)
+
+                                  .hori-space-x2
+                                    if workflow.path[index - 1].result.length > 0
+                                      a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                                        img.small-icon(src = '/images/run_icon.svg')
+                                        | &nbsp; Perform Action
+                                    else 
+                                      a.btn-sm.btn-danger
+                                        | Perform Previous Steps First
+                      else
+                        if step.result.length > 0
+                          td 
+                            a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+                        else 
+                          td
+                            .form-inline 
+                              | (step not yet performed)
+
+                              .hori-space-x2
+                                if workflow.path[index - 1].result.length > 0
+                                  a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                                    img.small-icon(src = '/images/run_icon.svg')
+                                    | &nbsp; Perform Action
+                                else 
+                                  a.btn-sm.btn-danger
+                                    | Perform Previous Steps First
 
     .vert-space-x1
       .panel.panel-default

--- a/app/pug/workflow_list.pug
+++ b/app/pug/workflow_list.pug
@@ -27,7 +27,7 @@ block content
             th.col-md-1
 
         tbody
-          each workflow in workflows
+          each workflow, index in workflows
             - const notSingleType_notTrashed = !singleType && !allWorkflowTypeForms[workflow.typeFormId].tags.includes('Trash');
 
             if notSingleType_notTrashed || singleType
@@ -42,10 +42,10 @@ block content
                 else 
                   td (component not yet created)
 
-                if workflow.status === 'Complete'
-                  td.text-success.font-weight-bold #{workflow.status}
+                if workflowStatuses[index] == 'Complete'
+                  td.text-success.font-weight-bold #{workflowStatuses[index]}
                 else
-                  td.text-danger.font-weight-bold #{workflow.status}
+                  td.text-danger.font-weight-bold #{workflowStatuses[index]}
 
                 td
                   a.btn-sm.btn-secondary(href = `/json/workflow/${workflow.workflowId}`, target = '_blank')

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -80,10 +80,14 @@ router.get('/action/:typeFormId/' + utils.uuid_regex, permissions.checkPermissio
 
     if (!component) return res.status(404).send(`There is no component record with component UUID = ${req.params.uuid}`);
 
-    // Set the workflow ID if one is provided
+    // Set both the workflow ID and workflow step index if the former is provided (either both or neither will be present)
     let workflowId = '';
+    let stepIndex = '-99';
 
-    if (req.query.workflowId) workflowId = req.query.workflowId;
+    if (req.query.workflowId) {
+      workflowId = req.query.workflowId;
+      stepIndex = req.query.stepIndex;
+    }
 
     // Render the interface page
     res.render('action_specComponent.pug', {
@@ -91,6 +95,7 @@ router.get('/action/:typeFormId/' + utils.uuid_regex, permissions.checkPermissio
       componentUuid: req.params.uuid,
       componentName: component.data.name,
       workflowId,
+      stepIndex,
     });
   } catch (err) {
     logger.error(err);
@@ -122,6 +127,7 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})/edit', permissions.checkPermissio
       componentUuid: action.componentUuid,
       componentName: component.data.name,
       workflowId: '',
+      stepIndex: '-99',
     });
   } catch (err) {
     logger.error(err);
@@ -155,7 +161,7 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})/updateLocations/:location/:date',
     // On the other hand, if it was a standalone action, go to the page for viewing the action record
     // Note that these redirections are identical to those performed after submitting ANY action (see '/app/static/pages/action_specComponent.js')
     if (req.query.workflowId) {
-      res.redirect(`/workflow/${req.query.workflowId}/action/${req.params.actionId}`);
+      res.redirect(`/workflow/${req.query.workflowId}/${req.query.stepIndex}/action/${req.params.actionId}`);
     } else {
       res.redirect(`/action/${req.params.actionId}`);
     }

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -332,15 +332,8 @@ router.get('/component/' + utils.uuid_regex + '/updateLocations/:location/:date'
         const result = await Components.updateLocation(board.component_uuid, req.params.location, req.params.date);
       }
 
-      // Depending on if the originating 'Board Shipment Reception' action was part of a workflow or not, redirect to an appropriate page
-      // If the action originated from a workflow (and therefore a workflow ID has been provided), go to the page for updating the workflow path step results
-      // On the other hand, if it was a standalone action, go to the page for viewing the action record
-      // Note that these redirections are identical to those performed after submitting ANY action (see '/app/static/pages/action_specComponent.js')
-      if (req.query.workflowId) {
-        res.redirect(`/workflow/${req.query.workflowId}/action/${req.query.actionId}`);
-      } else {
-        res.redirect(`/action/${req.query.actionId}`);
-      }
+      // Once all boards have been updated, redirect to the page for viewing the action record
+      res.redirect(`/action/${req.query.actionId}`);
     } else if (collection.formId === 'GroundingMeshShipment') {
       // Throw an error if there is no record corresponding to the specified UUID
       if (!collection) return res.status(404).send(`There is no grounding mesh panel shipment with component UUID = ${req.params.uuid}`);
@@ -351,15 +344,8 @@ router.get('/component/' + utils.uuid_regex + '/updateLocations/:location/:date'
         const result = await Components.updateLocation(mesh.component_uuid, req.params.location, req.params.date);
       }
 
-      // Depending on if the originating 'Grounding Mesh Shipment Reception' action was part of a workflow or not, redirect to an appropriate page
-      // If the action originated from a workflow (and therefore a workflow ID has been provided), go to the page for updating the workflow path step results
-      // On the other hand, if it was a standalone action, go to the page for viewing the action record
-      // Note that these redirections are identical to those performed after submitting ANY action (see '/app/static/pages/action_specComponent.js')
-      if (req.query.workflowId) {
-        res.redirect(`/workflow/${req.query.workflowId}/action/${req.query.actionId}`);
-      } else {
-        res.redirect(`/action/${req.query.actionId}`);
-      }
+      // Once all boards have been updated, redirect to the page for viewing the action record
+      res.redirect(`/action/${req.query.actionId}`);
     } else if (collection.formId === 'ReturnedGeometryBoardBatch') {
       // Throw an error if there is no record corresponding to the specified UUID
       if (!collection) return res.status(404).send(`There is no returned geometry board batch with component UUID = ${req.params.uuid}`);

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 
+const Actions = require('../lib/Actions');
 const Components = require('../lib/Components');
 const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
@@ -43,6 +44,25 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
       }
     }
 
+    // Retrieve and store the status of each action that has been performed (i.e. that has a result) - that is, the value (true or false) of the action's 'data.actionComplete' field
+    // Note that this field is common across all action type forms that are used in workflows, and so it should always exist one way or the other
+    // At the same time, determine the overall status of the workflow - it is 'complete' only if every action is individually complete ...
+    // ... i.e. there are the same number of completed actions as there are total actions in the workflow path
+    let actionsDictionary = {};
+    let numberOfCompleteActions = 0;
+
+    for (let stepIndex = 1; stepIndex < workflow.path.length; stepIndex++) {
+      if (workflow.path[stepIndex].result.length > 0) {
+        const action = await Actions.retrieve(workflow.path[stepIndex].result);
+
+        actionsDictionary[stepIndex] = action.data.actionComplete;
+
+        if (action.data.actionComplete) numberOfCompleteActions++;
+      }
+    }
+
+    const workflowStatus = (numberOfCompleteActions === workflow.path.length - 1) ? 'Complete' : 'In Progress';
+
     // Simultaneously retrieve lists of all component and action type forms that currently exist in their respective collections
     const [componentTypeForms, actionTypeForms] = await Promise.all([
       Forms.list('componentForms'),
@@ -52,9 +72,11 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
     // Render the interface page
     res.render('workflow.pug', {
       workflow,
+      workflowStatus,
       workflowVersions,
       workflowTypeForm,
       componentName,
+      actionsDictionary,
       componentTypeForms,
       actionTypeForms,
       queryDictionary: req.query,
@@ -123,11 +145,6 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})/:stepIndex/:stepType/:stepRes
     // Parse the step index (remembering that it is passed to this function as a string, but needs to be an integer)
     const stepIndex = parseInt(req.params.stepIndex, 10);
 
-    // Check if this is the final step in the workflow, i.e. if the workflow is complete after this step's result is saved
-    let workflowStatus = 'In Progress';
-
-    if ((stepIndex + 1) === workflow.path.length) workflowStatus = 'Complete';
-
     // Get the specified step type from the URL, and throw an error if it is not valid
     const stepType = req.params.stepType;
 
@@ -144,9 +161,8 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})/:stepIndex/:stepType/:stepRes
 
     if (!matchedComponent && !matchedAction) return res.status(404).send(`The provided step result (${stepResult}) is not valid for this step type ('${stepType}'')`);
 
-    // Update the step result
-    // If successful, the updating function returns 'result = 1', but we don't actually need this value for anything
-    const result = await Workflows.updatePathStep(req.params.workflowId, stepIndex, stepResult, workflowStatus);
+    // Update the step result ... if successful, the updating function returns 'result = 1', but we don't actually need this value for anything
+    const result = await Workflows.updatePathStep(req.params.workflowId, stepIndex, stepResult);
 
     // Redirect the user to the interface page for viewing the workflow record
     res.redirect(`/workflow/${req.params.workflowId}`);
@@ -222,12 +238,32 @@ router.get('/workflows/list', permissions.checkPermission('workflows:view'), asy
     // The first argument should be 'null' in order to match to any type form ID
     const workflows = await Workflows.list(null, { limit: 200 });
 
+    // For each workflow, determine its overall status - it is 'complete' only if every action is individually complete ...
+    // ... i.e. there are the same number of completed actions (specified by the value (true or false) of the action's 'data.actionComplete' field) as there are total actions in the workflow path
+    let workflowStatuses = [];
+
+    for (const workflow of workflows) {
+      let numberOfCompleteActions = 0;
+
+      for (let stepIndex = 1; stepIndex < workflow.stepResultIDs.length; stepIndex++) {
+        if (workflow.stepResultIDs[stepIndex].length > 0) {
+          const action = await Actions.retrieve(workflow.stepResultIDs[stepIndex]);
+
+          if (action.data.actionComplete) numberOfCompleteActions++;
+        }
+      }
+
+      const workflowStatus = (numberOfCompleteActions === workflow.stepResultIDs.length - 1) ? 'Complete' : 'In Progress';
+      workflowStatuses.push(workflowStatus);
+    }
+
     // Retrieve a list of all workflow type forms that currently exist in the 'workflowForms' collection
     const allWorkflowTypeForms = await Forms.list('workflowForms');
 
     // Render the interface page
     res.render('workflow_list.pug', {
       workflows,
+      workflowStatuses,
       singleType: false,
       title: 'All Created / Edited Workflows (All Types)',
       allWorkflowTypeForms,
@@ -246,6 +282,25 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermission('workflows
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
     const workflows = await Workflows.list({ typeFormId: req.params.typeFormId }, { limit: 200 });
 
+    // For each workflow, determine its overall status - it is 'complete' only if every action is individually complete ...
+    // ... i.e. there are the same number of completed actions (specified by the value (true or false) of the action's 'data.actionComplete' field) as there are total actions in the workflow path
+    let workflowStatuses = [];
+
+    for (const workflow of workflows) {
+      let numberOfCompleteActions = 0;
+
+      for (let stepIndex = 1; stepIndex < workflow.stepResultIDs.length; stepIndex++) {
+        if (workflow.stepResultIDs[stepIndex].length > 0) {
+          const action = await Actions.retrieve(workflow.stepResultIDs[stepIndex]);
+
+          if (action.data.actionComplete) numberOfCompleteActions++;
+        }
+      }
+
+      const workflowStatus = (numberOfCompleteActions === workflow.stepResultIDs.length - 1) ? 'Complete' : 'In Progress';
+      workflowStatuses.push(workflowStatus);
+    }
+
     // Retrieve the workflow type form corresponding to the specified type form ID
     const workflowTypeForm = await Forms.retrieve('workflowForms', req.params.typeFormId);
 
@@ -255,6 +310,7 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermission('workflows
     // Render the interface page
     res.render('workflow_list.pug', {
       workflows,
+      workflowStatuses,
       singleType: true,
       title: 'All Created / Edited Workflows (Single Type)',
       workflowTypeForm,

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -113,24 +113,15 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})/edit', permissions.checkPermi
 
 
 /// Update a single step result in the path of an existing workflow
-router.get('/workflow/:workflowId([A-Fa-f0-9]{24})/:stepType/:stepResult', permissions.checkPermission('workflows:edit'), async function (req, res, next) {
+router.get('/workflow/:workflowId([A-Fa-f0-9]{24})/:stepIndex/:stepType/:stepResult', permissions.checkPermission('workflows:edit'), async function (req, res, next) {
   try {
     // Retrieve the most recent version of the record corresponding to the specified workflow ID, and throw an error if there is no such record
     const workflow = await Workflows.retrieve(req.params.workflowId);
 
     if (!workflow) return res.status(404).send(`There is no workflow record with workflow ID = ${req.params.workflowId}`);
 
-    // Retrieve the index of the first incomplete step in the workflow path (this is the step whose result will be updated)
-    let stepIndex = -99;
-
-    for (let i = 0; i < workflow.path.length; i++) {
-      if (workflow.path[i].result === '') {
-        stepIndex = i;
-        break;
-      }
-    }
-
-    if (stepIndex === -99) return res.status(404).send(`There are no more steps to perform in the path of this workflow (ID = ${req.params.workflowId})`);
+    // Parse the step index (remembering that it is passed to this function as a string, but needs to be an integer)
+    const stepIndex = parseInt(req.params.stepIndex, 10);
 
     // Check if this is the final step in the workflow, i.e. if the workflow is complete after this step's result is saved
     let workflowStatus = 'In Progress';

--- a/app/static/pages/action_specComponent.js
+++ b/app/static/pages/action_specComponent.js
@@ -94,10 +94,7 @@ function SubmitData(submission) {
       const receptionLocation = submission.data.receptionLocation;
       const receptionDate = (submission.data.receptionDate).toString().slice(0, 10);
 
-      let url = `/component/${shipmentUUID}/updateLocations/${receptionLocation}/${receptionDate}`;
-      url += `?actionId=${result}`;
-
-      if (!(workflowId === '')) url += `?workflowId=${workflowId}`;
+      let url = `/component/${shipmentUUID}/updateLocations/${receptionLocation}/${receptionDate}?actionId=${result}`;
 
       window.location.href = url;
     } else if (installation_typeFormIDs.includes(submission.typeFormId)) {
@@ -108,12 +105,12 @@ function SubmitData(submission) {
 
       let url = `/action/${result}/updateLocations/${receptionLocation}/${receptionDate}`;
 
-      if (!(workflowId === '')) url += `?workflowId=${workflowId}`;
+      if (!(workflowId === '')) url += `?workflowId=${workflowId}&stepIndex=${stepIndex}`;
 
       window.location.href = url;
     } else {
       if (!(workflowId === '')) {
-        window.location.href = `/workflow/${workflowId}/action/${result}`;
+        window.location.href = `/workflow/${workflowId}/${stepIndex}/action/${result}`;
       } else {
         window.location.href = `/action/${result}`;
       }

--- a/app/static/pages/component_edit.js
+++ b/app/static/pages/component_edit.js
@@ -268,7 +268,7 @@ function SubmitData(submission) {
       window.location.href = `/component/${batchUUID}/updateLocations/${receptionLocation}/${receptionDate}`;
     } else {
       if (!(workflowId === '')) {
-        window.location.href = `/workflow/${workflowId}/component/${result}`;
+        window.location.href = `/workflow/${workflowId}/0/component/${result}`;
       } else {
         window.location.href = `/component/${result}`;
       }

--- a/app/static/pages/component_execSummary.js
+++ b/app/static/pages/component_execSummary.js
@@ -1,5 +1,12 @@
 // Set up the schema for the QC signoffs
 function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCableTempSensorQC) {
+  const apaQC_link = (apaQC.actionId !== '' ? `<a href = '/action/${apaQC.actionId}' > APA QC Review Details </a>` : `[missing APA QC Review]`);
+  const frameQC_link = (frameQC.actionId !== '' ? `<a href = '/action/${frameQC.qcActionId}' > Frame QC Review Details </a>` : `[missing no Frame QC Review]`);
+  const frameSurveys_link = (frameQC.surveysActionId !== '' ? `<a href = '/action/${frameQC.surveysActionId}' > Frame Survey Details </a>` : `[missing Frame Survey]`);
+  const meshPanelQC_link = (meshPanelQC.actionId !== '' ? `<a href = '/action/${meshPanelQC.actionId}' > Mesh Panel Installation QC Details </a>` : `[missing Mesh Panel Installation QC]`);
+  const cableConduitQC_link = (cableConduitQC.actionId !== '' ? `<a href = '/action/${cableConduitQC.actionId}' > Cable Conduit Insertion QC Details </a>` : `[missing Cable Conduit Insertion QC]`);
+  const pdCableTempSensorQC_link = (pdCableTempSensorQC.actionId !== '' ? `<a href = '/action/${pdCableTempSensorQC.actionId}' > PD and RTD Installation Details </a>` : `[missing PD and RTD Installation]`);
+
   const schema_qcSignoffs = {
     components: [{
       label: 'QC Signoffs',
@@ -30,7 +37,7 @@ function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCa
           key: 'apaQC_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${apaQC.actionId}' > APA QC Review Details </a> </br></p>`,
+          content: `<p><br> ${apaQC_link} </br></p>`,
         }],
         width: 3,
         size: 'sm',
@@ -51,7 +58,7 @@ function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCa
           key: 'frameQC_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${frameQC.qcActionId}' > Frame QC Review Details </a> </br></p>`,
+          content: `<p><br> ${frameQC_link} </br></p>`,
         }],
         width: 1,
         size: 'sm',
@@ -61,7 +68,7 @@ function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCa
           key: 'frameQC_surveysActionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${frameQC.surveysActionId}' > Frame Survey Details </a> </br></p>`,
+          content: `<p><br> ${frameSurveys_link} </br></p>`,
         }],
         width: 2,
         size: 'sm',
@@ -88,7 +95,7 @@ function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCa
           key: 'meshPanelQC_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${meshPanelQC.actionId}' > Mesh Panel Installation QC Details </a> </br></p>`,
+          content: `<p><br> ${meshPanelQC_link} </br></p>`,
         }],
         width: 3,
         size: 'sm',
@@ -109,7 +116,7 @@ function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCa
           key: 'cableConduitQC_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${cableConduitQC.actionId}' > Cable Conduit Insertion QC Details </a> </br></p>`,
+          content: `<p><br> ${cableConduitQC_link} </br></p>`,
         }],
         width: 3,
         size: 'sm',
@@ -147,7 +154,7 @@ function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCa
           key: 'pdCableTempSensorQC_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${pdCableTempSensorQC.actionId}' > PD and RTD Installation Details </a> </br></p>`,
+          content: `<p><br> ${pdCableTempSensorQC_link} </br></p>`,
         }],
         width: 3,
         size: 'sm',
@@ -165,6 +172,10 @@ function SetSection_qcSignoffs(apaQC, frameQC, meshPanelQC, cableConduitQC, pdCa
 
 // Set up the schema for a single wire layer entry
 function SetEntry_wireLayer(layer, layerInfo) {
+  const winding_link = (layerInfo.winding_actionId !== '' ? `<a href = '/action/${layerInfo.winding_actionId}' > Winding Details </a>` : `[missing Winding Details]`);
+  const soldering_link = (layerInfo.soldering_actionId !== '' ? `<a href = '/action/${layerInfo.soldering_actionId}' > Soldering Details </a>` : `[missing Soldering Details]`);
+  const tensions_link = (layerInfo.tensions_actionId !== '' ? `<a href = '/action/${layerInfo.tensions_actionId}' > Tension Measurements </a>` : `[missing Tension Measurements]`);
+
   const schema_wireLayer = {
     components: [{
       label: `Wire Layer ${layer}`,
@@ -275,7 +286,7 @@ function SetEntry_wireLayer(layer, layerInfo) {
           key: 'wireLayer_winding_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${layerInfo.winding_actionId}' > Winding Details </a> </br></p>`,
+          content: `<p><br> ${winding_link} </br></p>`,
         }],
         width: 2,
         size: 'sm',
@@ -285,7 +296,7 @@ function SetEntry_wireLayer(layer, layerInfo) {
           key: 'wireLayer_soldering_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${layerInfo.soldering_actionId}' > Soldering Details </a> </br></p>`,
+          content: `<p><br> ${soldering_link} </br></p>`,
         }],
         width: 2,
         size: 'sm',
@@ -323,7 +334,7 @@ function SetEntry_wireLayer(layer, layerInfo) {
           key: 'tensions_actionId',
           type: 'htmlelement',
           input: false,
-          content: `<p><br> <a href = '/action/${layerInfo.tensions_actionId}' > Tension Measurements </a> </br></p>`,
+          content: `<p><br> ${tensions_link} </br></p>`,
         }],
         width: 2,
         size: 'sm',

--- a/app/static/pages/workflow_edit.js
+++ b/app/static/pages/workflow_edit.js
@@ -45,10 +45,8 @@ async function onPageLoad() {
 
     // If this is a completely new workflow, copy the 'path' object from the workflow type form into the 'submission' object
     // For an existing workflow that is being edited, we don't want to do this, since it would overwrite any existing path results
-    // Also for a completely new workflow, set a 'status' field in the submission ... initially with a value of 'In Progress'
     if (newWorkflow) {
       submission.path = workflowTypeForm.path;
-      submission.status = 'In Progress';
     }
 
     // Once all additions and changes to the 'submission' object have been completed, submit it to the database


### PR DESCRIPTION
First Commit:
- workflows may now contain a section in which the steps may be done in any order ... selection of freeform steps is hardcoded and dependent on the workflow type
- step index is now propagated through the interface, routes and library, and library function now explicitly sets the result of the specified step (previously would assume to set the result of the first step with no result)
- reworked workflow information page accordingly ... new conditionals according to step result, position of step in workflow, whether step is freeform or not
- cleaned up some unnecessary code relating to submitting components that will never be part of workflows (previously would still check if they were)

Second Commit:
- overhaul of how workflow completeness is determined ... individual actions now have their own completeness tracked (via checkbox), and the workflow will now check the individual actions directly for their completeness
- individual action completeness is now displayed on the workflow information page, and workflow completeness derives from if all individual actions are explicitly complete or not
- workflow completeness no longer stored in the workflow record, but instead determined only as and when required (only on two pages of the interface)
- assembled APA executive summaries now display more user-friendly information if and when actions have not yet been performed or completed ... default field value when QC review personnel are missing, and links disabled and relabelled when action IDs are missing