### PR TITLE
Fixing probable bug in Executive Summary code

### DIFF
--- a/app/pug/component_execSummary.pug
+++ b/app/pug/component_execSummary.pug
@@ -107,24 +107,27 @@ block allbody
     .entry_otherNCRs_header 
       .form_otherNCRs_header(data-record = [])
 
-    if (collatedInfo.apaNCRs_other.length > 0) || (collatedInfo.frameNCRs.length > 0) || (collatedInfo.meshPanelNCRs > 0)
-      each ncrInfo, index in collatedInfo.apaNCRs_other
-        .entry_otherNCRs.vert-space-x1
-          .form_otherNCRs(data-record = [ncrInfo])
+    if (collatedInfo.apaNCRs_other.length > 0) || (collatedInfo.frameNCRs.length > 0) || (collatedInfo.meshPanelNCRs.length > 0)
+      if collatedInfo.apaNCRs_other.length > 0
+        each ncrInfo, index in collatedInfo.apaNCRs_other
+          .entry_otherNCRs.vert-space-x1
+            .form_otherNCRs(data-record = [ncrInfo])
 
-        hr
+          hr
 
-      each ncrInfo, index in collatedInfo.frameNCRs
-        .entry_otherNCRs.vert-space-x1
-          .form_otherNCRs(data-record = [ncrInfo])
+      if collatedInfo.frameNCRs.length > 0
+        each ncrInfo, index in collatedInfo.frameNCRs
+          .entry_otherNCRs.vert-space-x1
+            .form_otherNCRs(data-record = [ncrInfo])
 
-        hr
+          hr
 
-      each ncrInfo, index in collatedInfo.meshPanelNCRs
-        .entry_otherNCRs.vert-space-x1
-          .form_otherNCRs(data-record = [ncrInfo])
+      if collatedInfo.meshPanelNCRs.length > 0
+        each ncrInfo, index in collatedInfo.meshPanelNCRs
+          .entry_otherNCRs.vert-space-x1
+            .form_otherNCRs(data-record = [ncrInfo])
 
-        hr
+          hr
     else 
       p [no other non-conformances reported]
 


### PR DESCRIPTION
Length of mesh panel NCRs array was not being checked before potentially being used.
Also improved the if-statement logic of the "Other NCRs" section of the summary ... previously would only check if ANY of the sub-sections had information to show, now checks them individually as well.
