### PR TITLE
Requests relating to Populated Board Kits

### DIFF
--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -151,6 +151,10 @@ body(class = `deployment-${NODE_ENV}`)
                     |      Grounding Mesh Panels by Location or Part Number
 
                 li.nav-item
+                  +navlink(href = '/search/boardKitComponentsByLocation')
+                    |      Populated Board Kit Components by Location
+
+                li.nav-item
                   +navlink(href = '/search/apaByLocation')
                     |      Assembled APA by Location
 

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -111,6 +111,18 @@ block content
 
     .vert-space-x2
       h4
+        a(href = '/search/boardKitComponentsByLocation') Populated Board Kit Components By Location
+
+      p This page may be used to search specifically for components that make up <b>populated board kits</b> (<b>CR boards</b>, <b>G-Bias boards</b>, <b>SHV boards</b> and <b>cable harnesses</b>) that have been received at a <u>specified location</u>.
+
+      p Users may select one of the available board kit reception locations from the list, and a summary of information about all found components will be displayed in the search results panel on the right side of the page.
+
+      p Please note that a board kit (and therefore, its constituent components) is only deemed to be at a given location if it has been recorded as being received there via a successfully submitted <b>Populated Board Kit Reception</b> action.
+
+      hr
+
+    .vert-space-x2
+      h4
         a(href = '/search/apaByLocation') Assembled APA by Location
 
       p This page may be used to search specifically for <b>assembled APAs</b> that match <b>both</b> of the following user-specified record details:

--- a/app/pug/search_boardKitComponentsByLocation.pug
+++ b/app/pug/search_boardKitComponentsByLocation.pug
@@ -1,0 +1,38 @@
+extend default
+
+block vars
+  - const page_title = 'Search for Populated Board Kit Components by Location';
+
+block extrascripts
+  block workscripts 
+    script(src = '/pages/search_boardKitComponentsByLocation.js')
+
+block content
+  .container-fluid
+    .vert-space-x2
+      h2 Search for Populated Board Kit Components by Location
+
+    .vert-space-x2
+      hr
+
+      .row
+        .col-md-4
+          h4 Select Location
+
+          .vert-space-x1
+            p Select a location from the options below.
+
+          select.form-control#locationSelection
+            option(value = '')
+            option(value = 'cern') CERN 
+            option(value = 'surf') SURF 
+
+        .col-md-1
+
+        .col-md-7
+          h4 Search Results
+
+          .vert-space-x1
+            table#results
+
+    .vert-space-x2

--- a/app/pug/search_componentsByUUIDOrTypeAndNumber.pug
+++ b/app/pug/search_componentsByUUIDOrTypeAndNumber.pug
@@ -41,6 +41,11 @@ block content
               option(value = '')          
               option(value = 'GeometryBoard') Geometry Board
               option(value = 'GroundingMeshPanel') Grounding Mesh Panel
+              option(value = 'CRBoard') CR Board
+              option(value = 'GBiasBoard') G-Bias Board
+              option(value = 'CEAdapterBoard') CE Adapter Board
+              option(value = 'SHVBoard') SHV Board
+              option(value = 'CableHarness') Cable Harness
 
             .vert-space-x1
             p Enter a type record number below and press the 'Enter' key.

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -131,6 +131,21 @@ router.get('/search/meshesByPartNumber/:partNumber', async function (req, res, n
 });
 
 
