### PR TITLE
Interface Improvements and Search Bug Fixes

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -289,8 +289,12 @@ async function list(match_condition, options) {
     },
   });
 
-  // Re-sort the records by last edit date ... most recent first
-  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  // Re-sort the records ... by (alphabetical) component name for APA frames and assembled APAs, or by last edit date (most recent first) for other component types
+  if ((match_condition) && (match_condition.formId) && ((match_condition.formId === 'APAFrame') || (match_condition.formId === 'AssembledAPA'))) {
+    aggregation_stages.push({ $sort: { name: 1 } });
+  } else {
+    aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  }
 
   // Add aggregation stages for any additionally specified options
   if (options) {

--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -79,6 +79,12 @@ async function nonConformanceByComponentType(componentType, disposition, status)
     .aggregate(aggregation_stages)
     .toArray();
 
+  // Add the component name to each matching record ... this needs to be retrieved from the component's own record, since it is not stored in the action record
+  for (let result of results) {
+    const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
+    result.componentName = component.data.name;
+  }
+
   // Return the list of actions
   return results;
 }
@@ -117,6 +123,12 @@ async function nonConformanceByUUID(componentUUID) {
   let results = await db.collection('actions')
     .aggregate(aggregation_stages)
     .toArray();
+
+  // Add the component name to each matching record ... this needs to be retrieved from the component's own record, since it is not stored in the action record
+  for (let result of results) {
+    const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
+    result.componentName = component.data.name;
+  }
 
   // Return the list of actions
   return results;

--- a/app/lib/Search_GeoBoards.js
+++ b/app/lib/Search_GeoBoards.js
@@ -77,10 +77,10 @@ async function boardsByLocation(location) {
           const name_splits = apa.data.name.split('-');
           cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
         } else {
-          cleanedBoardGroup.installedOnAPA.push('[No UUID!]');
+          cleanedBoardGroup.installedOnAPA.push('[No APA UUID found!]');
         }
       } else {
-        cleanedBoardGroup.installedOnAPA.push('[Not on APA]');
+        cleanedBoardGroup.installedOnAPA.push('[Not installed on APA]');
       }
     }
 
@@ -160,10 +160,10 @@ async function boardsByPartNumber(partNumber) {
           const name_splits = apa.data.name.split('-');
           cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
         } else {
-          cleanedBoardGroup.installedOnAPA.push('[No UUID!]');
+          cleanedBoardGroup.installedOnAPA.push('[No APA UUID found!]');
         }
       } else {
-        cleanedBoardGroup.installedOnAPA.push('[Not on APA]');
+        cleanedBoardGroup.installedOnAPA.push('[Not installed on APA]');
       }
     }
 

--- a/app/lib/Search_GeoBoards.js
+++ b/app/lib/Search_GeoBoards.js
@@ -29,7 +29,6 @@ async function boardsByLocation(location) {
       componentUuid: { '$first': '$componentUuid' },
       ukid: { '$first': '$data.typeRecordNumber' },
       receptionDate: { '$first': '$reception.date' },
-      receptionDetail: { '$first': '$reception.detail' },
     },
   });
 
@@ -44,7 +43,6 @@ async function boardsByLocation(location) {
       componentUuid: { $push: '$componentUuid' },
       ukid: { $push: '$ukid' },
       receptionDate: { $push: '$receptionDate' },
-      receptionDetail: { '$first': '$receptionDetail' },
     }
   });
 
@@ -61,27 +59,30 @@ async function boardsByLocation(location) {
 
     cleanedBoardGroup.partNumber = boardGroup._id.partNumber;
     cleanedBoardGroup.partString = boardGroup._id.partString;
+    cleanedBoardGroup.ukids = boardGroup.ukid;
+    cleanedBoardGroup.receptionDates = boardGroup.receptionDate;
 
     cleanedBoardGroup.componentUuids = [];
+    cleanedBoardGroup.installedOnAPA = [];
 
     for (const boardUuid of boardGroup.componentUuid) {
       cleanedBoardGroup.componentUuids.push(MUUID.from(boardUuid).toString());
-    }
 
-    cleanedBoardGroup.installedOnAPA = [];
+      const board = await Components.retrieve(MUUID.from(boardUuid).toString());
 
-    for (const receptionDetail of boardGroup.receptionDetail) {
       if (location === 'installed_on_APA') {
-        const component = await Components.retrieve(receptionDetail);
-        const name_splits = component.data.name.split('-');
-        cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        if (board.reception.detail) {
+          const apa = await Components.retrieve(board.reception.detail);
+
+          const name_splits = apa.data.name.split('-');
+          cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        } else {
+          cleanedBoardGroup.installedOnAPA.push('[No UUID!]');
+        }
       } else {
-        cleanedBoardGroup.installedOnAPA.push('[n.a.]');
+        cleanedBoardGroup.installedOnAPA.push('[Not on APA]');
       }
     }
-
-    cleanedBoardGroup.ukids = boardGroup.ukid;
-    cleanedBoardGroup.receptionDates = boardGroup.receptionDate;
 
     cleanedResults.push(cleanedBoardGroup);
   }
