### PR TITLE
Pre-emptive bug fix for replaced wires and bad solders ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -50,7 +50,7 @@ async function save(input, req) {
   // ... so for these types of action, if the array contains a single entry of empty strings, reset the array to be empty (NOT NULL!) 
   if ((newRecord.typeFormId === 'g_winding') || (newRecord.typeFormId === 'u_winding') || (newRecord.typeFormId === 'v_winding') || (newRecord.typeFormId === 'x_winding')) {
     if (newRecord.data.replacedWires.length === 1) {
-      if ((newRecord.data.replacedWires[0].side === '') && (newRecord.data.replacedWires[0].layer === '') && (newRecord.data.replacedWires[0].boardLocation === '')) {
+      if ((newRecord.data.replacedWires[0].side === '') && (newRecord.data.replacedWires[0].boardLocation === '')) {
         newRecord.data.replacedWires = [];
       }
     }
@@ -58,7 +58,7 @@ async function save(input, req) {
 
   if ((newRecord.typeFormId === 'g_solder') || (newRecord.typeFormId === 'u_solder') || (newRecord.typeFormId === 'v_solder') || (newRecord.typeFormId === 'x_solder')) {
     if (newRecord.data.badSolderJoints.length === 1) {
-      if ((newRecord.data.badSolderJoints[0].side === '') && (newRecord.data.badSolderJoints[0].layer === '') && (newRecord.data.badSolderJoints[0].boardLocation === '')) {
+      if ((newRecord.data.badSolderJoints[0].side === '') && (newRecord.data.badSolderJoints[0].boardLocation === '')) {
         newRecord.data.badSolderJoints = [];
       }
     }


### PR DESCRIPTION
- currently, the code checks if there are three empty strings - 'side', 'layer' and 'boardLocation' - in the first entry of the 'replacedWires' or 'badSolderJoints' field
- if so, the entire field is replaced by an empty list, since the empty strings would indicate that no wires or solders have actually been entered
- HOWEVER, because the 'layer' sub-field has a default value in the type forms, this will never be an empty string ... and so there will always be an entry in the list, even if no wires or solders have indeed been entered
- the check on the 'layer' string has now been removed ... the 'side' and 'boardLocation' string checks remain, since they can be empty (and will be, if no wires or solders have been entered)