+/// Search for populated board kit components that have been received at a specified location
+router.get('/search/boardKitComponentsByLocation/:location', async function (req, res, next) {
+  try {
+    // Retrieve a list of populated board kit components, grouped by component type, that have been received at the specified location
+    const componentsByType = await Search_OtherComponents.boardKitComponentsByLocation(req.params.location);
+
+    // Return the list in JSON format
+    return res.json(componentsByType);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
 /// Search for workflows that involve a particular component, specified by its UUID
 router.get('/search/workflowsByUUID/' + utils.uuid_regex, async function (req, res, next) {
   try {

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -313,7 +313,7 @@ router.get('/component/' + utils.uuid_regex + '/edit', permissions.checkPermissi
 });
 
 
-/// Update the most recently recorded reception location and date of all individual components in a shipment or batch
+/// Update the most recently recorded reception location and date of all individual components in a collection of components (i.e. a shipment, batch or kit)
 /// This is an internal route - it should not be accessed directly by a user through their browser ...
 /// ... instead, it is automatically called during submission of an appropriate 'XXX Reception' action or 'Returned XXX Batch' component 
 router.get('/component/' + utils.uuid_regex + '/updateLocations/:location/:date', permissions.checkPermission('components:edit'), async function (req, res, next) {
@@ -323,7 +323,7 @@ router.get('/component/' + utils.uuid_regex + '/updateLocations/:location/:date'
 
     if (!collection) return res.status(404).send(`There is no component record with component UUID = ${req.params.uuid}`);
 
-    // Because the board UUIDs are stored differently in the various shipment and batch type components, set up separate (but annoyingly similar!) scenarios for each one
+    // Because the board UUIDs are stored differently in the various collections of components, set up separate (but annoyingly similar!) scenarios for each one
     if (collection.formId === 'BoardShipment') {
       // For each board in the shipment, extract the UUID and update the reception details to match those from the 'Board Shipment Reception' action
       // If successful, the updating function returns 'result = 1', but we don't actually need this value for anything

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -43,6 +43,13 @@ router.get('/search/meshesByLocationOrPartNumber', async function (req, res, nex
 });
 
 
+/// Search for populated board kit components that have been received at a specific location
+router.get('/search/boardKitComponentsByLocation', async function (req, res, next) {
+  // Render the interface page
+  res.render('search_boardKitComponentsByLocation.pug');
+});
+
+
 /// Search for an assembled APA using its location and production number
 router.get('/search/apaByLocation', async function (req, res, next) {
   // Render the interface page

--- a/app/static/pages/action_specComponent.js
+++ b/app/static/pages/action_specComponent.js
@@ -77,7 +77,7 @@ function SubmitData(submission) {
     typeForm.emit('submitDone');
 
     // Redirect the user to the appropriate post-submission page (where 'result' is the action record's action ID)
-    // If the action is a 'Board' or 'Grounding Mesh' Shipment Reception type, we must first update the board information (and further redirection will be handled from there)
+    // If the action is a 'XXX Reception' type (performed on a shipment or batch), we must first update the individual component information (and further redirection will be handled from there)
     // Similarly, if the action is one of the board installation types, we must also first update the board information (in a different way)
     // If neither of these is the case, then we can simply proceed with standard post-submission redirection:
     //   - if the action originates from a workflow, go to the page for updating the workflow path step results
@@ -89,7 +89,7 @@ function SubmitData(submission) {
       'x_foot_board_install', 'x_head_board_install_sideA', 'x_head_board_install_sideB',
     ];
 
-    if ((submission.typeFormId === 'BoardReception') || (submission.typeFormId === 'GroundingMeshShipmentReception')) {
+    if ((submission.typeFormId === 'BoardReception') || (submission.typeFormId === 'GroundingMeshShipmentReception') || (submission.typeFormId === 'PopulatedBoardKitReception')) {
       const shipmentUUID = submission.componentUuid;
       const receptionLocation = submission.data.receptionLocation;
       const receptionDate = (submission.data.receptionDate).toString().slice(0, 10);

--- a/app/static/pages/action_specComponent.js
+++ b/app/static/pages/action_specComponent.js
@@ -90,11 +90,11 @@ function SubmitData(submission) {
     ];
 
     if ((submission.typeFormId === 'BoardReception') || (submission.typeFormId === 'GroundingMeshShipmentReception') || (submission.typeFormId === 'PopulatedBoardKitReception')) {
-      const shipmentUUID = submission.componentUuid;
+      const collectionUUID = submission.componentUuid;
       const receptionLocation = submission.data.receptionLocation;
       const receptionDate = (submission.data.receptionDate).toString().slice(0, 10);
 
-      let url = `/component/${shipmentUUID}/updateLocations/${receptionLocation}/${receptionDate}?actionId=${result}`;
+      let url = `/component/${collectionUUID}/updateLocations/${receptionLocation}/${receptionDate}?actionId=${result}`;
 
       window.location.href = url;
     } else if (installation_typeFormIDs.includes(submission.typeFormId)) {

--- a/app/static/pages/search_boardKitComponentsByLocation.js
+++ b/app/static/pages/search_boardKitComponentsByLocation.js
@@ -1,0 +1,106 @@
+// Declare variables to hold the (initially empty) user-specified board location
+let receptionLocation = null;
+
+
+// Main function
+$(function () {
+  // When the selected location is changed, get the newly selected location from the corresponding page element
+  // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
+  $('#locationSelection').on('change', async function () {
+    receptionLocation = $('#locationSelection').val();
+
+    if (receptionLocation) {
+      $.ajax({
+        contentType: 'application/json',
+        method: 'GET',
+        url: `/json/search/boardKitComponentsByLocation/${receptionLocation}`,
+        dataType: 'json',
+        success: postSuccess,
+      }).fail(postFail);
+    }
+  });
+});
+
+
+// Set up a dictionary containing the possible component type form ID and name [key, string] pairs
+const componentTypesDictionary = {
+  CRBoard: 'CR Board',
+  GBiasBoard: 'G-Bias Board',
+  SHVBoard: 'SHV Board',
+  CableHarness: 'Cable Harness',
+};
+
+
+// Function to run for a successful search query
+function postSuccess(result) {
+  // Make sure that the page element where the results will be displayed is empty, and then enter an initial message to display
+  $('#results').empty();
+
+  const resultsStart = `
+    <tr>
+      <td colspan = "3">The following populated board kit components have been received at <b>${$('#locationSelection option:selected').text()}</b>.</td>
+    </tr>
+    <tr>
+      <td colspan = "3">They are grouped by component type, and then ordered by last DB record edit (most recent at the top).
+        <br>
+        <hr>
+      </td>
+    </tr>`;
+
+  $('#results').append(resultsStart);
+
+  // If there are no search results, display a message to indicate this, but otherwise set up a table of the search results
+  if (Object.keys(result).length === 0) {
+    $('#results').append('<b>There are no populated board kit components at the specified location</b>');
+  } else {
+    for (const componentGroup of result) {
+      const componentCount = `
+        <tr>
+          <td colspan = "3">Found ${componentGroup.componentUuids.length} components of type: <b>${componentTypesDictionary[componentGroup.type]}</b></td>
+        </tr>`;
+
+      $('#results').append(componentCount);
+    }
+
+    $('#results').append('<br>');
+
+    for (const componentGroup of result) {
+      const groupTitle = `<b>Component Type: ${componentTypesDictionary[componentGroup.type]}</b>`;
+
+      $('#results').append(groupTitle);
+
+      const tableStart = `
+        <tr>
+          <th scope = 'col' width = '40%'>Component UUID</th>
+          <th scope = 'col' width = '40%'>DUNE PID</th>
+          <th scope = 'col' width = '20%'>Received On:</th>
+        </tr>`;
+
+      $('#results').append(tableStart);
+
+      for (const i in componentGroup.componentUuids) {
+        const componentText = `
+          <tr>
+            <td><a href = '/component/${componentGroup.componentUuids[i]}' target = '_blank'</a>${componentGroup.componentUuids[i]}</td>
+            <td>${componentGroup.dunePids[i]}</td>
+            <td>${componentGroup.receptionDates[i]}</td>
+          </tr>`;
+
+        $('#results').append(componentText);
+      }
+
+      $('#results').append('<br>');
+    }
+  }
+};
+
+
+// Function to run for a failed search query
+function postFail(result, statusCode, statusMsg) {
+  // If the query result contains a response message, display it, and if not, display any status message and error code instead
+  if (result.responseText) {
+    console.log('POSTFAIL: ', result.responseText);
+  } else {
+    console.log('POSTFAIL: ', `${statusMsg} (${statusCode})`);
+  }
+};


### PR DESCRIPTION
- populated board kit constituent components (CR boards, G-Bias boards, SHV boards and cable harnesses) can now be searched for by type and number
- they can also now be received at a specified location (using a 'Populated Board Kit Reception' action), and then searched for by reception location