@@ -115,7 +116,6 @@ async function boardsByPartNumber(partNumber) {
       ukid: { '$first': '$data.typeRecordNumber' },
       receptionDate: { '$first': '$reception.date' },
       receptionLocation: { '$first': '$reception.location' },
-      receptionDetail: { '$first': '$reception.detail' },
     },
   });
 
@@ -127,7 +127,6 @@ async function boardsByPartNumber(partNumber) {
       componentUuid: { $push: '$componentUuid' },
       ukid: { $push: '$ukid' },
       receptionDate: { $push: '$receptionDate' },
-      receptionDetail: { '$first': '$receptionDetail' },
     }
   });
 
@@ -143,26 +142,30 @@ async function boardsByPartNumber(partNumber) {
     let cleanedBoardGroup = {};
 
     cleanedBoardGroup.receptionLocation = boardGroup._id.receptionLocation;
+    cleanedBoardGroup.ukids = boardGroup.ukid;
+    cleanedBoardGroup.receptionDates = boardGroup.receptionDate;
 
     cleanedBoardGroup.componentUuids = [];
     cleanedBoardGroup.installedOnAPA = [];
 
     for (const boardUuid of boardGroup.componentUuid) {
       cleanedBoardGroup.componentUuids.push(MUUID.from(boardUuid).toString());
-    }
 
-    for (const receptionDetail of boardGroup.receptionDetail) {
+      const board = await Components.retrieve(MUUID.from(boardUuid).toString());
+
       if (boardGroup._id.receptionLocation === 'installed_on_APA') {
-        const component = await Components.retrieve(receptionDetail);
-        const name_splits = component.data.name.split('-');
-        cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        if (board.reception.detail) {
+          const apa = await Components.retrieve(board.reception.detail);
+
+          const name_splits = apa.data.name.split('-');
+          cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        } else {
+          cleanedBoardGroup.installedOnAPA.push('[No UUID!]');
+        }
       } else {
-        cleanedBoardGroup.installedOnAPA.push('[n.a.]');
+        cleanedBoardGroup.installedOnAPA.push('[Not on APA]');
       }
     }
-
-    cleanedBoardGroup.ukids = boardGroup.ukid;
-    cleanedBoardGroup.receptionDates = boardGroup.receptionDate;
 
     cleanedResults.push(cleanedBoardGroup);
   }

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -166,7 +166,6 @@ async function meshesByLocation(location) {
       componentUuid: { '$first': '$componentUuid' },
       dunePid: { '$first': '$data.name' },
       receptionDate: { '$first': '$reception.date' },
-      receptionDetail: { '$first': '$reception.detail' },
     },
   });
 
@@ -178,7 +177,6 @@ async function meshesByLocation(location) {
       componentUuid: { $push: '$componentUuid' },
       dunePid: { $push: '$dunePid' },
       receptionDate: { $push: '$receptionDate' },
-      receptionDetail: { '$first': '$receptionDetail' },
     }
   });
 
@@ -194,27 +192,30 @@ async function meshesByLocation(location) {
     let cleanedMeshGroup = {};
 
     cleanedMeshGroup.partNumber = meshGroup._id.partNumber;
+    cleanedMeshGroup.dunePids = meshGroup.dunePid;
+    cleanedMeshGroup.receptionDates = meshGroup.receptionDate;
 
     cleanedMeshGroup.componentUuids = [];
+    cleanedMeshGroup.installedOnAPA = [];
 
     for (const meshUuid of meshGroup.componentUuid) {
       cleanedMeshGroup.componentUuids.push(MUUID.from(meshUuid).toString());
-    }
 
-    cleanedMeshGroup.installedOnAPA = [];
+      const mesh = await Components.retrieve(MUUID.from(meshUuid).toString());
 
-    for (const receptionDetail of meshGroup.receptionDetail) {
       if (location === 'installed_on_APA') {
-        const component = await Components.retrieve(receptionDetail);
-        const name_splits = component.data.name.split('-');
-        cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        if (mesh.reception.detail) {
+          const apa = await Components.retrieve(mesh.reception.detail);
+
+          const name_splits = apa.data.name.split('-');
+          cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        } else {
+          cleanedMeshGroup.installedOnAPA.push('[No UUID!]');
+        }
       } else {
-        cleanedMeshGroup.installedOnAPA.push('[n.a.]');
+        cleanedMeshGroup.installedOnAPA.push('[Not on APA]');
       }
     }
-
-    cleanedMeshGroup.dunePids = meshGroup.dunePid;
-    cleanedMeshGroup.receptionDates = meshGroup.receptionDate;
 
     cleanedResults.push(cleanedMeshGroup);
   }
