### PR TITLE
Additional changes to location searches ...

### DIFF
--- a/app/static/pages/search_boardKitComponentsByLocation.js
+++ b/app/static/pages/search_boardKitComponentsByLocation.js
@@ -1,5 +1,5 @@
-// Declare variables to hold the (initially empty) user-specified board location
-let location = null;
+// Declare variables to hold the (initially empty) user-specified board kit location
+let boardKitLocation = null;
 
 
 // Main function
@@ -7,13 +7,13 @@ $(function () {
   // When the selected location is changed, get the newly selected location from the corresponding page element
   // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#locationSelection').on('change', async function () {
-    location = $('#locationSelection').val();
+    boardKitLocation = $('#locationSelection').val();
 
-    if (location) {
+    if (boardKitLocation) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/boardKitComponentsByLocation/${location}`,
+        url: `/json/search/boardKitComponentsByLocation/${boardKitLocation}`,
         dataType: 'json',
         success: postSuccess,
       }).fail(postFail);

--- a/app/static/pages/search_boardShipmentsByReceptionDetails.js
+++ b/app/static/pages/search_boardShipmentsByReceptionDetails.js
@@ -109,18 +109,6 @@ async function renderSearchForms() {
 }
 
 
-// Function to correctly format a location string
-function formatLocation(rawLocationString) {
-  let location = '';
-
-  if (rawLocationString === 'williamAndMary') location = 'William and Mary';
-  else if (rawLocationString === 'uwPsl') location = 'UW / PSL';
-  else location = rawLocationString[0].toUpperCase() + rawLocationString.slice(1);
-
-  return location;
-};
-
-
 // Function to run for a successful search query
 function postSuccess(result) {
   // Make sure that the page element where the results will be displayed is empty, and then enter an initial message to display
@@ -170,8 +158,8 @@ function postSuccess(result) {
         <tr>
           <td><a href = '/component/${shipment.uuid}' target = '_blank'</a>${shipment.uuid}</td>
           <td>${shipment.numberOfBoards}</td>
-          <td>${formatLocation(shipment.origin)}</td>
-          <td>${formatLocation(shipment.destination)}</td>
+          <td>${dictionary_locations[shipment.origin]}</td>
+          <td>${dictionary_locations[shipment.destination]}</td>
           ${actionIdLinkLine}
           <td>${shipment.receptionComment}</td>
           <td>${shipment.searchComment}</td>

--- a/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
+++ b/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
@@ -1,6 +1,6 @@
 // Declare variables to hold the (initially empty) user-specified board location and/or part number
-let location = null;
-let partNumber = null;
+let boardLocation = null;
+let boardPartNumber = null;
 
 
 // Main function
@@ -8,13 +8,13 @@ $(function () {
   // When the selected location is changed, get the newly selected location from the corresponding page element
   // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#locationSelection').on('change', async function () {
-    location = $('#locationSelection').val();
+    boardLocation = $('#locationSelection').val();
 
-    if (location) {
+    if (boardLocation) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/geoBoardsByLocation/${location}`,
+        url: `/json/search/geoBoardsByLocation/${boardLocation}`,
         dataType: 'json',
         success: postSuccess_location,
       }).fail(postFail);
@@ -24,13 +24,13 @@ $(function () {
   // When the selected board part number is changed, get the newly selected part number from the corresponding page element
   // If the part number is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#partNumberSelection').on('change', async function () {
-    partNumber = $('#partNumberSelection').val();
+    boardPartNumber = $('#partNumberSelection').val();
 
-    if (partNumber) {
+    if (boardPartNumber) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/geoBoardsByPartNumber/${partNumber}`,
+        url: `/json/search/geoBoardsByPartNumber/${boardPartNumber}`,
         dataType: 'json',
         success: postSuccess_partNumber,
       }).fail(postFail);

--- a/app/static/pages/search_meshesByLocationOrPartNumber.js
+++ b/app/static/pages/search_meshesByLocationOrPartNumber.js
@@ -1,6 +1,6 @@
-// Declare variables to hold the (initially empty) user-specified mesh location and/or part number
-let location = null;
-let partNumber = null;
+// Declare variables to hold the (initially empty) user-specified mesh panel location and/or part number
+let meshPanelLocation = null;
+let meshPanelPartNumber = null;
 
 
 // Main function
@@ -8,13 +8,13 @@ $(function () {
   // When the selected location is changed, get the newly selected location from the corresponding page element
   // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#locationSelection').on('change', async function () {
-    location = $('#locationSelection').val();
+    meshPanelLocation = $('#locationSelection').val();
 
-    if (location) {
+    if (meshPanelLocation) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/meshesByLocation/${location}`,
+        url: `/json/search/meshesByLocation/${meshPanelLocation}`,
         dataType: 'json',
         success: postSuccess_location,
       }).fail(postFail);
@@ -24,13 +24,13 @@ $(function () {
   // When the selected mesh part number is changed, get the newly selected part number from the corresponding page element
   // If the part number is valid, perform the appropriate jQuery 'ajax' call to make the search
   $('#partNumberSelection').on('change', async function () {
-    partNumber = $('#partNumberSelection').val();
+    meshPanelPartNumber = $('#partNumberSelection').val();
 
-    if (partNumber) {
+    if (meshPanelPartNumber) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/meshesByPartNumber/${partNumber}`,
+        url: `/json/search/meshesByPartNumber/${meshPanelPartNumber}`,
         dataType: 'json',
         success: postSuccess_partNumber,
       }).fail(postFail);


### PR DESCRIPTION
- changed 'Search for Board Shipment by Reception Details' to correctly use the central list of locations ... was already being passed to the interface page, just not being used
- renamed some variables to avoid conflict with the global, immutable 'location' variable