### PR TITLE
Implementing location tracking for all components ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -36,7 +36,7 @@ async function save(input, req) {
   newRecord.recordType = 'action';
   newRecord.actionId = new ObjectID(input.actionId);
   newRecord.typeFormId = input.typeFormId;
-  newRecord.typeFormName = input.typeFormName || typeForm.formName;
+  newRecord.typeFormName = typeForm.formName;
   newRecord.componentUuid = MUUID.from(input.componentUuid);
   newRecord.data = input.data;
 
@@ -66,8 +66,6 @@ async function save(input, req) {
 
   // Generate and add an 'insertion' field to the new record
   newRecord.insertion = commonSchema.insertion(req);
-
-  let _lock = await dbLock(`saveAction_${newRecord.actionId}`, 1000);
 
   // Attempt to retrieve an existing record with the same action ID as the specified one (relevant if we are editing an existing record)
   let oldRecord = null;
@@ -125,6 +123,8 @@ async function save(input, req) {
   }
 
   // Insert the new record into the 'actions' records collection, and throw an error if the insertion fails
+  let _lock = await dbLock(`saveAction_${newRecord.actionId}`, 1000);
+
   const result = await db.collection('actions')
     .insertOne(newRecord);
 

--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -5,6 +5,7 @@ const Components = require('./Components');
 const { db } = require('./db');
 const Search_ActionsWorkflows = require('./Search_ActionsWorkflows');
 const Workflows = require('./Workflows');
+const utils = require('./utils');
 
 
 /// Retrieve collated information about a single assembled APA (and associated components and actions) that will be displayed in its executive summary
@@ -295,11 +296,6 @@ async function collateInfo(componentUUID) {
     wireAlloyInternational: 'Wire Alloy International',
   }
 
-  const dictionary_locations = {
-    daresbury: 'Daresbury',
-    chicago: 'Chicago',
-  };
-
   const dictionary_systems = {
     dwa1: 'DWA #1',
     dwa2: 'DWA #2',
@@ -463,7 +459,7 @@ async function collateInfo(componentUUID) {
       .toArray();
 
     if (results.length > 0) {
-      collatedInfo[dictionaries[i]].tensions_location = dictionary_locations[results[0].location];
+      collatedInfo[dictionaries[i]].tensions_location = utils.dictionary_locations[results[0].location];
       collatedInfo[dictionaries[i]].tensions_system = dictionary_systems[results[0].system];
       collatedInfo[dictionaries[i]].tensions_A = results[0].tensions_A;
       collatedInfo[dictionaries[i]].tensions_B = results[0].tensions_B;

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -47,14 +47,12 @@ async function save(input, req) {
   newRecord.recordType = 'workflow';
   newRecord.workflowId = new ObjectID(input.workflowId);
   newRecord.typeFormId = input.typeFormId;
-  newRecord.typeFormName = input.typeFormName || typeForm.formName;
+  newRecord.typeFormName = typeForm.formName;
   newRecord.data = input.data;
   newRecord.path = input.path;
 
   // Generate and add an 'insertion' field to the new record
   newRecord.insertion = commonSchema.insertion(req);
-
-  let _lock = await dbLock(`saveWorkflow_${newRecord.workflowId}`, 1000);
 
   // Attempt to retrieve an existing record with the same workflow ID as the specified one (relevant if we are editing an existing record)
   let oldRecord = null;
@@ -66,6 +64,8 @@ async function save(input, req) {
   newRecord.validity.ancestor_id = input._id;
 
   // Insert the new record into the 'workflows' records collection, and throw and error if the insertion fails
+  let _lock = await dbLock(`saveWorkflow_${newRecord.workflowId}`, 1000);
+
   const result = await db.collection('workflows')
     .insertOne(newRecord);
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -4,4 +4,29 @@ module.exports = {
 
   // A 20 to 22 character long shortened UUID
   short_uuid_regex: ':shortuuid([0-9a-bA-Z-]{20,22})',
+
+  // A dictionary of locations that are used across all component and action type forms
+  // Using this centralised dictionary allows locations to be consistently displayed, regardless of on which page of the interface
+  dictionary_locations: {
+    bnl: 'BNL',
+    cambridge: 'Cambridge',
+    cern: 'CERN',
+    chicago: 'Chicago',
+    daresbury: 'Daresbury Factory',
+    fermilab: 'Fermilab',
+    harvard: 'Harvard',
+    in_transit: 'In Transit',
+    installed_on_APA: 'Used / Installed on APA',
+    lancaster: 'Lancaster',
+    manchester: 'Manchester',
+    merlin: 'Merlin',
+    sheffield: 'Sheffield',
+    surf: 'SURF',
+    sussex: 'Sussex',
+    ukWarehouse: 'UK Warehouse',
+    uw: 'Wisconsin',
+    uwPsl: 'UW / PSL',
+    williamAndMary: 'William and Mary',
+    wisconsin: 'Wisconsin',
+  },
 }

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -57,7 +57,7 @@ block content
 
         dt Action Data:
         dd This is version #{action.validity.version} of the action, and it was last performed on !{' '}
-          +dateFormat(action.insertion.insertDate)
+          +dateTimeFormat(action.insertion.insertDate)
 
           if action.insertion.user
             |  by !{' '}
@@ -326,7 +326,7 @@ block content
             li 
               a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
               |  on 
-              +dateFormat(v.insertion.insertDate)
+              +dateTimeFormat(v.insertion.insertDate)
 
               if v.insertion.user
                 |  by !{' '}

--- a/app/pug/action_list.pug
+++ b/app/pug/action_list.pug
@@ -40,7 +40,7 @@ block content
                 td
                   a(href = `/component/${uuid}`) #{action.componentName}
                 td
-                  +dateFormat(action.lastEditDate)
+                  +dateTimeFormat(action.lastEditDate)
                 td
                   a.btn-sm.btn-secondary(href = `/json/action/${action.actionId}`, target = '_blank')
                     img.small-icon(src = '/images/checklist_icon.svg')

--- a/app/pug/common.pug
+++ b/app/pug/common.pug
@@ -11,10 +11,15 @@ block pugscripts
   //- Return the ordinal of a given number when provided with the remainders of that number divided by 10 and 100
   - function get_ordinal(r10, r100) { if (r10 === 1 && r100 !== 100) return 'st'; if (r10 === 2 && r100 !== 12) return 'nd'; if (r10 === 3 && r100 !== 13) return 'rd'; return 'th'; }
 
-mixin dateFormat(date)
+mixin dateTimeFormat(date)
   - const fullDate = new Date(date);
   - const ordinal = get_ordinal(fullDate.getDate() % 10, fullDate.getDate() % 100);
   span.date(data - date = date) #{`${fullDate.toLocaleString('default', { month: 'long' })} ${fullDate.getDate()}${ordinal} ${fullDate.getFullYear()}, ${fullDate.toLocaleTimeString()}`}
+
+mixin dateFormat(date)
+  - const fullDate = new Date(date);
+  - const ordinal = get_ordinal(fullDate.getDate() % 10, fullDate.getDate() % 100);
+  span.date(data - date = date) #{`${fullDate.toLocaleString('default', { month: 'long' })} ${fullDate.getDate()}${ordinal} ${fullDate.getFullYear()}`}
 
 mixin arrayFormat(array)
   span #{JSON.stringify(array).replace(/["\[\]]/g, '').replace(/,/g, ', ')}

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -13,7 +13,8 @@ block extrascripts
     const actions = !{JSON.stringify(actions, null, 4)};
     const actionTypeForms = !{JSON.stringify(actionTypeForms, null, 4)};
     const base_url = '!{base_url}';
-    const queryDictionary = !{JSON.stringify(queryDictionary, null, 4)};
+    const dictionary_queries = !{JSON.stringify(dictionary_queries, null, 4)};
+    const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
 
   block workscripts
     script(src = '/pages/component.js')
@@ -45,12 +46,23 @@ block content
                 .hori-space-x1
                   a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
 
-            dt Component Name
-
             if component.data.name
+              dt Component Name            
               dd #{component.data.name}
-            else
-              dd (none)
+
+            if component.reception && component.reception.location !== ''
+              dt Current Location
+
+              if component.reception.detail && component.reception.detail != ''
+                dd
+                  a(href = `/component/${component.reception.detail}`, target = '_blank') #{dictionary_locations[component.reception.location]}
+                  |  (as of 
+                  +dateFormat(component.reception.date)
+                  | )
+              else 
+                dd #{dictionary_locations[component.reception.location]} (as of 
+                  +dateFormat(component.reception.date)
+                  | )
 
             if component.formId == 'GroundingMeshPanel'
               dt Factory ID
@@ -68,7 +80,7 @@ block content
 
             dt Component Data:
             dd This is version #{component.validity.version} of the component, and it was last edited on !{' '}
-              +dateFormat(component.insertion.insertDate)
+              +dateTimeFormat(component.insertion.insertDate)
 
               if component.insertion.user
                 |  by !{' '}
@@ -77,10 +89,10 @@ block content
             if component.formId === 'BoardShipment'
               .vert-space-x1.border-success.border.rounded.p-2
                 dt Origin Location 
-                dd #{component.data.originOfShipment.toUpperCase()}
+                dd #{dictionary_locations[component.data.originOfShipment]}
 
                 dt Destination Location
-                dd #{component.data.destinationOfShipment.toUpperCase()}
+                dd #{dictionary_locations[component.data.destinationOfShipment]}
 
                 dt Boards in Shipment
                 dd
@@ -106,10 +118,10 @@ block content
             else if component.formId === 'GroundingMeshShipment'
               .vert-space-x1.border-success.border.rounded.p-2
                 dt Origin Location
-                dd #{component.data.originOfShipment.toUpperCase()}
+                dd #{dictionary_locations[component.data.originOfShipment]}
 
                 dt Destination Location
-                dd #{component.data.destinationOfShipment.toUpperCase()}
+                dd #{dictionary_locations[component.data.destinationOfShipment]}
 
                 dt Meshes in Shipment
                 dd
@@ -135,10 +147,10 @@ block content
             else if component.formId === 'PopulatedBoardShipment'
               .vert-space-x1.border-success.border.rounded.p-2
                 dt Origin Location
-                dd #{component.data.originOfShipment.toUpperCase()}
+                dd #{dictionary_locations[component.data.originOfShipment]}
 
                 dt Destination Location
-                dd #{component.data.destinationOfShipment.toUpperCase()}
+                dd #{dictionary_locations[component.data.destinationOfShipment]}
 
                 dt Components in Kit
                 dd
@@ -222,7 +234,7 @@ block content
                   li 
                     a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
                     |  on 
-                    +dateFormat(v.insertion.insertDate)
+                    +dateTimeFormat(v.insertion.insertDate)
 
                     if v.insertion.user
                       |  by !{' '}
@@ -238,7 +250,7 @@ block content
         | &nbsp; Edit Component
 
       - let jsonURLString = `/json/component/${component.componentUuid}`;
-      - if ('version' in queryDictionary) jsonURLString += `?version=${queryDictionary.version}`;
+      - if ('version' in dictionary_queries) jsonURLString += `?version=${dictionary_queries.version}`;
 
       .hori-space-x2
         a.btn.btn-secondary(href = `${jsonURLString}`, target = '_blank')
@@ -290,7 +302,7 @@ block content
                       a(href = `/action/${action.actionId}`) #{action.actionId}
 
                     td
-                      +dateFormat(action.lastEditDate)
+                      +dateTimeFormat(action.lastEditDate)
 
         .col-sm-6
           h4 Select an Action Type to Perform

--- a/app/pug/component_execSummary.pug
+++ b/app/pug/component_execSummary.pug
@@ -53,7 +53,7 @@ block allbody
 
           .vert-space-x1.hori-space-x1
             p &nbsp; This summary generated on: 
-              +dateFormat(new Date())
+              +dateTimeFormat(new Date())
 
         .col-sm-4
           #qr-code

--- a/app/pug/component_list.pug
+++ b/app/pug/component_list.pug
@@ -52,7 +52,7 @@ block content
                   td
 
                 td
-                  +dateFormat(component.lastEditDate)
+                  +dateTimeFormat(component.lastEditDate)
                 td
                   a.btn-sm.btn-secondary(href = `/json/component/${uuid}`, target = '_blank')
                     img.small-icon(src = '/images/checklist_icon.svg')

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -53,7 +53,7 @@ block allbody
 
           .vert-space-x1.hori-space-x1
             p &nbsp; Printed: 
-              +dateFormat(new Date())
+              +dateTimeFormat(new Date())
 
         .col-sm-5
           #qr-code
@@ -63,7 +63,7 @@ block allbody
         dl
           dt Current Version:
           dd This is version #{component.validity.version} of the component, and it was last edited on !{' '}
-            +dateFormat(component.insertion.insertDate)
+            +dateTimeFormat(component.insertion.insertDate)
 
             if component.insertion.user
               |  by !{' '} #{component.insertion.user.displayName}
@@ -105,7 +105,7 @@ block allbody
 
               dt Performance Data:
               dd This is version #{action.validity.version} of the action, performed on !{' '}
-                +dateFormat(action.insertion.insertDate)
+                +dateTimeFormat(action.insertion.insertDate)
 
                 if action.insertion.user
                   |  by !{' '} #{action.insertion.user.displayName}
@@ -134,7 +134,7 @@ block allbody
 
               dt Performance Data:
               dd This is version #{action.validity.version} of the action, performed on !{' '}
-                +dateFormat(action.insertion.insertDate)
+                +dateTimeFormat(action.insertion.insertDate)
 
                 if action.insertion.user
                   |  by !{' '} #{action.insertion.user.displayName}
@@ -163,7 +163,7 @@ block allbody
 
               dt Performance Data:
               dd This is version #{action.validity.version} of the action, performed on !{' '}
-                +dateFormat(action.insertion.insertDate)
+                +dateTimeFormat(action.insertion.insertDate)
 
                 if action.insertion.user
                   |  by !{' '} #{action.insertion.user.displayName}

--- a/app/pug/search_apaByLocation.pug
+++ b/app/pug/search_apaByLocation.pug
@@ -24,9 +24,11 @@ block content
 
           select.form-control#locationSelection
             option(value = '')          
-            option(value = 'daresbury') Daresbury 
-            option(value = 'chicago') Chicago
-            option(value = 'wisconsin') Wisconsin 
+            option(value = 'daresbury') Daresbury Factory 
+            option(value = 'cern') CERN
+            option(value = 'fermilab') Fermilab
+            option(value = 'in_transit') In Transit 
+            option(value = 'surf') SURF 
 
           .vert-space-x2
             h4 Enter Production Number

--- a/app/pug/search_boardKitComponentsByLocation.pug
+++ b/app/pug/search_boardKitComponentsByLocation.pug
@@ -25,6 +25,7 @@ block content
           select.form-control#locationSelection
             option(value = '')
             option(value = 'cern') CERN 
+            option(value = 'in_transit') In Transit 
             option(value = 'surf') SURF 
 
         .col-md-1

--- a/app/pug/search_boardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_boardShipmentsByReceptionDetails.pug
@@ -40,6 +40,7 @@ block content
           select.form-control#originLocationSelection
             option(value = '') (any)
             option(value = 'cambridge') Cambridge 
+            option(value = 'chicago') Chicago
             option(value = 'daresbury') Daresbury 
             option(value = 'lancaster') Lancaster 
             option(value = 'manchester') Manchester 
@@ -47,8 +48,7 @@ block content
             option(value = 'sheffield') Sheffield 
             option(value = 'sussex') Sussex 
             option(value = 'williamAndMary') William and Mary 
-            option(value = 'uwPsl') UW / PSL 
-            option(value = 'chicago') Chicago
+            option(value = 'wisconsin') Wisconsin 
 
         .col-md-3
           h4 Select Destination Location
@@ -61,6 +61,7 @@ block content
           select.form-control#destinationLocationSelection
             option(value = '') (any)
             option(value = 'cambridge') Cambridge 
+            option(value = 'chicago') Chicago
             option(value = 'daresbury') Daresbury 
             option(value = 'lancaster') Lancaster 
             option(value = 'manchester') Manchester 
@@ -68,8 +69,7 @@ block content
             option(value = 'sheffield') Sheffield 
             option(value = 'sussex') Sussex 
             option(value = 'williamAndMary') William and Mary 
-            option(value = 'uwPsl') UW / PSL 
-            option(value = 'chicago') Chicago
+            option(value = 'wisconsin') Wisconsin 
 
         .col-md-3 
 

--- a/app/pug/search_componentsByUUIDOrTypeAndNumber.pug
+++ b/app/pug/search_componentsByUUIDOrTypeAndNumber.pug
@@ -39,13 +39,13 @@ block content
 
             select.form-control#componentTypeSelection
               option(value = '')          
+              option(value = 'CEAdapterBoard') CE Adapter Board
+              option(value = 'CRBoard') CR Board
+              option(value = 'CableHarness') Cable Harness
+              option(value = 'GBiasBoard') G-Bias Board
               option(value = 'GeometryBoard') Geometry Board
               option(value = 'GroundingMeshPanel') Grounding Mesh Panel
-              option(value = 'CRBoard') CR Board
-              option(value = 'GBiasBoard') G-Bias Board
-              option(value = 'CEAdapterBoard') CE Adapter Board
               option(value = 'SHVBoard') SHV Board
-              option(value = 'CableHarness') Cable Harness
 
             .vert-space-x1
             p Enter a type record number below and press the 'Enter' key.

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -25,16 +25,17 @@ block content
           select.form-control#locationSelection
             option(value = '')
             option(value = 'cambridge') Cambridge 
+            option(value = 'chicago') Chicago
             option(value = 'daresbury') Daresbury 
+            option(value = 'in_transit') In Transit 
+            option(value = 'installed_on_APA') Installed on APA
             option(value = 'lancaster') Lancaster 
             option(value = 'manchester') Manchester 
             option(value = 'merlin') Merlin 
             option(value = 'sheffield') Sheffield 
             option(value = 'sussex') Sussex 
             option(value = 'williamAndMary') William and Mary 
-            option(value = 'uwPsl') UW / PSL 
-            option(value = 'chicago') Chicago
-            option(value = 'installed_on_APA') Installed on APA
+            option(value = 'wisconsin') Wisconsin 
 
           .vert-space-x2
             hr

--- a/app/pug/search_meshesByLocationOrPartNumber.pug
+++ b/app/pug/search_meshesByLocationOrPartNumber.pug
@@ -24,10 +24,10 @@ block content
 
           select.form-control#locationSelection
             option(value = '')
-            option(value = 'lockers') Lockers 
-            option(value = 'sheffield') Sheffield 
-            option(value = 'daresbury') Daresbury 
             option(value = 'chicago') Chicago 
+            option(value = 'in_transit') In Transit 
+            option(value = 'installed_on_APA') Installed on APA 
+            option(value = 'ukWarehouse') UK Warehouse  
 
           .vert-space-x2
             hr

--- a/app/pug/search_tensionMeasurementsByUUID.pug
+++ b/app/pug/search_tensionMeasurementsByUUID.pug
@@ -4,6 +4,9 @@ block vars
   - const page_title = 'Search for Wire Tension Measurements by UUID';
 
 block extrascripts
+  script(type = 'text/javascript').
+    const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
+
   block workscripts
     script(src = '/pages/search_tensionMeasurementsByUUID.js')
 

--- a/app/pug/user.pug
+++ b/app/pug/user.pug
@@ -29,11 +29,11 @@ block content
 
             dt Created On:
             dd
-              +dateFormat(userProfile.created_at)
+              +dateTimeFormat(userProfile.created_at)
 
             dt Last Login:
             dd
-              +dateFormat(userProfile.last_login)
+              +dateTimeFormat(userProfile.last_login)
 
             dt Last IP Address
             dd

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -42,7 +42,7 @@ block content
 
         dt Workflow Data:
         dd This is version #{workflow.validity.version} of the workflow, and it was last edited on !{' '}
-          +dateFormat(workflow.insertion.insertDate)
+          +dateTimeFormat(workflow.insertion.insertDate)
 
           if workflow.insertion.user
             |  by !{' '}
@@ -207,7 +207,7 @@ block content
             li 
               a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
               |  on 
-              +dateFormat(v.insertion.insertDate)
+              +dateTimeFormat(v.insertion.insertDate)
 
               if v.insertion.user
                 |  by !{' '}

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -1,5 +1,7 @@
 const router = require('express').Router();
 
+const utils = require('../lib/utils');
+
 
 /// View descriptions of the available search pages
 router.get('/search', async function (req, res, next) {
@@ -74,7 +76,7 @@ router.get('/search/nonConformanceByComponentTypeOrUUID', async function (req, r
 /// Search for tension measurement actions performed on a single component, specified by its UUID
 router.get('/search/tensionMeasurementsByUUID', async function (req, res, next) {
   // Render the interface page
-  res.render('search_tensionMeasurementsByUUID.pug');
+  res.render('search_tensionMeasurementsByUUID.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 

--- a/app/static/pages/action_specComponent.js
+++ b/app/static/pages/action_specComponent.js
@@ -41,7 +41,6 @@ async function onPageLoad() {
     // At this point, the 'submission' object contains ONLY the information that has been entered into the type form (i.e. the 'data' field)
     // Add all other required information, inheriting from the variables that were passed through the route to this page
     submission.typeFormId = actionTypeForm.formId;
-    submission.typeFormName = actionTypeForm.formName;
     submission.componentUuid = componentUuid;
 
     // If the action originates from a workflow (and therefore a non-empty workflow ID has been provided), save the workflow ID into the 'submission' object
@@ -77,44 +76,36 @@ function SubmitData(submission) {
     typeForm.emit('submitDone');
 
     // Redirect the user to the appropriate post-submission page (where 'result' is the action record's action ID)
-    // If the action is a 'XXX Reception' type (performed on a shipment or batch), we must first update the individual component information (and further redirection will be handled from there)
-    // Similarly, if the action is one of the board installation types, we must also first update the board information (in a different way)
+    // If the action is one of the 'XXX Reception' types, we must first update the individual components' information (and further redirection will be handled from there)
+    // Similarly, if the action is one of the board or mesh installation types, we must first update the board or mesh information (in a different way)
     // If neither of these is the case, then we can simply proceed with standard post-submission redirection:
     //   - if the action originates from a workflow, go to the page for updating the workflow path step results
-    //   - if this is a standalone action, go to the page for viewing the action record 
+    //   - if this is a standalone action, go to the page for viewing the action record
+    const reception_typeFormIDs = ['APAShipmentReception', 'BoardReception', 'GroundingMeshShipmentReception', 'PopulatedBoardKitReception'];
     const installation_typeFormIDs = [
-      'g_foot_board_install', 'g_head_board_install_sideA', 'g_head_board_install_sideB',
+      'g_foot_board_install', 'g_head_board_install_sideA', 'g_head_board_install_sideB', 'x_foot_board_install', 'x_head_board_install_sideA', 'x_head_board_install_sideB',
       'u_foot_boards_install', 'u_head_board_install_sideA', 'u_head_board_installation_sideB', 'u_side_board_install_HSB', 'u_side_board_install_LSB',
       'v_foot_board_install', 'v_head_board_install_sideA', 'v_head_board_install_sideB', 'v_side_board_install_HSB', 'v_side_board_install_LSB',
-      'x_foot_board_install', 'x_head_board_install_sideA', 'x_head_board_install_sideB',
+      'prep_mesh_panel_install',
     ];
 
-    if ((submission.typeFormId === 'BoardReception') || (submission.typeFormId === 'GroundingMeshShipmentReception') || (submission.typeFormId === 'PopulatedBoardKitReception')) {
-      const collectionUUID = submission.componentUuid;
-      const receptionLocation = submission.data.receptionLocation;
-      const receptionDate = (submission.data.receptionDate).toString().slice(0, 10);
+    let url = '';
 
-      let url = `/component/${collectionUUID}/updateLocations/${receptionLocation}/${receptionDate}?actionId=${result}`;
-
-      window.location.href = url;
+    if (reception_typeFormIDs.includes(submission.typeFormId)) {
+      url = `/component/${submission.componentUuid}/updateLocations/${submission.data.receptionLocation}/${(submission.data.receptionDate).toString().slice(0, 10)}?actionId=${result}`;
     } else if (installation_typeFormIDs.includes(submission.typeFormId)) {
-      const receptionLocation = 'installed_on_APA';
-
-      const currentDT = new Date();
-      const receptionDate = `${currentDT.getFullYear()}-${currentDT.getMonth() + 1}-${currentDT.getDate()}`;
-
-      let url = `/action/${result}/updateLocations/${receptionLocation}/${receptionDate}`;
+      url = `/action/${result}/updateLocations/${'installed_on_APA'}/${(new Date()).toISOString().slice(0, 10)}`;
 
       if (!(workflowId === '')) url += `?workflowId=${workflowId}&stepIndex=${stepIndex}`;
-
-      window.location.href = url;
     } else {
       if (!(workflowId === '')) {
-        window.location.href = `/workflow/${workflowId}/${stepIndex}/action/${result}`;
+        url = `/workflow/${workflowId}/${stepIndex}/action/${result}`;
       } else {
-        window.location.href = `/action/${result}`;
+        url = `/action/${result}`;
       }
     }
+
+    window.location.href = url;
   }
 
 

--- a/app/static/pages/search_tensionMeasurementsByUUID.js
+++ b/app/static/pages/search_tensionMeasurementsByUUID.js
@@ -75,7 +75,7 @@ function postSuccess(result) {
           <tr>
             <td><a href = '/action/${action.actionId}' target = '_blank'</a>${action.actionId}</td>
             <td>${action.apaLayer.toUpperCase()}</td>
-            <td>${(action.location) ? (action.location[0].toUpperCase() + action.location.slice(1)) : '[unknown]'}</td>
+            <td>${(action.location) ? (dictionary_locations[action.location]) : '[unknown]'}</td>
             <td>${action.comments}</td>
           </tr>`;
 

--- a/app/static/pages/workflow_edit.js
+++ b/app/static/pages/workflow_edit.js
@@ -41,7 +41,6 @@ async function onPageLoad() {
     // At this point, the 'submission' object contains ONLY the information that has been entered into the type form (i.e. the 'data' field)
     // Add all other required information, inheriting from the variables that were passed through the route to this page
     submission.typeFormId = workflowTypeForm.formId;
-    submission.typeFormName = workflowTypeForm.formName;
 
     // If this is a completely new workflow, copy the 'path' object from the workflow type form into the 'submission' object
     // For an existing workflow that is being edited, we don't want to do this, since it would overwrite any existing path results


### PR DESCRIPTION
- all components are now assigned a default location at creation (specific location depends on component type)
- location information for certain component types can be changed through submitting certain actions or creating certain other component types
- moved component name and location assignment to centralised block in server side library function (was previously done in various places on the client side)
- made server/client side codes for actions and workflows consistent with newly re-organised component codes (only small changes needed)
- new centralised dictionary of location key/value pairs, which is passed through to the interface pages as required (for consistent displayed locations across the entire DB)
- added new pug mixin for displaying only the date (not the time as well), and renamed the existing mixin to explicitly show that it displays the date AND time
- a component's current location is now displayed on its information page, along with the date at which it moved there
- if a component is installed on an APA (geometry boards and grounding mesh panels), the specific APA will be recorded in the component's location information
- update location search interface pages with additional potential locations that have been recently added to various action type forms