@@ -248,7 +249,6 @@ async function meshesByPartNumber(partNumber) {
       dunePid: { '$first': '$data.name' },
       receptionDate: { '$first': '$reception.date' },
       receptionLocation: { '$first': '$reception.location' },
-      receptionDetail: { '$first': '$reception.detail' },
     },
   });
 
@@ -260,7 +260,6 @@ async function meshesByPartNumber(partNumber) {
       componentUuid: { $push: '$componentUuid' },
       dunePid: { $push: '$dunePid' },
       receptionDate: { $push: '$receptionDate' },
-      receptionDetail: { '$first': '$receptionDetail' },
     }
   });
 
@@ -276,27 +275,30 @@ async function meshesByPartNumber(partNumber) {
     let cleanedMeshGroup = {};
 
     cleanedMeshGroup.receptionLocation = meshGroup._id.receptionLocation;
+    cleanedMeshGroup.dunePids = meshGroup.dunePid;
+    cleanedMeshGroup.receptionDates = meshGroup.receptionDate;
 
     cleanedMeshGroup.componentUuids = [];
+    cleanedMeshGroup.installedOnAPA = [];
 
     for (const meshUuid of meshGroup.componentUuid) {
       cleanedMeshGroup.componentUuids.push(MUUID.from(meshUuid).toString());
-    }
 
-    cleanedMeshGroup.installedOnAPA = [];
+      const mesh = await Components.retrieve(MUUID.from(meshUuid).toString());
 
-    for (const receptionDetail of meshGroup.receptionDetail) {
       if (meshGroup._id.receptionLocation === 'installed_on_APA') {
-        const component = await Components.retrieve(receptionDetail);
-        const name_splits = component.data.name.split('-');
-        cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        if (mesh.reception.detail) {
+          const apa = await Components.retrieve(mesh.reception.detail);
+
+          const name_splits = apa.data.name.split('-');
+          cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+        } else {
+          cleanedMeshGroup.installedOnAPA.push('[No UUID!]');
+        }
       } else {
-        cleanedMeshGroup.installedOnAPA.push('[n.a.]');
+        cleanedMeshGroup.installedOnAPA.push('[Not on APA]');
       }
     }
-
-    cleanedMeshGroup.dunePids = meshGroup.dunePid;
-    cleanedMeshGroup.receptionDates = meshGroup.receptionDate;
 
     cleanedResults.push(cleanedMeshGroup);
   }

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -210,10 +210,10 @@ async function meshesByLocation(location) {
           const name_splits = apa.data.name.split('-');
           cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
         } else {
-          cleanedMeshGroup.installedOnAPA.push('[No UUID!]');
+          cleanedMeshGroup.installedOnAPA.push('[No APA UUID found!]');
         }
       } else {
-        cleanedMeshGroup.installedOnAPA.push('[Not on APA]');
+        cleanedMeshGroup.installedOnAPA.push('[Not installed on APA]');
       }
     }
 
@@ -293,10 +293,10 @@ async function meshesByPartNumber(partNumber) {
           const name_splits = apa.data.name.split('-');
           cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
         } else {
-          cleanedMeshGroup.installedOnAPA.push('[No UUID!]');
+          cleanedMeshGroup.installedOnAPA.push('[No APA UUID found!]');
         }
       } else {
-        cleanedMeshGroup.installedOnAPA.push('[Not on APA]');
+        cleanedMeshGroup.installedOnAPA.push('[Not installed on APA]');
       }
     }
 

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -190,6 +190,7 @@ async function list(match_condition, options) {
       workflowId: { '$first': '$workflowId' },
       typeFormId: { '$first': '$typeFormId' },
       typeFormName: { '$first': '$typeFormName' },
+      stepTypeForms: { '$first': '$path.formName' },
       stepResultIDs: { '$first': '$path.result' },
       lastEditDate: { '$first': '$validity.startDate' },
     },

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -88,14 +88,18 @@ block content
                       table.table
                         thead
                           tr
-                            th.col-md-2 Index of Wire or Wire Segment
+                            th.col-md-2 Wire / Wire Segment
                             th.col-md-2 Original Tension (N)
                             th.col-md-2 Latest Tension (N)
 
                         tbody
                           each changedTension in action.data.changedTensions_sideA
                             tr
-                              td #{changedTension[0]}
+                              if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
+                                td #{changedTension[0] + 1}
+                              else 
+                                td #{changedTension[0] + 8}
+
                               td #{changedTension[1]}
                               td #{changedTension[2]}
             .col-md-6
@@ -111,14 +115,18 @@ block content
                       table.table
                         thead
                           tr
-                            th.col-md-2 Index of Wire or Wire Segment
+                            th.col-md-2 Wire / Wire Segment
                             th.col-md-2 Original Tension (N)
                             th.col-md-2 Latest Tension (N)
 
                         tbody
                           each changedTension in action.data.changedTensions_sideB
                             tr
