### PR TITLE
Safeguarding against future 'Exceeded Memory Limit' bug reoccurrence ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -204,6 +204,17 @@ async function list(match_condition, options) {
     aggregation_stages.push({ $match: match_condition });
   }
 
+  // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
+  aggregation_stages.push({
+    $project: {
+      componentUuid: true,
+      formId: true,
+      formName: true,
+      data: true,
+      validity: true,
+    }
+  })
+
   // Select only the latest version of each record
   // First sort the matching records by validity ... highest version first
   // Then group the records by the component UUID (i.e. each group contains all versions of the same component), and select only the first (highest version number) entry in each group

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -168,6 +168,17 @@ async function list(match_condition, options) {
   // If a matching condition has been specified, set it as the first aggregation stage
   if (match_condition) aggregation_stages.push({ $match: match_condition });
 
+  // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
+  aggregation_stages.push({
+    $project: {
+      workflowId: true,
+      typeFormId: true,
+      typeFormName: true,
+      path: true,
+      validity: true,
+    }
+  })
+
   // Select only the latest version of each record
   // First sort the matching records by validity ... highest version first
   // Then group the records by the workflow ID (i.e. each group contains all versions of the same workflow), and select only the first (highest version number) entry in each group
@@ -179,7 +190,6 @@ async function list(match_condition, options) {
       workflowId: { '$first': '$workflowId' },
       typeFormId: { '$first': '$typeFormId' },
       typeFormName: { '$first': '$typeFormName' },
-      name: { '$first': '$data.name' },
       stepResultIDs: { '$first': '$path.result' },
       lastEditDate: { '$first': '$validity.startDate' },
     },


### PR DESCRIPTION
- applied 'project' MongoDB operators to component and workflow list library functions, to reduce the amount of information being passed to later 'sort' operators
- equivalent to recently added operator on action list function, which solved the bug there