### PR TITLE
Another attempt to fix Memory Limit bug ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -231,6 +231,16 @@ async function list(match_condition, options) {
     aggregation_stages.push({ $match: match_condition });
   }
 
+  // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
+  aggregation_stages.push({
+    $project: {
+      actionId: true,
+      typeFormId: true,
+      typeFormName: true,
+      componentUuid: true,
+      validity: true,
+    }
+  })
   // Select only the latest version of each record
   // First sort the matching records by validity ... highest version first
   // Then group the records by the action ID (i.e. each group contains all versions of the same action), and select only the first (highest version number) entry in each group
@@ -258,7 +268,7 @@ async function list(match_condition, options) {
 
   // Query the 'actions' records collection using the aggregation stages defined above
   let records = await db.collection('actions')
-    .aggregate(aggregation_stages, {allowDiskUse: true})
+    .aggregate(aggregation_stages)
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -232,7 +232,7 @@ async function list(match_condition, options) {
 
   // Query the 'components' records collection using the aggregation stages defined above
   let records = await db.collection('components')
-    .aggregate(aggregation_stages, {allowDiskUse: true})
+    .aggregate(aggregation_stages)
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display


### PR DESCRIPTION
- trying use of MongodB 'project' aggregation stage to reduce the amount of information being passed to the 'sort' stage
- removed 'allowDiskUse' flags recently added ... don't appear to be doing anything, and it is actually enabled by default in MongoDB v6.0, so wouldn't be needed anyway in the future