-                              td #{changedTension[0]}
+                              if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
+                                td #{changedTension[0] + 1}
+                              else 
+                                td #{changedTension[0] + 8}
+
                               td #{changedTension[1]}
                               td #{changedTension[2]}
 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -99,8 +99,9 @@ block content
                   table.table
                     thead
                       tr
-                        th.col-md-3 UUID
+                        th.col-md-2 UUID
                         th.col-md-1 UK ID
+                        th.col-md-1 Part Number
                         th.col-md-3 QR Code Link 
 
                     tbody
@@ -110,7 +111,8 @@ block content
                             a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
 
                           td #{info[1]}
-                          td #{`${base_url}/c/${info[2]}`}
+                          td #{info[2]}
+                          td #{`${base_url}/c/${info[3]}`}
 
                 a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
                   img.small-icon(src = '/images/checklist_icon.svg')
@@ -129,7 +131,8 @@ block content
                     thead 
                       tr 
                         th.col-md-2 UUID 
-                        th.col-md-2 DUNE PID
+                        th.col-md-1 Factory ID
+                        th.col-md-1 Part Number
                         th.col-md-3 QR Code Link 
 
                     tbody 
@@ -139,7 +142,8 @@ block content
                             a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
 
                           td #{info[1]}
-                          td #{`${base_url}/c/${info[2]}`}
+                          td #{info[2]}
+                          td #{`${base_url}/c/${info[3]}`}
 
                 a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
                   img.small-icon(src = '/images/checklist_icon.svg')
@@ -168,9 +172,9 @@ block content
                           td
                             a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
 
-                          td #{info[3]}
+                          td #{info[2]}
                           td #{info[1]}
-                          td #{`${base_url}/c/${info[2]}`}
+                          td #{`${base_url}/c/${info[3]}`}
 
                 a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
                   img.small-icon(src = '/images/checklist_icon.svg')

--- a/app/pug/search_boardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_boardShipmentsByReceptionDetails.pug
@@ -94,7 +94,7 @@ block content
           .vert-space-x1
             p Select a date by clicking the box below.
               br
-              | The search match reception <b><u>on and before</u></b> this date.
+              | The search will match reception <b><u>on and before</u></b> this date.
 
             #latestdateform
 

--- a/app/pug/workflow_list.pug
+++ b/app/pug/workflow_list.pug
@@ -22,8 +22,9 @@ block content
           tr
             th.col-md-1 Type Name
             th.col-md-1 Workflow ID
-            th.col-md-3 Associated Component
+            th.col-md-1 Associated Component
             th.col-md-1 Status
+            th.col-md-2 Next Action to Complete
             th.col-md-1
 
         tbody
@@ -47,6 +48,7 @@ block content
                 else
                   td.text-danger.font-weight-bold #{workflowStatuses[index]}
 
+                td #{firstIncompleteActions[index]}
                 td
                   a.btn-sm.btn-secondary(href = `/json/workflow/${workflow.workflowId}`, target = '_blank')
                     img.small-icon(src = '/images/checklist_icon.svg')

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -50,7 +50,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         if (uuid !== '') {
           const boardRecord = await Components.retrieve(uuid);
 
-          if (boardRecord) collectionDetails.push([uuid, boardRecord.data.typeRecordNumber, boardRecord.shortUuid]);
+          if (boardRecord) collectionDetails.push([uuid, boardRecord.data.typeRecordNumber, boardRecord.data.partNumber, boardRecord.shortUuid]);
         }
       }
     }
@@ -62,7 +62,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         if (uuid !== '') {
           const meshRecord = await Components.retrieve(uuid);
 
-          if (meshRecord) collectionDetails.push([uuid, meshRecord.data.name, meshRecord.shortUuid]);
+          if (meshRecord) collectionDetails.push([uuid, meshRecord.data.typeRecordNumber, meshRecord.data.meshPanelPartNumber, meshRecord.shortUuid]);
         }
       }
     }
@@ -74,7 +74,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
 
@@ -84,7 +84,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
 
@@ -94,7 +94,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
 
@@ -104,7 +104,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
     }

