### PR TITLE
Bug Fixes for Memory Limit and non-existent Inspection Results ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -258,7 +258,7 @@ async function list(match_condition, options) {
 
   // Query the 'actions' records collection using the aggregation stages defined above
   let records = await db.collection('actions')
-    .aggregate(aggregation_stages)
+    .aggregate(aggregation_stages, {allowDiskUse: true})
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -232,7 +232,7 @@ async function list(match_condition, options) {
 
   // Query the 'components' records collection using the aggregation stages defined above
   let records = await db.collection('components')
-    .aggregate(aggregation_stages)
+    .aggregate(aggregation_stages, {allowDiskUse: true})
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -217,7 +217,7 @@ block content
                           tr
                             td #{value.Measurement}
 
-                            if value.Units !== null
+                            if value.Units !== null && value.Actual !== ''
                               if value.Actual < value.Tolerance
                                 td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
                               else
@@ -228,7 +228,11 @@ block content
 
                             else 
                               td #{value.Actual}
-                              td
+                              
+                              if value.Units == null
+                                td
+                              else 
+                                td #{value.Units}
                               td #{value.Tolerance}
 
                             td #{value.Comment}


### PR DESCRIPTION
- trying a different approach to fix the memory limit exceeded bug when sorting too many actions - new flag allows MongoDB to use local temporary files to help
- bug fix for displaying non-existent vertical inspection results ... previously code assumes that all results are available, but some are missing for older frames.  New code will now show empty lines where appropriate, instead of crashing