### PR TITLE
Updates to Searches by Location ...

### DIFF
--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -23,7 +23,7 @@ head
   link(rel = 'stylesheet', href = '/css/component_summary.css')
   link(rel = 'stylesheet', href = '/css/fonts.css')
           //- Copied from https://fonts.googleapis.com/css2?family=Inconsolata&family=Palanquin&display=swap
-  
+
   //- The 'formio.full.min.css' stylesheet has to be loaded from an external source, because it itself references another font package by URL ...
   //- ... and a local version of this stylesheet is not able to reference that URL (gives a 404 error)
   link(rel = 'preload', href = 'https://cdn.jsdelivr.net/npm/formiojs@4.13.3/dist/formio.full.min.css', as = 'style', 
@@ -144,8 +144,8 @@ body(class = `deployment-${NODE_ENV}`)
                     |      Populated Board Kit Components by Location
 
                 li.nav-item
-                  +navlink(href = '/search/apaByLocation')
-                    |      Assembled APA by Location
+                  +navlink(href = '/search/apaByProductionDetails')
+                    |      Assembled APA by Production Details
 
                 li.nav-item
                   +navlink(href = '/search/actionsByIDOrReferencedUUID')

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -123,14 +123,14 @@ block content
 
     .vert-space-x2
       h4
-        a(href = '/search/apaByLocation') Assembled APA by Location
+        a(href = '/search/apaByProductionDetails') Assembled APA by Production Details
 
       p This page may be used to search specifically for <b>assembled APAs</b> that match <b>both</b> of the following user-specified record details:
         ul
-          li <b>location</b>: the location at which the APA is being assembled
-          li <b>production number</b>: the production number of the APA at the specified location, i.e. the order in which the APAs have been assembled
+          li <b>production location</b>: the location at which the APA is being assembled
+          li <b>production number</b>: the order in which the APA has been assembled at the specified location
 
-      p Users may select one of the locations from the list, and manually enter an (integer) production number.  Please note that <b>both pieces of information must be provided</b> for the search to be performed.
+      p Users may select one of the production locations from the list, and manually enter an (integer) production number.  Please note that <b>both pieces of information must be provided</b> for the search to be performed.
 
       p If an existing assembled APA record that matches both pieces of information is successfully found in the database, the user will be automatically redirected to the page for viewing the APA component record.
         br

--- a/app/pug/search_apaByProductionDetails.pug
+++ b/app/pug/search_apaByProductionDetails.pug
@@ -1,34 +1,35 @@
 extend default
 
 block vars
-  - const page_title = 'Search for Assembled APA by Location';
+  - const page_title = 'Search for Assembled APA by Production Details';
 
 block extrascripts
+  script(type = 'text/javascript').
+    const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
+
   block workscripts 
-    script(src = '/pages/search_apaByLocation.js')
+    script(src = '/pages/search_apaByProductionDetails.js')
 
 block content
   .container-fluid
     .vert-space-x2
-      h2 Search for Assembled APA by Location
+      h2 Search for Assembled APA by Production Details
 
     .vert-space-x2
       hr
 
       .row
         .col-md-4
-          h4 Select Location
+          h4 Select Production Location
 
           .vert-space-x1
             p Select a location from the options below.
 
           select.form-control#locationSelection
             option(value = '')          
-            option(value = 'daresbury') Daresbury Factory 
-            option(value = 'cern') CERN
-            option(value = 'fermilab') Fermilab
-            option(value = 'in_transit') In Transit 
-            option(value = 'surf') SURF 
+            option(value = 'chicago') #{dictionary_locations['chicago']} 
+            option(value = 'daresbury') #{dictionary_locations['daresbury']} 
+            option(value = 'fermilab') #{dictionary_locations['fermilab']} 
 
           .vert-space-x2
             h4 Enter Production Number
@@ -36,7 +37,7 @@ block content
             .vert-space-x1
               p Enter the production number of the APA at the specified location below and <b>press the 'Enter' key</b>.
 
-            input.form-control#productionNumberSelection
+            input.form-control#numberSelection
 
         .col-md-1
 

--- a/app/pug/search_boardKitComponentsByLocation.pug
+++ b/app/pug/search_boardKitComponentsByLocation.pug
@@ -4,6 +4,9 @@ block vars
   - const page_title = 'Search for Populated Board Kit Components by Location';
 
 block extrascripts
+  script(type = 'text/javascript').
+    const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
+
   block workscripts 
     script(src = '/pages/search_boardKitComponentsByLocation.js')
 
@@ -24,9 +27,10 @@ block content
 
           select.form-control#locationSelection
             option(value = '')
-            option(value = 'cern') CERN 
-            option(value = 'in_transit') In Transit 
-            option(value = 'surf') SURF 
+            option(value = 'cern') #{dictionary_locations['cern']} 
+            option(value = 'in_transit') #{dictionary_locations['in_transit']} 
+            option(value = 'surf') #{dictionary_locations['surf']} 
+            option(value = 'wisconsin') #{dictionary_locations['wisconsin']} 
 
         .col-md-1
 

--- a/app/pug/search_boardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_boardShipmentsByReceptionDetails.pug
@@ -4,6 +4,9 @@ block vars
   - const page_title = 'Search for Geometry Board Shipments by Reception Details';
 
 block extrascripts
+  script(type = 'text/javascript').
+    const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
+
   block workscripts 
     script(src = '/pages/search_boardShipmentsByReceptionDetails.js')
 
@@ -39,16 +42,14 @@ block content
 
           select.form-control#originLocationSelection
             option(value = '') (any)
-            option(value = 'cambridge') Cambridge 
-            option(value = 'chicago') Chicago
-            option(value = 'daresbury') Daresbury 
-            option(value = 'lancaster') Lancaster 
-            option(value = 'manchester') Manchester 
-            option(value = 'merlin') Merlin 
-            option(value = 'sheffield') Sheffield 
-            option(value = 'sussex') Sussex 
-            option(value = 'williamAndMary') William and Mary 
-            option(value = 'wisconsin') Wisconsin 
+            option(value = 'cambridge') #{dictionary_locations['cambridge']} 
+            option(value = 'daresbury') #{dictionary_locations['daresbury']} 
+            option(value = 'lancaster') #{dictionary_locations['lancaster']} 
+            option(value = 'manchester') #{dictionary_locations['manchester']} 
+            option(value = 'merlin') #{dictionary_locations['merlin']} 
+            option(value = 'sheffield') #{dictionary_locations['sheffield']} 
+            option(value = 'sussex') #{dictionary_locations['sussex']} 
+            option(value = 'williamAndMary') #{dictionary_locations['williamAndMary']} 
 
         .col-md-3
           h4 Select Destination Location
@@ -60,16 +61,16 @@ block content
 
           select.form-control#destinationLocationSelection
             option(value = '') (any)
-            option(value = 'cambridge') Cambridge 
-            option(value = 'chicago') Chicago
-            option(value = 'daresbury') Daresbury 
-            option(value = 'lancaster') Lancaster 
-            option(value = 'manchester') Manchester 
-            option(value = 'merlin') Merlin 
-            option(value = 'sheffield') Sheffield 
-            option(value = 'sussex') Sussex 
-            option(value = 'williamAndMary') William and Mary 
-            option(value = 'wisconsin') Wisconsin 
+            option(value = 'cambridge') #{dictionary_locations['cambridge']} 
+            option(value = 'chicago') #{dictionary_locations['chicago']} 
+            option(value = 'daresbury') #{dictionary_locations['daresbury']} 
+            option(value = 'lancaster') #{dictionary_locations['lancaster']} 
+            option(value = 'manchester') #{dictionary_locations['manchester']} 
+            option(value = 'merlin') #{dictionary_locations['merlin']} 
+            option(value = 'sheffield') #{dictionary_locations['sheffield']} 
+            option(value = 'sussex') #{dictionary_locations['sussex']} 
+            option(value = 'williamAndMary') #{dictionary_locations['williamAndMary']} 
+            option(value = 'wisconsin') #{dictionary_locations['wisconsin']} 
 
         .col-md-3 
 

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -4,6 +4,9 @@ block vars
   - const page_title = 'Search for Geometry Boards by Location or Part Number';
 
 block extrascripts
+  script(type = 'text/javascript').
+    const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
+
   block workscripts 
     script(src = '/pages/search_geoBoardsByLocationOrPartNumber.js')
 
@@ -24,18 +27,18 @@ block content
 
           select.form-control#locationSelection
             option(value = '')
-            option(value = 'cambridge') Cambridge 
-            option(value = 'chicago') Chicago
-            option(value = 'daresbury') Daresbury 
-            option(value = 'in_transit') In Transit 
-            option(value = 'installed_on_APA') Installed on APA
-            option(value = 'lancaster') Lancaster 
-            option(value = 'manchester') Manchester 
-            option(value = 'merlin') Merlin 
-            option(value = 'sheffield') Sheffield 
-            option(value = 'sussex') Sussex 
-            option(value = 'williamAndMary') William and Mary 
-            option(value = 'wisconsin') Wisconsin 
+            option(value = 'cambridge') #{dictionary_locations['cambridge']} 
+            option(value = 'chicago') #{dictionary_locations['chicago']} 
+            option(value = 'daresbury') #{dictionary_locations['daresbury']} 
+            option(value = 'in_transit') #{dictionary_locations['in_transit']} 
+            option(value = 'installed_on_APA') #{dictionary_locations['installed_on_APA']} 
+            option(value = 'lancaster') #{dictionary_locations['lancaster']} 
+            option(value = 'manchester') #{dictionary_locations['manchester']} 
+            option(value = 'merlin') #{dictionary_locations['merlin']} 
+            option(value = 'sheffield') #{dictionary_locations['sheffield']} 
+            option(value = 'sussex') #{dictionary_locations['sussex']} 
+            option(value = 'williamAndMary') #{dictionary_locations['williamAndMary']} 
+            option(value = 'wisconsin') #{dictionary_locations['wisconsin']} 
 
           .vert-space-x2
             hr

--- a/app/pug/search_meshesByLocationOrPartNumber.pug
+++ b/app/pug/search_meshesByLocationOrPartNumber.pug
@@ -4,6 +4,9 @@ block vars
   - const page_title = 'Search for Grounding Mesh Panels by Location or Part Number';
 
 block extrascripts
+  script(type = 'text/javascript').
+    const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
+
   block workscripts 
     script(src = '/pages/search_meshesByLocationOrPartNumber.js')
 
@@ -24,10 +27,10 @@ block content
 
           select.form-control#locationSelection
             option(value = '')
-            option(value = 'chicago') Chicago 
-            option(value = 'in_transit') In Transit 
-            option(value = 'installed_on_APA') Installed on APA 
-            option(value = 'ukWarehouse') UK Warehouse  
+            option(value = 'chicago') #{dictionary_locations['chicago']} 
+            option(value = 'in_transit') #{dictionary_locations['in_transit']} 
+            option(value = 'installed_on_APA') #{dictionary_locations['installed_on_APA']} 
+            option(value = 'ukWarehouse') #{dictionary_locations['ukWarehouse']} 
 
           .vert-space-x2
             hr

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -161,11 +161,11 @@ router.get('/search/workflowsByUUID/' + utils.uuid_regex, async function (req, r
 });
 
 
-/// Search for an assembled APA using its location and production number
-router.get('/search/apaByLocation/:apaLocation/:apaProductionNumber', async function (req, res, next) {
+/// Search for an assembled APA using its production location and number
+router.get('/search/apaByProductionDetails/:apaLocation/:apaNumber', async function (req, res, next) {
   try {
     // Retrieve a list of assembled APAs that match the specified record details
-    const assembledAPAs = await Search_OtherComponents.apasByLocation(req.params.apaLocation, req.params.apaProductionNumber);
+    const assembledAPAs = await Search_OtherComponents.apasByProductionDetails(req.params.apaLocation, req.params.apaNumber);
 
     // Return the list in JSON format
     return res.json(assembledAPAs);

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -20,7 +20,7 @@ router.get('/search/componentsByUUIDOrTypeAndNumber', async function (req, res, 
 /// Search for geometry boards that have been received at a specific location, or are of a specified part number
 router.get('/search/geoBoardsByLocationOrPartNumber', async function (req, res, next) {
   // Render the interface page
-  res.render('search_geoBoardsByLocationOrPartNumber.pug');
+  res.render('search_geoBoardsByLocationOrPartNumber.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 
@@ -34,28 +34,28 @@ router.get('/search/geoBoardsByVisInspectOrOrderNumber', async function (req, re
 /// Search for geometry board shipments using various shipment reception details
 router.get('/search/boardShipmentsByReceptionDetails', async function (req, res, next) {
   // Render the interface page
-  res.render('search_boardShipmentsByReceptionDetails.pug');
+  res.render('search_boardShipmentsByReceptionDetails.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 
 /// Search for grounding mesh panels that have been received at a specific location, or are of a specified part number
 router.get('/search/meshesByLocationOrPartNumber', async function (req, res, next) {
   // Render the interface page
-  res.render('search_meshesByLocationOrPartNumber.pug');
+  res.render('search_meshesByLocationOrPartNumber.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 
 /// Search for populated board kit components that have been received at a specific location
 router.get('/search/boardKitComponentsByLocation', async function (req, res, next) {
   // Render the interface page
-  res.render('search_boardKitComponentsByLocation.pug');
+  res.render('search_boardKitComponentsByLocation.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 
-/// Search for an assembled APA using its location and production number
-router.get('/search/apaByLocation', async function (req, res, next) {
+/// Search for an assembled APA using its production location and number
+router.get('/search/apaByProductionDetails', async function (req, res, next) {
   // Render the interface page
-  res.render('search_apaByLocation.pug');
+  res.render('search_apaByProductionDetails.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 

--- a/app/static/pages/search_apaByProductionDetails.js
+++ b/app/static/pages/search_apaByProductionDetails.js
@@ -1,25 +1,25 @@
-// Declare variables to hold the (initially empty) user-specified assembled APA location and production number
+// Declare variables to hold the (initially empty) user-specified assembled APA production location and number
 let apaLocation = null;
-let apaProductionNumber = null;
+let apaNumber = null;
 
 
 // Main function
 $(function () {
-  // When the selected APA location is changed, get the newly selected location from the corresponding page element
+  // When the selected APA production location is changed, get the newly selected location from the corresponding page element
   // If both user-specified search criteria are valid, then perform the search
   $('#locationSelection').on('change', async function () {
     apaLocation = $('#locationSelection').val();
 
-    if (apaLocation && apaProductionNumber) performSearch();
+    if (apaLocation && apaNumber) performSearch();
   });
 
-  // When the entered APA production number is changed and the 'Enter' key is pressed, get the newly entered production number from the corresponding page element
+  // When the entered APA production number is changed and the 'Enter' key is pressed, get the newly entered number from the corresponding page element
   // If both user-specified search criteria are valid, then perform the search
-  document.getElementById('productionNumberSelection').addEventListener('keyup', function (e) {
+  document.getElementById('numberSelection').addEventListener('keyup', function (e) {
     if (e.key === 'Enter') {
-      apaProductionNumber = $('#productionNumberSelection').val();
+      apaNumber = $('#numberSelection').val();
 
-      if (apaLocation && apaProductionNumber) performSearch();
+      if (apaLocation && apaNumber) performSearch();
     }
   });
 });
@@ -30,7 +30,7 @@ function performSearch() {
   $.ajax({
     contentType: 'application/json',
     method: 'GET',
-    url: `/json/search/apaByLocation/${apaLocation}/${apaProductionNumber}`,
+    url: `/json/search/apaByProductionDetails/${apaLocation}/${apaNumber}`,
     dataType: 'json',
     success: postSuccess,
   }).fail(postFail);

--- a/app/static/pages/search_boardKitComponentsByLocation.js
+++ b/app/static/pages/search_boardKitComponentsByLocation.js
@@ -1,5 +1,5 @@
 // Declare variables to hold the (initially empty) user-specified board location
-let receptionLocation = null;
+let location = null;
 
 
 // Main function
@@ -7,13 +7,13 @@ $(function () {
   // When the selected location is changed, get the newly selected location from the corresponding page element
   // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#locationSelection').on('change', async function () {
-    receptionLocation = $('#locationSelection').val();
+    location = $('#locationSelection').val();
 
-    if (receptionLocation) {
+    if (location) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/boardKitComponentsByLocation/${receptionLocation}`,
+        url: `/json/search/boardKitComponentsByLocation/${location}`,
         dataType: 'json',
         success: postSuccess,
       }).fail(postFail);
@@ -38,7 +38,7 @@ function postSuccess(result) {
 
   const resultsStart = `
     <tr>
-      <td colspan = "3">The following populated board kit components have been received at <b>${$('#locationSelection option:selected').text()}</b>.</td>
+      <td colspan = "3">The following populated board kit components are at <b>${$('#locationSelection option:selected').text()}</b>.</td>
     </tr>
     <tr>
       <td colspan = "3">They are grouped by component type, and then ordered by last DB record edit (most recent at the top).
@@ -73,7 +73,7 @@ function postSuccess(result) {
         <tr>
           <th scope = 'col' width = '40%'>Component UUID</th>
           <th scope = 'col' width = '40%'>DUNE PID</th>
-          <th scope = 'col' width = '20%'>Received On:</th>
+          <th scope = 'col' width = '20%'>Arrived On:</th>
         </tr>`;
 
       $('#results').append(tableStart);

--- a/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
+++ b/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
@@ -1,5 +1,5 @@
 // Declare variables to hold the (initially empty) user-specified board location and/or part number
-let receptionLocation = null;
+let location = null;
 let partNumber = null;
 
 
@@ -8,13 +8,13 @@ $(function () {
   // When the selected location is changed, get the newly selected location from the corresponding page element
   // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#locationSelection').on('change', async function () {
-    receptionLocation = $('#locationSelection').val();
+    location = $('#locationSelection').val();
 
-    if (receptionLocation) {
+    if (location) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/geoBoardsByLocation/${receptionLocation}`,
+        url: `/json/search/geoBoardsByLocation/${location}`,
         dataType: 'json',
         success: postSuccess_location,
       }).fail(postFail);
@@ -46,7 +46,7 @@ function postSuccess_location(result) {
 
   const resultsStart = `
     <tr>
-      <td colspan = "3">The following geometry boards have been received at <b>${$('#locationSelection option:selected').text()}</b>.</td>
+      <td colspan = "3">The following geometry boards are at <b>${$('#locationSelection option:selected').text()}</b>.</td>
     </tr>
     <tr>
       <td colspan = "3">They are grouped by board part number, and then ordered by last DB record edit (most recent at the top).
@@ -81,7 +81,7 @@ function postSuccess_location(result) {
         <tr>
           <th scope = 'col' width = '50%'>Board UUID</th>
           <th scope = 'col' width = '15%'>UKID</th>
-          <th scope = 'col' width = '20%'>Received On:</th>
+          <th scope = 'col' width = '20%'>Arrived On:</th>
           <th scope = 'col' width = '15%'>On APA:</th>
         </tr>`;
 
@@ -105,24 +105,6 @@ function postSuccess_location(result) {
 };
 
 
-// Function to correctly format a board location string
-function formatBoardLocation(rawLocationString) {
-  let location = '';
-
-  if (!rawLocationString) location = '[unknown]';
-  else {
-    location = rawLocationString;
-
-    if (location === 'williamAndMary') location = 'William and Mary';
-    else if (location === 'uwPsl') location = 'UW / PSL';
-    else if (location === 'installed_on_APA') location = 'Installed on APA';
-    else location = location[0].toUpperCase() + location.slice(1);
-  }
-
-  return location;
-};
-
-
 // Function to run for a successful search query by part number
 function postSuccess_partNumber(result) {
   // Make sure that the page element where the results will be displayed is empty, and then enter an initial message to display
@@ -133,7 +115,7 @@ function postSuccess_partNumber(result) {
       <td colspan = "3">The following geometry boards with part number <b>${$('#partNumberSelection option:selected').text()}</b> have been received.</td>
     </tr>
     <tr>
-      <td colspan = "3">They are grouped by reception location, and then ordered by last DB record edit (most recent at the top).
+      <td colspan = "3">They are grouped by location, and then ordered by last DB record edit (most recent at the top).
         <br>
         <hr>
       </td>
@@ -143,12 +125,12 @@ function postSuccess_partNumber(result) {
 
   // If there are no search results, display a message to indicate this, but otherwise set up a table of the search results
   if (Object.keys(result).length === 0) {
-    $('#results').append('<b>No geometry boards of the given part number have been received at any location</b>');
+    $('#results').append('<b>No geometry boards of the given part number are at any location</b>');
   } else {
     for (const boardGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${boardGroup.componentUuids.length} boards received at ${formatBoardLocation(boardGroup.receptionLocation)}</td>
+          <td colspan = "3">Found ${boardGroup.componentUuids.length} boards at ${dictionary_locations[boardGroup.receptionLocation]}</td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -157,7 +139,7 @@ function postSuccess_partNumber(result) {
     $('#results').append('<br>');
 
     for (const boardGroup of result) {
-      const groupTitle = `<b>Location: ${formatBoardLocation(boardGroup.receptionLocation)}</b>`;
+      const groupTitle = `<b>Location: ${dictionary_locations[boardGroup.receptionLocation]}</b>`;
 
       $('#results').append(groupTitle);
 
@@ -165,7 +147,7 @@ function postSuccess_partNumber(result) {
         <tr>
           <th scope = 'col' style = 'width: 50%'>Board UUID</th>
           <th scope = 'col' style = 'width: 15%'>UKID</th>
-          <th scope = 'col' style = 'width: 20%'>Received On:</th>
+          <th scope = 'col' style = 'width: 20%'>Arrived On:</th>
           <th scope = 'col' style = 'width: 15%'>On APA:</th>
         </tr>`;
 

--- a/app/static/pages/search_meshesByLocationOrPartNumber.js
+++ b/app/static/pages/search_meshesByLocationOrPartNumber.js
@@ -1,5 +1,5 @@
 // Declare variables to hold the (initially empty) user-specified mesh location and/or part number
-let receptionLocation = null;
+let location = null;
 let partNumber = null;
 
 
@@ -8,13 +8,13 @@ $(function () {
   // When the selected location is changed, get the newly selected location from the corresponding page element
   // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#locationSelection').on('change', async function () {
-    receptionLocation = $('#locationSelection').val();
+    location = $('#locationSelection').val();
 
-    if (receptionLocation) {
+    if (location) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/meshesByLocation/${receptionLocation}`,
+        url: `/json/search/meshesByLocation/${location}`,
         dataType: 'json',
         success: postSuccess_location,
       }).fail(postFail);
@@ -57,7 +57,7 @@ function postSuccess_location(result) {
 
   const resultsStart = `
     <tr>
-      <td colspan = "3">The following grounding mesh panels have been received at <b>${$('#locationSelection option:selected').text()}</b>.</td>
+      <td colspan = "3">The following grounding mesh panels are at <b>${$('#locationSelection option:selected').text()}</b>.</td>
     </tr>
     <tr>
       <td colspan = "3">They are grouped by part number, and then ordered by last DB record edit (most recent at the top).
@@ -90,9 +90,10 @@ function postSuccess_location(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '40%'>Mesh UUID</th>
-          <th scope = 'col' width = '40%'>DUNE PID</th>
-          <th scope = 'col' width = '20%'>Received On:</th>
+          <th scope = 'col' width = '35%'>Mesh UUID</th>
+          <th scope = 'col' width = '30%'>DUNE PID</th>
+          <th scope = 'col' width = '20%'>Arrived On:</th>
+          <th scope = 'col' width = '15%'>On APA:</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -103,6 +104,7 @@ function postSuccess_location(result) {
             <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.componentUuids[i]}</td>
             <td>${meshGroup.dunePids[i]}</td>
             <td>${meshGroup.receptionDates[i]}</td>
+            <td>${meshGroup.installedOnAPA[i]}</td>
           </tr>`;
 
         $('#results').append(boardText);
@@ -111,19 +113,6 @@ function postSuccess_location(result) {
       $('#results').append('<br>');
     }
   }
-};
-
-
-// Function to correctly format a mesh's location string
-function formatMeshLocation(rawLocationString) {
-  let location = '';
-
-  if (!rawLocationString) location = '[unknown]';
-  else {
-    location = rawLocationString[0].toUpperCase() + rawLocationString.slice(1);
-  }
-
-  return location;
 };
 
 
@@ -137,7 +126,7 @@ function postSuccess_partNumber(result) {
       <td colspan = "3">The following grounding mesh panels with part number <b>${$('#partNumberSelection option:selected').text()}</b> have been received.</td>
     </tr>
     <tr>
-      <td colspan = "3">They are grouped by reception location, and then ordered by last DB record edit (most recent at the top).
+      <td colspan = "3">They are grouped by location, and then ordered by last DB record edit (most recent at the top).
         <br>
         <hr>
       </td>
@@ -147,12 +136,12 @@ function postSuccess_partNumber(result) {
 
   // If there are no search results, display a message to indicate this, but otherwise set up a table of the search results
   if (Object.keys(result).length === 0) {
-    $('#results').append('<b>No grounding mesh panels of the given part number have been received at any location</b>');
+    $('#results').append('<b>No grounding mesh panels of the given part number are at any location</b>');
   } else {
     for (const meshGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${meshGroup.componentUuids.length} meshes received at ${formatMeshLocation(meshGroup.receptionLocation)}</td>
+          <td colspan = "3">Found ${meshGroup.componentUuids.length} meshes at ${dictionary_locations[meshGroup.receptionLocation]}</td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -161,15 +150,16 @@ function postSuccess_partNumber(result) {
     $('#results').append('<br>');
 
     for (const meshGroup of result) {
-      const groupTitle = `<b>Location: ${formatMeshLocation(meshGroup.receptionLocation)}</b>`;
+      const groupTitle = `<b>Location: ${dictionary_locations[meshGroup.receptionLocation]}</b>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' style = 'width: 40%'>Mesh UUID</th>
-          <th scope = 'col' style = 'width: 40%'>DUNE PID:</th>
-          <th scope = 'col' style = 'width: 20%'>Received On:</th>
+          <th scope = 'col' style = 'width: 35%'>Mesh UUID</th>
+          <th scope = 'col' style = 'width: 30%'>DUNE PID:</th>
+          <th scope = 'col' style = 'width: 20%'>Arrived On:</th>
+          <th scope = 'col' style = 'width: 15%'>On APA:</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -180,6 +170,7 @@ function postSuccess_partNumber(result) {
             <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.componentUuids[i]}</td>
             <td>${meshGroup.dunePids[i]}</td>
             <td>${meshGroup.receptionDates[i]}</td>
+            <td>${boardGroup.installedOnAPA[i]}</td>
           </tr>`;
 
         $('#results').append(boardText);


### PR DESCRIPTION
- all searches now use the centralised list of possible locations for consistent displayed names
- changed the previous 'Search for Assembled APA by Location' to make it more explicit that this is related to the APA's PRODUCTION location (and number), not necessarily its current location (though they may of course be the same)
- reduced mentions of 'reception location' in variable names and comments - since the component location is now generalised, and may not necessarily represent where a component was last received anymore
- added information about which APAs grounding mesh panels are installed on to 'Search for Grounding Mesh Panels by Location' search results
- reworked how information about which APAs geometry boards are installed on is generated ... no longer need to retrieve Board Installation actions, since the APA UUID is now stored in the board record itself

Note that the library function changes will need to be tested on Staging once that instance's records have been updated with new component information.