--- a/app/static/pages/search_boardKitComponentsByLocation.js
+++ b/app/static/pages/search_boardKitComponentsByLocation.js
@@ -38,10 +38,10 @@ function postSuccess(result) {
 
   const resultsStart = `
     <tr>
-      <td colspan = "3">The following populated board kit components are at <b>${$('#locationSelection option:selected').text()}</b>.</td>
+      <td colspan = "2">The following populated board kit components are at <b>${$('#locationSelection option:selected').text()}</b>.</td>
     </tr>
     <tr>
-      <td colspan = "3">They are grouped by component type, and then ordered by last DB record edit (most recent at the top).
+      <td colspan = "2">They are grouped by component type, and then ordered by last DB record edit (most recent at the top).
         <br>
         <hr>
       </td>
@@ -56,7 +56,7 @@ function postSuccess(result) {
     for (const componentGroup of result) {
       const componentCount = `
         <tr>
-          <td colspan = "3">Found ${componentGroup.componentUuids.length} components of type: <b>${componentTypesDictionary[componentGroup.type]}</b></td>
+          <td colspan = "2">Found ${componentGroup.componentUuids.length} components of type: <b>${componentTypesDictionary[componentGroup.type]}</b></td>
         </tr>`;
 
       $('#results').append(componentCount);
@@ -65,15 +65,17 @@ function postSuccess(result) {
     $('#results').append('<br>');
 
     for (const componentGroup of result) {
-      const groupTitle = `<b>Component Type: ${componentTypesDictionary[componentGroup.type]}</b>`;
+      const groupTitle = `
+        <tr>
+          <td colspan "2"><b>Component Type: ${componentTypesDictionary[componentGroup.type]}</b></td>
+        </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '40%'>Component UUID</th>
-          <th scope = 'col' width = '40%'>DUNE PID</th>
-          <th scope = 'col' width = '20%'>Arrived On:</th>
+          <th scope = 'col' width = '50%'>DUNE PID</th>
+          <th scope = 'col' width = '50%'>Date at Location</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -81,8 +83,7 @@ function postSuccess(result) {
       for (const i in componentGroup.componentUuids) {
         const componentText = `
           <tr>
-            <td><a href = '/component/${componentGroup.componentUuids[i]}' target = '_blank'</a>${componentGroup.componentUuids[i]}</td>
-            <td>${componentGroup.dunePids[i]}</td>
+            <td><a href = '/component/${componentGroup.componentUuids[i]}' target = '_blank'</a>${componentGroup.dunePids[i]}</td>
             <td>${componentGroup.receptionDates[i]}</td>
           </tr>`;
 

--- a/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
+++ b/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
@@ -64,7 +64,7 @@ function postSuccess_location(result) {
     for (const boardGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${boardGroup.componentUuids.length} boards with part number ${boardGroup.partNumber} (${boardGroup.partString})</td>
+          <td colspan = "3">Found ${boardGroup.componentUuids.length} boards with part number <b>${boardGroup.partNumber} (${boardGroup.partString})</b></td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -73,16 +73,18 @@ function postSuccess_location(result) {
     $('#results').append('<br>');
 
     for (const boardGroup of result) {
-      const groupTitle = `<b>Part Number: ${boardGroup.partNumber}  (${boardGroup.partString})</b>`;
+      const groupTitle = `
+        <tr>
+          <td colspan = "3"><b>Part Number: ${boardGroup.partNumber}  (${boardGroup.partString})</b></td>
+        </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '50%'>Board UUID</th>
-          <th scope = 'col' width = '15%'>UKID</th>
-          <th scope = 'col' width = '20%'>Arrived On:</th>
-          <th scope = 'col' width = '15%'>On APA:</th>
+          <th scope = 'col' style = 'width: 25%'>Board UKID</th>
+          <th scope = 'col' style = 'width: 25%'>Date at Location</th>
+          <th scope = 'col' style = 'width: 50%'>Installed on APA</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -90,8 +92,7 @@ function postSuccess_location(result) {
       for (const i in boardGroup.componentUuids) {
         const boardText = `
           <tr>
-            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.componentUuids[i]}</td>
-            <td>${boardGroup.ukids[i]}</td>
+            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
             <td>${boardGroup.receptionDates[i]}</td>
             <td>${boardGroup.installedOnAPA[i]}</td>
           </tr>`;
@@ -130,7 +131,7 @@ function postSuccess_partNumber(result) {
     for (const boardGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${boardGroup.componentUuids.length} boards at ${dictionary_locations[boardGroup.receptionLocation]}</td>
+          <td colspan = "3">Found ${boardGroup.componentUuids.length} boards at <b>${dictionary_locations[boardGroup.receptionLocation]}</b></td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -139,16 +140,18 @@ function postSuccess_partNumber(result) {
     $('#results').append('<br>');
 
     for (const boardGroup of result) {
-      const groupTitle = `<b>Location: ${dictionary_locations[boardGroup.receptionLocation]}</b>`;
+      const groupTitle = `
+        <tr>
+          <td colspan = "3"><b>Location: ${dictionary_locations[boardGroup.receptionLocation]}</b></td>
+        </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' style = 'width: 50%'>Board UUID</th>
-          <th scope = 'col' style = 'width: 15%'>UKID</th>
-          <th scope = 'col' style = 'width: 20%'>Arrived On:</th>
-          <th scope = 'col' style = 'width: 15%'>On APA:</th>
+          <th scope = 'col' style = 'width: 25%'>Board UKID</th>
+          <th scope = 'col' style = 'width: 25%'>Date at Location</th>
+          <th scope = 'col' style = 'width: 50%'>Installed on APA</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -156,8 +159,7 @@ function postSuccess_partNumber(result) {
       for (const i in boardGroup.componentUuids) {
         const boardText = `
           <tr>
-            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.componentUuids[i]}</td>
-            <td>${boardGroup.ukids[i]}</td>
+            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
             <td>${boardGroup.receptionDates[i]}</td>
             <td>${boardGroup.installedOnAPA[i]}</td>
           </tr>`;

--- a/app/static/pages/search_geoBoardsByVisInspectOrOrderNumber.js
+++ b/app/static/pages/search_geoBoardsByVisInspectOrOrderNumber.js
@@ -139,7 +139,7 @@ function postSuccess_disposition(result) {
     for (const boardGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${boardGroup.componentUuids.length} boards of part number ${boardGroup.partNumber}  (${boardGroup.partString})</td>
+          <td colspan = "5">Found ${boardGroup.componentUuids.length} boards of part number ${boardGroup.partNumber}  (${boardGroup.partString})</td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -148,18 +148,20 @@ function postSuccess_disposition(result) {
     $('#results').append('<br>');
 
     for (const boardGroup of result) {
-      const groupTitle = `<b>Part Number: ${boardGroup.partNumber}  (${boardGroup.partString})</b>`;
+      const groupTitle = `
+        <tr>
+          <td colspan = "5"><b>Part Number: ${boardGroup.partNumber}  (${boardGroup.partString})</b></td>
+        </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '23%'>Board UUID</th>
-          <th scope = 'col' width = '5%'>UKID</th>
-          <th scope = 'col' width = '10%'>Order Number</th>
-          <th scope = 'col' width = '15%'>Visual Inspection Record</th>
-          <th scope = 'col' width = '25%'>Issue(s) Identified</th>
-          <th scope = 'col' width = '22%'>Repairs Description (if applicable)</th>
+          <th scope = 'col' width = '10%'>Board UKID</th>
+          <th scope = 'col' width = '15%'>Part of Order</th>
+          <th scope = 'col' width = '25%'>Visual Inspection Action</th>
+          <th scope = 'col' width = '25%'>Issue(s) Identified:</th>
+          <th scope = 'col' width = '25%'>Repairs Description (if applicable)</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -169,8 +171,7 @@ function postSuccess_disposition(result) {
 
         const boardText = `
           <tr>
-            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.componentUuids[i]}</td>
-            <td>${boardGroup.ukids[i]}</td>
+            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
             <td><a href = '/component/${boardGroup.batchUuids[i]}' target = '_blank'</a>${boardGroup.orderNumbers[i]}</td>
             <td><a href = '/action/${boardGroup.actionIds[i]}' target = '_blank'</a>${boardGroup.actionIds[i]}</td>
             <td>${inspectionData.issues}</td>
@@ -204,13 +205,13 @@ function postSuccess_orderNumber(result) {
 
   const resultsStart = `
     <tr>
-      <td colspan = "5">The following geometry boards with order number: <b>${$('#orderNumberSelection').val()}</b> and at least one recorded visual inspection have been found.</td>
+      <td colspan = "4">The following geometry boards with order number: <b>${$('#orderNumberSelection').val()}</b> and at least one recorded visual inspection have been found.</td>
     </tr>
     <tr>
-      <td colspan = "5">They are grouped by visual inspection disposition, and then ordered by last DB record edit (most recent at the top).
+      <td colspan = "4">They are grouped by visual inspection disposition, and then ordered by last DB record edit (most recent at the top).
     </tr>
     <tr>
-      <td colspan = "5"><b>Please note that only boards which have had a visual inspection performed on them are displayed here - there may be additional boards with this order number that have not had inspections performed.</b>
+      <td colspan = "4"><b>Please note that only boards which have had a visual inspection performed on them are displayed here - there may be additional boards with this order number that have not had inspections performed.</b>
         <br>
         <hr>
       </td>
@@ -225,7 +226,7 @@ function postSuccess_orderNumber(result) {
     for (const boardGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${boardGroup.actionIds.length} boards with visual inspection disposition: ${dispositionsDictionary[boardGroup.disposition]}</td>
+          <td colspan = "4">Found ${boardGroup.actionIds.length} boards with visual inspection disposition: <b>${dispositionsDictionary[boardGroup.disposition]}</b></td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -234,17 +235,19 @@ function postSuccess_orderNumber(result) {
     $('#results').append('<br>');
 
     for (const boardGroup of result) {
-      const groupTitle = `<b>Disposition: ${dispositionsDictionary[boardGroup.disposition]}</b>`;
+      const groupTitle = `
+        <tr>
+          <td colspan = "4"><b>Disposition: ${dispositionsDictionary[boardGroup.disposition]}</b></td>
+        </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '28%'>Board UUID</th>
-          <th scope = 'col' width = '5%'>UKID</th>
-          <th scope = 'col' width = '20%'>Visual Inspection Record</th>
-          <th scope = 'col' width = '25%'>Issue(s) Identified</th>
-          <th scope = 'col' width = '21%'>Repairs Description (if applicable)</th>
+          <th scope = 'col' width = '25%'>Board UKID</th>
+          <th scope = 'col' width = '25%'>Visual Inspection Action</th>
+          <th scope = 'col' width = '25%'>Issue(s) Ddentified</th>
+          <th scope = 'col' width = '25%'>Repairs Description (if applicable)</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -254,8 +257,7 @@ function postSuccess_orderNumber(result) {
 
         const boardText = `
           <tr>
-            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.componentUuids[i]}</td>
-            <td>${boardGroup.ukids[i]}</td>
+            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
             <td><a href = '/action/${boardGroup.actionIds[i]}' target = '_blank'</a>${boardGroup.actionIds[i]}</td>
             <td>${inspectionData.issues}</td>
             <td>${inspectionData.repairsDescription}</td>

--- a/app/static/pages/search_meshesByLocationOrPartNumber.js
+++ b/app/static/pages/search_meshesByLocationOrPartNumber.js
@@ -75,7 +75,7 @@ function postSuccess_location(result) {
     for (const meshGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${meshGroup.componentUuids.length} meshes with part number ${partNumbersDictionary[meshGroup.partNumber]}</td>
+          <td colspan = "3">Found ${meshGroup.componentUuids.length} meshes with part number <b>${partNumbersDictionary[meshGroup.partNumber]}</b></td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -84,16 +84,18 @@ function postSuccess_location(result) {
     $('#results').append('<br>');
 
     for (const meshGroup of result) {
-      const groupTitle = `<b>Part Number: ${partNumbersDictionary[meshGroup.partNumber]}</b>`;
+      const groupTitle = `
+        <tr>
+          <td colspan = "3"><b>Part Number: ${partNumbersDictionary[meshGroup.partNumber]}</b></td>
+        </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '35%'>Mesh UUID</th>
-          <th scope = 'col' width = '30%'>DUNE PID</th>
-          <th scope = 'col' width = '20%'>Arrived On:</th>
-          <th scope = 'col' width = '15%'>On APA:</th>
+          <th scope = 'col' width = '50%'>Mesh DUNE PID</th>
+          <th scope = 'col' width = '25%'>Date at Location</th>
+          <th scope = 'col' width = '25%'>Installed on APA</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -101,8 +103,7 @@ function postSuccess_location(result) {
       for (const i in meshGroup.componentUuids) {
         const boardText = `
           <tr>
-            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.componentUuids[i]}</td>
-            <td>${meshGroup.dunePids[i]}</td>
+            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.dunePids[i]}</td>
             <td>${meshGroup.receptionDates[i]}</td>
             <td>${meshGroup.installedOnAPA[i]}</td>
           </tr>`;
@@ -141,7 +142,7 @@ function postSuccess_partNumber(result) {
     for (const meshGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "3">Found ${meshGroup.componentUuids.length} meshes at ${dictionary_locations[meshGroup.receptionLocation]}</td>
+          <td colspan = "3">Found ${meshGroup.componentUuids.length} meshes at <b>${dictionary_locations[meshGroup.receptionLocation]}</b></td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -150,16 +151,18 @@ function postSuccess_partNumber(result) {
     $('#results').append('<br>');
 
     for (const meshGroup of result) {
-      const groupTitle = `<b>Location: ${dictionary_locations[meshGroup.receptionLocation]}</b>`;
+      const groupTitle = `
+        <tr>
+          <td colspan = "3"><b>Location: ${dictionary_locations[meshGroup.receptionLocation]}</b></td>
+        </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' style = 'width: 35%'>Mesh UUID</th>
-          <th scope = 'col' style = 'width: 30%'>DUNE PID:</th>
-          <th scope = 'col' style = 'width: 20%'>Arrived On:</th>
-          <th scope = 'col' style = 'width: 15%'>On APA:</th>
+          <th scope = 'col' width = '50%'>Mesh DUNE PID</th>
+          <th scope = 'col' width = '25%'>Date at Location</th>
+          <th scope = 'col' width = '25%'>Installed on APA</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -167,8 +170,7 @@ function postSuccess_partNumber(result) {
       for (const i in meshGroup.componentUuids) {
         const boardText = `
           <tr>
-            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.componentUuids[i]}</td>
-            <td>${meshGroup.dunePids[i]}</td>
+            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.dunePids[i]}</td>
             <td>${meshGroup.receptionDates[i]}</td>
             <td>${meshGroup.installedOnAPA[i]}</td>
           </tr>`;

--- a/app/static/pages/search_meshesByLocationOrPartNumber.js
+++ b/app/static/pages/search_meshesByLocationOrPartNumber.js
@@ -170,7 +170,7 @@ function postSuccess_partNumber(result) {
             <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.componentUuids[i]}</td>
             <td>${meshGroup.dunePids[i]}</td>
             <td>${meshGroup.receptionDates[i]}</td>
-            <td>${boardGroup.installedOnAPA[i]}</td>
+            <td>${meshGroup.installedOnAPA[i]}</td>
           </tr>`;
 
         $('#results').append(boardText);

--- a/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
+++ b/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
@@ -134,11 +134,11 @@ function postSuccess(result) {
   } else {
     const tableStart = `
       <tr>
-        <th scope = 'col' width = '12%'>Component Type</th>
-        <th scope = 'col' width = '20%'>Component UUID</th>
-        <th scope = 'col' width = '18%'>Action Title / ID</th>
+        <th scope = 'col' width = '15%'>Component Type</th>
+        <th scope = 'col' width = '20%'>Component Name</th>
+        <th scope = 'col' width = '25%'>Non-Conformance Title / Action ID</th>
         <th scope = 'col' width = '15%'>Disposition</th>
-        <th scope = 'col' width = '5%'>Status</th>
+        <th scope = 'col' width = '10%'>Status</th>
       </tr>`;
 
     $('#results').append(tableStart);
@@ -147,7 +147,7 @@ function postSuccess(result) {
       const actionText = `
         <tr>
           <td>${componentTypesDictionary[action.componentType]}</td>
-          <td><a href = '/component/${action.componentUuid}' target = '_blank'</a>${action.componentUuid}</td>
+          <td><a href = '/component/${action.componentUuid}' target = '_blank'</a>${action.componentName}</td>
           <td><a href = '/action/${action.actionId}' target = '_blank'</a>${action.title ? action.title : action.actionId}</td>
           <td>${dispositionsDictionary[action.disposition]}</td>
           <td>${statusDictionary[action.status]}</td>

--- a/app/static/pages/search_tensionMeasurementsByUUID.js
+++ b/app/static/pages/search_tensionMeasurementsByUUID.js
@@ -61,10 +61,10 @@ function postSuccess(result) {
   } else {
     const tableStart = `
         <tr>
-          <th scope = 'col' width = '20%'>Action</th>
-          <th scope = 'col' width = '10%'>Wire Layer</th>
-          <th scope = 'col' width = '20%'>Action Performed at:</th>
-          <th scope = 'col' width = '50%'>Comments</th>
+          <th scope = 'col' width = '30%'>Action</th>
+          <th scope = 'col' width = '15%'>Wire Layer</th>
+          <th scope = 'col' width = '30%'>Measurement Location</th>
+          <th scope = 'col' width = '20%'>Comments</th>
 
         </tr>`;
 

--- a/m2m/template_upload_tensions.py
+++ b/m2m/template_upload_tensions.py
@@ -8,10 +8,10 @@ from tensions import ExtractTensions
 # ##################################
 
 # For uploading (re-)tensioning measurements, the following information is required:
-csvFile         = '/user/majumdar/Desktop/horizontalInspections/UK_Frames/F000_X.csv'
+csvFile         = '/user/majumdar/Desktop/Tensions/V_layer_APA14.csv'
                                                             # Full path to the input data file (must be a string ending in '.csv')
-apaLayer        = 'X'                                       # Wire layer (must be given as one of 'X','V', 'U' or 'G')
-action_id       = '6582feba5fedc88fb468a8d3'                # ID of the existing tension measurements action to be edited (get from DB)
+apaLayer        = 'V'                                       # Wire layer (must be given as one of 'X','V', 'U' or 'G')
+action_id       = '66479e9ab80c19b8c800f8ae'                # ID of the existing tension measurements action to be edited (get from DB)
 
 # ##################################
 


### PR DESCRIPTION
Interface Improvements
- [Sotiris] APA Frames and Assembled APAs are now shown in alphanumeric component name order on their single component type listing pages (listing pages for other component types and the general listing page remain in order of most recently edited component) 
- [Brian] all workflow listing pages now additionally show which action is to be completed next ... this may not work entirely well for APA Assembly workflows, since they have a free-form section at the start, but I can look into improving it after seeing it in action first 
- [Brian] component information pages for Board Shipments and Grounding Mesh Shipments now show each constituent component's part number 
- [Carlos] tables of changed tensions on Tension Measurements action information pages now display the wire or wire segment number, instead of the index (the data is still stored by index) ... note that the scatter plot of tension vs. wire is still axised by wire index (Formio limitation)
- [Sotiris] when displaying search results involving components, the component name (DUNE PID, UKID, etc.) will now always be displayed if available, and the UUID will only be shown if this is not possible

Search Bug Fixes
- some geometry boards and grounding mesh panels appear to be missing the 'reception.detail' field entirely ... this is causing MongoDB to set a certain array to 'null', and stopping the search library function from completing
- workaround is to first check if the 'reception.detail' field exists before attempting to pull its information ... not as efficient, since this has to be done outside the MongoDB aggregation, but it works
- fixed misnamed variable in Mesh Panel Search by Location / Part Number inteface page's JS code