### PR TITLE
Improvements to Info Page Layouts and Adding Replaced Wires Count Cross-check

### DIFF
--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -373,6 +373,7 @@ async function collateInfo(componentUUID) {
 
       for (let i = 0; i < results[0].replacedWires.length; i++) {
         let singleWire_solderPads = results[0].replacedWires[i].solderPad;
+
         if (typeof singleWire_solderPads === 'number') {
           singleWire_solderPads = `${singleWire_solderPads}`;
         }
@@ -419,6 +420,7 @@ async function collateInfo(componentUUID) {
 
       for (let i = 0; i < results[0].badSolderJoints.length; i++) {
         let singleJoint_solderPads = results[0].badSolderJoints[i].solderPad;
+
         if (typeof singleJoint_solderPads === 'number') {
           singleJoint_solderPads = `${singleJoint_solderPads}`;
         }

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -97,9 +97,13 @@ module.exports = {
     daveSim: 'Dave Sim',
   },
 
-  // A dictionary of personnel who are authorised to sign-off on APA frame and grounding mesh intakes
-  dictionary_frameMeshSignoff: {
+  // A dictionary of personnel who are authorised to sign-off on APA frame and grounding mesh intake (including frame intake survey results)
+  dictionary_frameIntakeSignoff: {
     gedBell: 'Ged Bell',
     callumHolt: 'Callum Holt',
+  },
+
+  // A dictionary of personnel who are authorised to sign-off on APA frame installation survey results
+  dictionary_frameInstallationSignoff: {
   },
 }

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -1,9 +1,6 @@
 extend default
 include common.pug
 
-block vars
-  - const page_title = 'View Action Information';
-
 block extrascripts
   script(type = 'text/javascript').
     const action = !{JSON.stringify(action, null, 4)};
@@ -15,459 +12,463 @@ block extrascripts
   block workscripts
     script(src = '/pages/action.js')
 
+block vars
+  - const page_title = `Action: ${action.typeFormName}`;
+
 block content
   .container-fluid
     .vert-space-x2
-      h2 View Action Information
+      h2 #{action.typeFormName}
 
     .vert-space-x1
-      dl
-        dt Action Type
-        dd 
+      .row 
+        .col-md-5
+          dl
+            dt Action ID
+            dd
+              .form-inline
+                a(href = `/action/${action.actionId}`) #{action.actionId}
+
+                .hori-space-x1
+                  a.copybutton.btn-sm#copy_id(onclick = 'CopyID(action.actionId)') Copy
+
+            - const uuid = MUUID.from(action.componentUuid).toString();
+
+            dt Performed on Component:
+
+            if (component.data.name)
+              dd 
+                a(href = `/component/${uuid}`) #{component.data.name}
+                |  (#{component.formName})
+            else 
+              dd 
+                a(href = `/component/${uuid}`) #{component.formName}
+
+            if action.workflowId
+              dt Part of Workflow:
+              dd
+                a(href = `/workflow/${action.workflowId}`, target = '_blank') #{action.workflowId}
+
+            dt Current Version:
+            dd This is version #{action.validity.version} of the action, and it was last performed on !{' '}
+              +dateTimeFormat(action.insertion.insertDate)
+
+              if action.insertion.user
+                |  by !{' '}
+                a(href = `mailto:${user_email(action.insertion.user)}`) #{action.insertion.user.displayName}
+
+            .vert-space-x1
+              .panel.panel-default
+              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
+                | All Versions: 
+                i.chevron.fa.fa-fw 
+
+              .collapse#versionsBox
+                ul
+                  each v in actionVersions
+                    li 
+                      a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
+                      |  on 
+                      +dateTimeFormat(v.insertion.insertDate)
+
+                      if v.insertion.user
+                        |  by !{' '}
+                        a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
+
+        .col-md-1 
+        .col-md-3 
           .form-inline
-            a #{action.typeFormName}
+            a.btn.btn-warning(href = `/action/${action.actionId}/edit`)
+              img.small-icon(src = '/images/edit_icon.svg')
+              | &nbsp; Edit Action
 
-            .hori-space-x1
-              a.btn-sm.btn-primary(href = `/action/${action.typeFormId}/unspec`)
-                img.small-icon(src = '/images/run_icon.svg')
-                | &nbsp; Perform New Action of This Type
+            - let jsonURLString = `/json/action/${action.actionId}`;
+            - if ('version' in queryDictionary) jsonURLString += `?version=${queryDictionary.version}`;
 
-        dt Action ID
-        dd
-          .form-inline
-            a(href = `/action/${action.actionId}`) #{action.actionId}
-
-            .hori-space-x1
-              a.copybutton.btn-sm#copy_id(onclick = 'CopyID(action.actionId)') Copy
-
-        - const uuid = MUUID.from(action.componentUuid).toString();
-
-        dt Performed on Component:
-        dd UUID: 
-          a(href = `/component/${uuid}`) #{uuid}
-          br
-          | Type: #{component.formName}
-          br
-          | Name: #{component.data.name}
-
-        if action.workflowId
-          dt Part of Workflow:
-          dd
-            a(href = `/workflow/${action.workflowId}`, target = '_blank') #{action.workflowId}
-
-        dt Action Data:
-        dd This is version #{action.validity.version} of the action, and it was last performed on !{' '}
-          +dateTimeFormat(action.insertion.insertDate)
-
-          if action.insertion.user
-            |  by !{' '}
-            a(href = `mailto:${user_email(action.insertion.user)}`) #{action.insertion.user.displayName}
-
-          .vert-space-x1.border-success.border.rounded.p-2
-            #typeform
+            .hori-space-x2
+              a.btn.btn-secondary(href = `${jsonURLString}`, target = '_blank')
+                img.small-icon(src = '/images/checklist_icon.svg')
+                | &nbsp; View JSON Record
 
           .vert-space-x1
+            a.btn.btn-primary(href = `/action/${action.typeFormId}/unspec`)
+              img.small-icon(src = '/images/run_icon.svg')
+              | &nbsp; Perform New Action of This Type
 
-        if (action.typeFormId == 'x_tension_testing') && (action.data.changedTensions_sideA)
-          dt Most recently re-tensioned wires / wire segments (comparing this version [#{action.validity.version}] and version #{action.data.changedTensions_version}):
+        .col-md-3
 
-          - let numberOfChangedTensions_sideA = action.data.changedTensions_sideA.length
-          - let numberOfChangedTensions_sideB = action.data.changedTensions_sideB.length
+    .vert-space-x1.border-success.border.rounded.p-2
+      #typeform
 
-          .row
-            .col-md-6
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxA')
-                | #{numberOfChangedTensions_sideA} on side A: 
-                i.chevron.fa.fa-fw 
+    .vert-space-x1
+      if (action.typeFormId == 'x_tension_testing') && (action.data.changedTensions_sideA)
+        dt Most recently re-tensioned wires / wire segments (comparing this version [#{action.validity.version}] and version #{action.data.changedTensions_version}):
 
-              .collapse#reTensionsBoxA
-                if numberOfChangedTensions_sideA > 0
-                  .vert-space-x1.border-success.border.rounded.p-2
-                    dd
-                      table.table
-                        thead
-                          tr
-                            th.col-md-2 Wire / Wire Segment
-                            th.col-md-2 Original Tension (N)
-                            th.col-md-2 Latest Tension (N)
+        - let numberOfChangedTensions_sideA = action.data.changedTensions_sideA.length
+        - let numberOfChangedTensions_sideB = action.data.changedTensions_sideB.length
 
-                        tbody
-                          each changedTension in action.data.changedTensions_sideA
-                            tr
-                              if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
-                                td #{changedTension[0] + 1}
-                              else 
-                                td #{changedTension[0] + 8}
+        .row
+          .col-md-6
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxA')
+              | #{numberOfChangedTensions_sideA} on side A: 
+              i.chevron.fa.fa-fw 
 
-                              td #{changedTension[1]}
-                              td #{changedTension[2]}
-            .col-md-6
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxB')
-                | #{numberOfChangedTensions_sideB} on side B: 
-                i.chevron.fa.fa-fw 
-
-              .collapse#reTensionsBoxB
-                if numberOfChangedTensions_sideB > 0
-                  .vert-space-x1.border-success.border.rounded.p-2
-                    dd
-                      table.table
-                        thead
-                          tr
-                            th.col-md-2 Wire / Wire Segment
-                            th.col-md-2 Original Tension (N)
-                            th.col-md-2 Latest Tension (N)
-
-                        tbody
-                          each changedTension in action.data.changedTensions_sideB
-                            tr
-                              if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
-                                td #{changedTension[0] + 1}
-                              else 
-                                td #{changedTension[0] + 8}
-
-                              td #{changedTension[1]}
-                              td #{changedTension[2]}
-
-          .vert-space-x2 
-
-        if (action.typeFormId == 'IntakeSurveys')
-          if (action.data.intake_m4Holes)
-            .vert-space-x1
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#m4HolesBox')
-                | M4 Hole Measurements (mm): 
-                i.chevron.fa.fa-fw 
-
-              .collapse#m4HolesBox
+            .collapse#reTensionsBoxA
+              if numberOfChangedTensions_sideA > 0
                 .vert-space-x1.border-success.border.rounded.p-2
                   dd
                     table.table
                       thead
                         tr
-                          th.col-md-1 Hole
-                          th.col-md-1 x
-                          th.col-md-1 y
-                          th.col-md-1 z 
-                          th.col-md-2 Actual Dist. to 1st hole 
-                          th.col-md-2 Diff [Actual - Nominal]
-                          th.col-md-2 Actual Dist. to Prev. hole
-                          th.col-md-2 Diff [Actual - Nominal]
+                          th.col-md-2 Wire / Wire Segment
+                          th.col-md-2 Original Tension (N)
+                          th.col-md-2 Latest Tension (N)
 
                       tbody
-                        for [key, value] of Object.entries(action.data.intake_m4Holes)
+                        each changedTension in action.data.changedTensions_sideA
                           tr
-                            td #{value['Hole']}
-                            td #{value['x']}
-                            td #{value['y']}
-                            td #{value['z']}
-                            td #{value['dist_1stHole']}
-                            td #{value['deviat_1stHole']}
-                            td #{value['dist_prevHole']}
-                            td #{value['deviat_prevHole']}
-          else
-            .vert-space-x1
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#m4HolesBox')
-                | M4 Hole Measurements (no results found in record!) 
-                i.chevron.fa.fa-fw 
+                            if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
+                              td #{changedTension[0] + 1}
+                            else 
+                              td #{changedTension[0] + 8}
 
-          if (action.data.intake_xCorners)
-            .vert-space-x1
-              - outOfSpecCount = 0
+                            td #{changedTension[1]}
+                            td #{changedTension[2]}
+          .col-md-6
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxB')
+              | #{numberOfChangedTensions_sideB} on side B: 
+              i.chevron.fa.fa-fw 
 
-              for [key, value] of Object.entries(action.data.intake_xCorners)
-                if (value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance)
-                  - outOfSpecCount += 1
-
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#xCornersBox')
-                | Manual Cross Corner Measurements (all measured at DSM) (#{outOfSpecCount} results outside tolerance): 
-                i.chevron.fa.fa-fw 
-
-              .collapse#xCornersBox
+            .collapse#reTensionsBoxB
+              if numberOfChangedTensions_sideB > 0
                 .vert-space-x1.border-success.border.rounded.p-2
                   dd
                     table.table
                       thead
                         tr
-                          th.col-md-2 Measurement
-                          th.col-md-1 Actual
-                          th.col-md-1 Units
-                          th.col-md-1 Tolerance 
-                          th.col-md-7 Comment
+                          th.col-md-2 Wire / Wire Segment
+                          th.col-md-2 Original Tension (N)
+                          th.col-md-2 Latest Tension (N)
 
                       tbody
-                        for [key, value] of Object.entries(action.data.intake_xCorners)
+                        each changedTension in action.data.changedTensions_sideB
                           tr
-                            td #{value.Measurement}
+                            if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
+                              td #{changedTension[0] + 1}
+                            else 
+                              td #{changedTension[0] + 8}
 
+                            td #{changedTension[1]}
+                            td #{changedTension[2]}
+
+        .vert-space-x2 
+
+      if (action.typeFormId == 'IntakeSurveys')
+        if (action.data.intake_m4Holes)
+          .vert-space-x1
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#m4HolesBox')
+              | M4 Hole Measurements (mm): 
+              i.chevron.fa.fa-fw 
+
+            .collapse#m4HolesBox
+              .vert-space-x1.border-success.border.rounded.p-2
+                dd
+                  table.table
+                    thead
+                      tr
+                        th.col-md-1 Hole
+                        th.col-md-1 x
+                        th.col-md-1 y
+                        th.col-md-1 z 
+                        th.col-md-2 Actual Dist. to 1st hole 
+                        th.col-md-2 Diff [Actual - Nominal]
+                        th.col-md-2 Actual Dist. to Prev. hole
+                        th.col-md-2 Diff [Actual - Nominal]
+
+                    tbody
+                      for [key, value] of Object.entries(action.data.intake_m4Holes)
+                        tr
+                          td #{value['Hole']}
+                          td #{value['x']}
+                          td #{value['y']}
+                          td #{value['z']}
+                          td #{value['dist_1stHole']}
+                          td #{value['deviat_1stHole']}
+                          td #{value['dist_prevHole']}
+                          td #{value['deviat_prevHole']}
+        else
+          .vert-space-x1
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#m4HolesBox')
+              | M4 Hole Measurements (no results found in record!) 
+              i.chevron.fa.fa-fw 
+
+        if (action.data.intake_xCorners)
+          .vert-space-x1
+            - outOfSpecCount = 0
+
+            for [key, value] of Object.entries(action.data.intake_xCorners)
+              if (value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance)
+                - outOfSpecCount += 1
+
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#xCornersBox')
+              | Manual Cross Corner Measurements (all measured at DSM) (#{outOfSpecCount} results outside tolerance): 
+              i.chevron.fa.fa-fw 
+
+            .collapse#xCornersBox
+              .vert-space-x1.border-success.border.rounded.p-2
+                dd
+                  table.table
+                    thead
+                      tr
+                        th.col-md-2 Measurement
+                        th.col-md-1 Actual
+                        th.col-md-1 Units
+                        th.col-md-1 Tolerance 
+                        th.col-md-7 Comment
+
+                    tbody
+                      for [key, value] of Object.entries(action.data.intake_xCorners)
+                        tr
+                          td #{value.Measurement}
+
+                          if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
+                            td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
+                          else
+                            td.text-danger.font-weight-bold #{value.Actual.toFixed(3)}
+
+                          td #{value.Units}
+                          td #{value.Tolerance.toFixed(2)}
+                          td #{value.Comment}
+        else
+          .vert-space-x1
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#xCornersBox')
+              | Manual Cross Corner Measurements (all measured at DSM) (no results found in record!) 
+              i.chevron.fa.fa-fw 
+
+        if (action.data.intake_planarity)
+          .vert-space-x1
+            - outOfSpecCount = 0
+
+            for [key, value] of Object.entries(action.data.intake_planarity)
+              if (value.Actual !== '') && (value.Actual !== '-') && ((value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance))
+                - outOfSpecCount += 1
+
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
+              | Planarity Analysis using M4/6 Holes (#{outOfSpecCount} results outside tolerance): 
+              i.chevron.fa.fa-fw 
+
+            .collapse#planarityBox
+              .vert-space-x1.border-success.border.rounded.p-2
+                dd
+                  table.table
+                    thead
+                      tr
+                        th.col-md-2 Measurement
+                        th.col-md-1 Actual
+                        th.col-md-1 Units
+                        th.col-md-1 Tolerance 
+                        th.col-md-7 Comment
+
+                    tbody
+                      for [key, value] of Object.entries(action.data.intake_planarity)
+                        tr
+                          td #{value.Measurement}
+
+                          if (value.Actual !== '') && (value.Actual !== '-')
                             if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
                               td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
                             else
                               td.text-danger.font-weight-bold #{value.Actual.toFixed(3)}
+                          else 
+                            td #{value.Actual}
 
-                            td #{value.Units}
+                          td #{value.Units}
+
+                          if value.Tolerance !== ''
                             td #{value.Tolerance.toFixed(2)}
+                          else 
+                            td #{value.Tolerance}
+
+                          if value.Measurement === 'Cross corner deviation'
+                            td For reference only - please refer instead to the manual cross corner measurements above
+                          else
                             td #{value.Comment}
-          else
-            .vert-space-x1
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#xCornersBox')
-                | Manual Cross Corner Measurements (all measured at DSM) (no results found in record!) 
-                i.chevron.fa.fa-fw 
+        else
+          .vert-space-x1
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
+              | Planarity Analysis using M4/6 Holes (no results found in record!) 
+              i.chevron.fa.fa-fw 
 
-          if (action.data.intake_planarity)
-            .vert-space-x1
-              - outOfSpecCount = 0
+        .vert-space-x2 
 
-              for [key, value] of Object.entries(action.data.intake_planarity)
-                if (value.Actual !== '') && (value.Actual !== '-') && ((value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance))
-                  - outOfSpecCount += 1
+      if (action.typeFormId == 'InstallationSurveys')
+        if (action.data.install_envelope)
+          .vert-space-x1
+            - let outOfSpecCount = 0
 
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
-                | Planarity Analysis using M4/6 Holes (#{outOfSpecCount} results outside tolerance): 
-                i.chevron.fa.fa-fw 
+            for [key, value] of Object.entries(action.data.install_envelope)
+              if value['Tolerance (±)'] != '-'
+                if key === 3 || key === 4
+                  if value['Max Deviation From Nominal'] >= value['Tolerance (±)']
+                    - outOfSpecCount += 1
+                else
+                  if (value['Max Deviation From Nominal'] <= (-1.0 * value['Tolerance (±)'])) || (value['Max Deviation From Nominal'] >= value['Tolerance (±)'])
+                    - outOfSpecCount += 1
 
-              .collapse#planarityBox
-                .vert-space-x1.border-success.border.rounded.p-2
-                  dd
-                    table.table
-                      thead
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#envelopeBox')
+              | Envelope Analysis (#{outOfSpecCount} results outside tolerance): 
+              i.chevron.fa.fa-fw 
+
+            .collapse#envelopeBox
+              .vert-space-x1.border-success.border.rounded.p-2
+                dd
+                  table.table
+                    thead
+                      tr
+                        th.col-md-3 Measurement Name (and link to EDMS)
+                        th.col-md-1 Units
+                        th.col-md-2 Position
+                        th.col-md-1 Nominal 
+                        th.col-md-1 Tolerance (±) 
+                        th.col-md-1 Actual
+                        th.col-md-1 Deviation
+                        th.col-md-2 Comments
+
+                    tbody
+                      for [key, value] of Object.entries(action.data.install_envelope)
                         tr
-                          th.col-md-2 Measurement
-                          th.col-md-1 Actual
-                          th.col-md-1 Units
-                          th.col-md-1 Tolerance 
-                          th.col-md-7 Comment
+                          if value['EDMS ID'] !== '-'
+                            td 
+                              a(href = `https://edms.cern.ch/document/${value['EDMS ID']}`, target = '_blank') #{value['Measurement']}
+                          else 
+                            td #{value['Measurement']}
 
-                      tbody
-                        for [key, value] of Object.entries(action.data.intake_planarity)
-                          tr
-                            td #{value.Measurement}
+                          td #{value['Units']}
+                          td #{value['Position']}
+                          td #{value['Nominal'].toFixed(2)}
 
-                            if (value.Actual !== '') && (value.Actual !== '-')
-                              if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
-                                td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
+                          if value['Tolerance (±)'] == '-'
+                            td #{value['Tolerance (±)']}
+                          else 
+                            td #{value['Tolerance (±)'].toFixed(2)}
+
+                          if value['Actual'] == '-'
+                            td #{value['Actual']}
+                          else 
+                            td #{value['Actual'].toFixed(2)}
+
+                          if value['Tolerance (±)'] != '-'
+                            if key === 3 || key === 4
+                              if value['Max Deviation From Nominal'] < value['Tolerance (±)']
+                                td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
                               else
-                                td.text-danger.font-weight-bold #{value.Actual.toFixed(3)}
-                            else 
-                              td #{value.Actual}
-
-                            td #{value.Units}
-
-                            if value.Tolerance !== ''
-                              td #{value.Tolerance.toFixed(2)}
-                            else 
-                              td #{value.Tolerance}
-
-                            if value.Measurement === 'Cross corner deviation'
-                              td For reference only - please refer instead to the manual cross corner measurements above
+                                td.text-danger.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
                             else
-                              td #{value.Comment}
-          else
-            .vert-space-x1
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
-                | Planarity Analysis using M4/6 Holes (no results found in record!) 
-                i.chevron.fa.fa-fw 
-
-          .vert-space-x2 
-
-        if (action.typeFormId == 'InstallationSurveys')
-          if (action.data.install_envelope)
-            .vert-space-x1
-              - let outOfSpecCount = 0
-
-              for [key, value] of Object.entries(action.data.install_envelope)
-                if value['Tolerance (±)'] != '-'
-                  if key === 3 || key === 4
-                    if value['Max Deviation From Nominal'] >= value['Tolerance (±)']
-                      - outOfSpecCount += 1
-                  else
-                    if (value['Max Deviation From Nominal'] <= (-1.0 * value['Tolerance (±)'])) || (value['Max Deviation From Nominal'] >= value['Tolerance (±)'])
-                      - outOfSpecCount += 1
-
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#envelopeBox')
-                | Envelope Analysis (#{outOfSpecCount} results outside tolerance): 
-                i.chevron.fa.fa-fw 
-
-              .collapse#envelopeBox
-                .vert-space-x1.border-success.border.rounded.p-2
-                  dd
-                    table.table
-                      thead
-                        tr
-                          th.col-md-3 Measurement Name (and link to EDMS)
-                          th.col-md-1 Units
-                          th.col-md-2 Position
-                          th.col-md-1 Nominal 
-                          th.col-md-1 Tolerance (±) 
-                          th.col-md-1 Actual
-                          th.col-md-1 Deviation
-                          th.col-md-2 Comments
-
-                      tbody
-                        for [key, value] of Object.entries(action.data.install_envelope)
-                          tr
-                            if value['EDMS ID'] !== '-'
-                              td 
-                                a(href = `https://edms.cern.ch/document/${value['EDMS ID']}`, target = '_blank') #{value['Measurement']}
-                            else 
-                              td #{value['Measurement']}
-
-                            td #{value['Units']}
-                            td #{value['Position']}
-                            td #{value['Nominal'].toFixed(2)}
-
-                            if value['Tolerance (±)'] == '-'
-                              td #{value['Tolerance (±)']}
-                            else 
-                              td #{value['Tolerance (±)'].toFixed(2)}
-
-                            if value['Actual'] == '-'
-                              td #{value['Actual']}
-                            else 
-                              td #{value['Actual'].toFixed(2)}
-
-                            if value['Tolerance (±)'] != '-'
-                              if key === 3 || key === 4
-                                if value['Max Deviation From Nominal'] < value['Tolerance (±)']
-                                  td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
-                                else
-                                  td.text-danger.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
+                              if (value['Max Deviation From Nominal'] > (-1.0 * value['Tolerance (±)'])) && (value['Max Deviation From Nominal'] < value['Tolerance (±)'])
+                                td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
                               else
-                                if (value['Max Deviation From Nominal'] > (-1.0 * value['Tolerance (±)'])) && (value['Max Deviation From Nominal'] < value['Tolerance (±)'])
-                                  td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
-                                else
-                                  td.text-danger.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
+                                td.text-danger.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
+                          else
+                            td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
+
+                          td #{value['Comments']}
+        else
+          .vert-space-x1
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#envelopeBox')
+              | Envelope Analysis (no results found in record!) 
+              i.chevron.fa.fa-fw 
+
+        if (action.data.install_planarity)
+          .vert-space-x1
+            - outOfSpecCount = 0
+
+            for [key, value] of Object.entries(action.data.install_planarity)
+              if (value.Actual !== '') && ((value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance))
+                - outOfSpecCount += 1
+
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
+              | Planarity Analysis using M6/10/20 Holes (#{outOfSpecCount} results outside tolerance): 
+              i.chevron.fa.fa-fw 
+
+            .collapse#planarityBox
+              .vert-space-x1.border-success.border.rounded.p-2
+                dd
+                  table.table
+                    thead
+                      tr
+                        th.col-md-2 Measurement
+                        th.col-md-1 Actual
+                        th.col-md-1 Units
+                        th.col-md-1 Tolerance 
+                        th.col-md-7 Comment
+
+                    tbody
+                      for [key, value] of Object.entries(action.data.install_planarity)
+                        tr
+                          td #{value.Measurement}
+
+                          if value.Actual !== ''
+                            if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
+                              td.text-success.font-weight-bold #{value.Actual.toFixed(2)}
                             else
-                              td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
+                              td.text-danger.font-weight-bold #{value.Actual.toFixed(2)}
+                          else 
+                            td #{value.Actual}
 
-                            td #{value['Comments']}
-          else
+                          td #{value.Units}
+
+                          if value.Tolerance !== ''
+                            td #{value.Tolerance.toFixed(2)}
+                          else 
+                            td #{value.Tolerance}
+
+                          td #{value.Comment}
+        else
+          .vert-space-x1
+            .panel.panel-default
+            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
+              | Planarity Analysis using M6/10/20 Holes (no results found in record!) 
+              i.chevron.fa.fa-fw 
+
+        .vert-space-x2 
+
+      if action.typeFormId == 'action_test' || action.typeFormId == 'APANonConformance' || action.typeFormId == 'x_tension_testing' || action.typeFormId == 'MeshQAInspection'
+        dt Add Images to Action Record:
+        dd Please use the 'Select Images' button below to select one or more images from your device to add to this action record.  Once you are happy with your selection, please use the 'Confirm Images' button to finalise the upload.
+          br
+          | Please make sure that your <b>images are individually no more than <u>1MB</u> in size</b>, and <b>please do not add more than <u>5 images</u> in total to any single record</b>.
+
+          .vert-space-x1.form-inline
+            label.btn.btn-primary(for = 'image-selector')
+              input.custom-file-input#image-selector(type = 'file', style = 'display:none', onchange = 'DisplayFileNames(this)', multiple)
+              | Select Images
+
+            .hori-space-x2
+              label.label-info#image-filenames 
+
+            .hori-space-x2
+              a.btn-danger.btn-sm#confirm-button(onclick = 'EncodeStoreImages()') Confirm Upload
+
+          if action.images
             .vert-space-x1
               .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#envelopeBox')
-                | Envelope Analysis (no results found in record!) 
+              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#imagesBox')
+                | View Gallery (#{action.images.length} images): 
                 i.chevron.fa.fa-fw 
 
-          if (action.data.install_planarity)
-            .vert-space-x1
-              - outOfSpecCount = 0
-
-              for [key, value] of Object.entries(action.data.install_planarity)
-                if (value.Actual !== '') && ((value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance))
-                  - outOfSpecCount += 1
-
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
-                | Planarity Analysis using M6/10/20 Holes (#{outOfSpecCount} results outside tolerance): 
-                i.chevron.fa.fa-fw 
-
-              .collapse#planarityBox
-                .vert-space-x1.border-success.border.rounded.p-2
-                  dd
-                    table.table
-                      thead
-                        tr
-                          th.col-md-2 Measurement
-                          th.col-md-1 Actual
-                          th.col-md-1 Units
-                          th.col-md-1 Tolerance 
-                          th.col-md-7 Comment
-
-                      tbody
-                        for [key, value] of Object.entries(action.data.install_planarity)
-                          tr
-                            td #{value.Measurement}
-
-                            if value.Actual !== ''
-                              if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
-                                td.text-success.font-weight-bold #{value.Actual.toFixed(2)}
-                              else
-                                td.text-danger.font-weight-bold #{value.Actual.toFixed(2)}
-                            else 
-                              td #{value.Actual}
-
-                            td #{value.Units}
-
-                            if value.Tolerance !== ''
-                              td #{value.Tolerance.toFixed(2)}
-                            else 
-                              td #{value.Tolerance}
-
-                            td #{value.Comment}
-          else
-            .vert-space-x1
-              .panel.panel-default
-              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
-                | Planarity Analysis using M6/10/20 Holes (no results found in record!) 
-                i.chevron.fa.fa-fw 
-
-          .vert-space-x2 
-
-        if action.typeFormId == 'action_test' || action.typeFormId == 'APANonConformance' || action.typeFormId == 'x_tension_testing' || action.typeFormId == 'MeshQAInspection'
-          dt Add Images to Action Record:
-          dd Please use the 'Select Images' button below to select one or more images from your device to add to this action record.  Once you are happy with your selection, please use the 'Confirm Images' button to finalise the upload.
-            br
-            | Please make sure that your <b>images are individually no more than <u>1MB</u> in size</b>, and <b>please do not add more than <u>5 images</u> in total to any single record</b>.
-
-            .vert-space-x1.form-inline
-              label.btn.btn-primary(for = 'image-selector')
-                input.custom-file-input#image-selector(type = 'file', style = 'display:none', onchange = 'DisplayFileNames(this)', multiple)
-                | Select Images
-
-              .hori-space-x2
-                label.label-info#image-filenames 
-
-              .hori-space-x2
-                a.btn-danger.btn-sm#confirm-button(onclick = 'EncodeStoreImages()') Confirm Upload
-
-            if action.images
-              .vert-space-x1
-                .panel.panel-default
-                .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#imagesBox')
-                  | View Gallery (#{action.images.length} images): 
-                  i.chevron.fa.fa-fw 
-
-                .collapse#imagesBox
-                  each imageString in action.images
-                    img.in-gallery(src = imageString)
-
-    .vert-space-x2
-      .panel.panel-default
-      .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
-        | All Versions: 
-        i.chevron.fa.fa-fw 
-
-      .collapse#versionsBox
-        ul
-          each v in actionVersions
-            li 
-              a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
-              |  on 
-              +dateTimeFormat(v.insertion.insertDate)
-
-              if v.insertion.user
-                |  by !{' '}
-                a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
-
-    .vert-space-x2.form-inline
-
-      a.btn.btn-warning(href = `/action/${action.actionId}/edit`)
-        img.small-icon(src = '/images/edit_icon.svg')
-        | &nbsp; Edit Action
-
-      - let jsonURLString = `/json/action/${action.actionId}`;
-      - if ('version' in queryDictionary) jsonURLString += `?version=${queryDictionary.version}`;
-
-      .hori-space-x2
-        a.btn.btn-secondary(href = `${jsonURLString}`, target = '_blank')
-          img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; View JSON Record
+              .collapse#imagesBox
+                each imageString in action.images
+                  img.in-gallery(src = imageString)
 
     .vert-space-x2

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -8,6 +8,7 @@ block extrascripts
     const actionTypeForm = !{JSON.stringify(actionTypeForm, null, 4)};
     const component = !{JSON.stringify(component, null, 4)};
     const queryDictionary = !{JSON.stringify(queryDictionary, null, 4)};
+    const numberOfReplacedWires = !{JSON.stringify(numberOfReplacedWires, null, 4)};
 
   block workscripts
     script(src = '/pages/action.js')
@@ -111,7 +112,7 @@ block content
           .col-md-6
             .panel.panel-default
             .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxA')
-              | #{numberOfChangedTensions_sideA} on side A: 
+              | #{numberOfChangedTensions_sideA} on side A (found #{numberOfReplacedWires[0]} in this layer's winding action): 
               i.chevron.fa.fa-fw 
 
             .collapse#reTensionsBoxA
@@ -138,7 +139,7 @@ block content
           .col-md-6
             .panel.panel-default
             .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxB')
-              | #{numberOfChangedTensions_sideB} on side B: 
+              | #{numberOfChangedTensions_sideB} on side B (found #{numberOfReplacedWires[1]} in this layer's winding action): 
               i.chevron.fa.fa-fw 
 
             .collapse#reTensionsBoxB

--- a/app/pug/action_editTypeForm.pug
+++ b/app/pug/action_editTypeForm.pug
@@ -1,5 +1,8 @@
 extend template_editTypeForm
 
+block vars
+  - const page_title = 'Edit Action Type Form';
+
 block content_header
   p.h2 Edit Action Type Form
 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -1,9 +1,6 @@
 extend default
 include common.pug
 
-block vars
-  - const page_title = 'View Component Information';
-
 block extrascripts
   script(type = 'text/javascript').
     const component = !{JSON.stringify(component, null, 4)};
@@ -19,25 +16,18 @@ block extrascripts
   block workscripts
     script(src = '/pages/component.js')
 
+block vars
+  - const page_title = `Component: ${component.formName}`;
+
 block content
   .container-fluid
     .vert-space-x2
-      h2 View Component Information
+      h2 #{component.formName}
 
     .vert-space-x1
       .row
-        .col-md-9
+        .col-md-5
           dl
-            dt Component Type
-            dd
-              .form-inline
-                a #{component.formName}
-
-                .hori-space-x1
-                  a.btn-sm.btn-primary(href = `/component/${component.formId}`)
-                    img.small-icon(src = '/images/run_icon.svg')
-                    | &nbsp; Create New Component of This Type
-
             dt Component UUID
             dd
               .form-inline
@@ -47,11 +37,15 @@ block content
                   a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
 
             if component.data.name
-              dt Component Name            
-              dd #{component.data.name}
+              dt Name or ID
+
+                if component.formId == 'GroundingMeshPanel'
+                  dd #{component.data.typeRecordNumber}
+                else
+                  dd #{component.data.name}
 
             if component.reception && component.reception.location !== ''
-              dt Current Location
+              dt Location
 
               if component.reception.detail && component.reception.detail != ''
                 dd
@@ -64,10 +58,6 @@ block content
                   +dateFormat(component.reception.date)
                   | )
 
-            if component.formId == 'GroundingMeshPanel'
-              dt Factory ID
-              dd #{component.data.typeRecordNumber}
-
             if component.workflowId
               dt Part of Workflow:
               dd
@@ -78,7 +68,7 @@ block content
               dd
                 a(href = `/component/${component.data.fromBatch}`, target = '_blank') #{component.data.fromBatch}
 
-            dt Component Data:
+            dt Current Version:
             dd This is version #{component.validity.version} of the component, and it was last edited on !{' '}
               +dateTimeFormat(component.insertion.insertDate)
 
@@ -86,227 +76,234 @@ block content
                 |  by !{' '}
                 a(href = `mailto:${user_email(component.insertion.user)}`) #{component.insertion.user.displayName}
 
-            if component.formId === 'BoardShipment'
-              .vert-space-x1.border-success.border.rounded.p-2
-                dt Origin Location 
-                dd #{dictionary_locations[component.data.originOfShipment]}
+            .vert-space-x1
+              .panel.panel-default
+              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
+                | All Versions: 
+                i.chevron.fa.fa-fw 
 
-                dt Destination Location
-                dd #{dictionary_locations[component.data.destinationOfShipment]}
+              .collapse#versionsBox
+                ul
+                  each v in componentVersions
+                    li 
+                      a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
+                      |  on 
+                      +dateTimeFormat(v.insertion.insertDate)
 
-                dt Boards in Shipment
-                dd
-                  table.table
-                    thead
-                      tr
-                        th.col-md-2 UUID
-                        th.col-md-1 UK ID
-                        th.col-md-1 Part Number
-                        th.col-md-3 QR Code Link 
+                      if v.insertion.user
+                        |  by !{' '}
+                        a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
 
-                    tbody
-                      each info in collectionDetails
-                        tr
-                          td
-                            a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+        .col-md-1
+        .col-md-3
+          .form-inline
+            a.btn.btn-warning(href = `/component/${component.componentUuid}/edit`)
+              img.small-icon(src = '/images/edit_icon.svg')
+              | &nbsp; Edit Component
 
-                          td #{info[1]}
-                          td #{info[2]}
-                          td #{`${base_url}/c/${info[3]}`}
+            - let jsonURLString = `/json/component/${component.componentUuid}`;
+            - if ('version' in dictionary_queries) jsonURLString += `?version=${dictionary_queries.version}`;
 
-                a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-                  img.small-icon(src = '/images/checklist_icon.svg')
-                  | &nbsp; Print all sub-component QR codes
-            else if component.formId === 'DWAComponentShipment'
-              .vert-space-x1.border-success.border.rounded.p-2
-                dt Origin Location
-                dd #{dictionary_locations[component.data.originOfShipment]}
+            .hori-space-x2
+              a.btn.btn-secondary(href = `${jsonURLString}`, target = '_blank')
+                img.small-icon(src = '/images/checklist_icon.svg')
+                | &nbsp; View JSON Record
 
-                dt Destination Location
-                dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-                dt Components in Shipment
-                dd
-                  table.table 
-                    thead 
-                      tr 
-                        th.col-md-2 UUID 
-                        th.col-md-1 Type
-                        th.col-md-1 Number
-                        th.col-md-3 QR Code Link 
-
-                    tbody 
-                      each info in collectionDetails
-                        tr
-                          td
-                            a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
-
-                          td #{info[2]}
-                          td #{info[1]}
-                          td #{`${base_url}/c/${info[3]}`}
-
-                a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-                  img.small-icon(src = '/images/checklist_icon.svg')
-                  | &nbsp; Print all sub-component QR codes
-            else if component.formId === 'GroundingMeshShipment'
-              .vert-space-x1.border-success.border.rounded.p-2
-                dt Origin Location
-                dd #{dictionary_locations[component.data.originOfShipment]}
-
-                dt Destination Location
-                dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-                dt Meshes in Shipment
-                dd
-                  table.table 
-                    thead 
-                      tr 
-                        th.col-md-2 UUID 
-                        th.col-md-1 Factory ID
-                        th.col-md-1 Part Number
-                        th.col-md-3 QR Code Link 
-
-                    tbody 
-                      each info in collectionDetails
-                        tr
-                          td
-                            a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
-
-                          td #{info[1]}
-                          td #{info[2]}
-                          td #{`${base_url}/c/${info[3]}`}
-
-                a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-                  img.small-icon(src = '/images/checklist_icon.svg')
-                  | &nbsp; Print all sub-component QR codes
-            else if component.formId === 'PopulatedBoardShipment'
-              .vert-space-x1.border-success.border.rounded.p-2
-                dt Origin Location
-                dd #{dictionary_locations[component.data.originOfShipment]}
-
-                dt Destination Location
-                dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-                dt Components in Kit
-                dd
-                  table.table 
-                    thead 
-                      tr 
-                        th.col-md-2 UUID 
-                        th.col-md-1 Type
-                        th.col-md-1 UW ID 
-                        th.col-md-3 QR Code Link 
-
-                    tbody 
-                      each info in collectionDetails
-                        tr
-                          td
-                            a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
-
-                          td #{info[2]}
-                          td #{info[1]}
-                          td #{`${base_url}/c/${info[3]}`}
-
-                a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-                  img.small-icon(src = '/images/checklist_icon.svg')
-                  | &nbsp; Print all sub-component QR codes
-            else if component.formId === 'CEAdapterBoardBatch' || component.formId === 'CRBoardBatch' || component.formId === 'GBiasBoardBatch' || component.formId === 'GeometryBoardBatch'
-              if component.formId === 'GeometryBoardBatch'
-                .vert-space-x1.border-success.border.rounded.p-2
-                  #typeform
-
-              - let columnHeader = ''
-
-              if component.data.subComponent_formId == 'CEAdapterBoard' || component.data.subComponent_formId == 'CRBoard' || component.data.subComponent_formId == 'GBiasBoard'
-                - columnHeader = 'UW ID'
-              else 
-                - columnHeader = 'UK ID'
-
-              .vert-space-x1.border-success.border.rounded.p-2
-                dt #{`Components in Batch (total = ${component.data.subComponent_count})`}
-                dd
-                  table.table
-                    thead
-                      tr
-                        th.col-md-3 UUID
-                        th.col-md-1 #{columnHeader}
-                        th.col-md-3 QR Code Link
-
-                    tbody
-                      each uuid, index in component.data.subComponent_fullUuids
-                        tr
-                          td
-                            a(href = `/component/${uuid}`, target = '_blank') #{uuid}
-
-                          if component.data.subComponent_typeRecordNumbers
-                            td #{component.data.subComponent_typeRecordNumbers[index]}
-                          else
-                            td (not retrievable)
-
-                          td #{`${base_url}/c/${component.data.subComponent_shortUuids[index]}`}
-
-                .form-inline
-                  a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-                    img.small-icon(src = '/images/checklist_icon.svg')
-                    | &nbsp; Print all sub-component QR codes
-
-                  .hori-space-x2 
-                    a.btn.btn-secondary#download_links(onclick = 'DownloadLinks(component.data.subComponent_shortUuids)', download = `links_${component.data.orderNumber}.txt`, href = '') Download List of Links
-
-            else
-              .vert-space-x1.border-success.border.rounded.p-2
-                #typeform
+          .vert-space-x1 
+            a.btn.btn-primary(href = `/component/${component.formId}`)
+              img.small-icon(src = '/images/run_icon.svg')
+              | &nbsp; Create New Component of This Type
 
           .vert-space-x1
-            .panel.panel-default
-            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
-              | All Versions: 
-              i.chevron.fa.fa-fw 
+            a.btn.btn-primary(href = `/component/${component.componentUuid}/qrCodes`)
+              img.small-icon(src = '/images/checklist_icon.svg')
+              | &nbsp; Print a set of the component's QR codes
 
-            .collapse#versionsBox
-              ul
-                each v in componentVersions
-                  li 
-                    a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
-                    |  on 
-                    +dateTimeFormat(v.insertion.insertDate)
+          .vert-space-x1
+            a.btn.btn-primary(href = `/component/${component.componentUuid}/summary`)
+              img.small-icon(src = '/images/checklist_icon.svg')
+              | &nbsp; View and print the component's summary
 
-                    if v.insertion.user
-                      |  by !{' '}
-                      a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
+          if component.formId == 'AssembledAPA'
+            .vert-space-x1
+              a.btn.btn-primary(href = `/component/${component.componentUuid}/execSummary`)
+                img.small-icon(src = '/images/checklist_icon.svg')
+                | &nbsp; View and print this APA's Executive Summary
 
         .col-md-3
           #qr-code
             +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, component.data.name)
 
-    .vert-space-x2.form-inline
-      a.btn.btn-warning(href = `/component/${component.componentUuid}/edit`)
-        img.small-icon(src = '/images/edit_icon.svg')
-        | &nbsp; Edit Component
+    if component.formId === 'BoardShipment'
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt Origin Location 
+        dd #{dictionary_locations[component.data.originOfShipment]}
 
-      - let jsonURLString = `/json/component/${component.componentUuid}`;
-      - if ('version' in dictionary_queries) jsonURLString += `?version=${dictionary_queries.version}`;
+        dt Destination Location
+        dd #{dictionary_locations[component.data.destinationOfShipment]}
 
-      .hori-space-x2
-        a.btn.btn-secondary(href = `${jsonURLString}`, target = '_blank')
+        dt Boards in Shipment
+        dd
+          table.table
+            thead
+              tr
+                th.col-md-2 UUID
+                th.col-md-1 UK ID
+                th.col-md-1 Part Number
+                th.col-md-3 QR Code Link 
+
+            tbody
+              each info in collectionDetails
+                tr
+                  td
+                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
+                  td #{info[1]}
+                  td #{info[2]}
+                  td #{`${base_url}/c/${info[3]}`}
+
+        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; View JSON Record
+          | &nbsp; Print all sub-component QR codes
+    else if component.formId === 'DWAComponentShipment'
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt Origin Location
+        dd #{dictionary_locations[component.data.originOfShipment]}
 
-      .hori-space-x2
-        a.btn.btn-primary(href = `/component/${component.componentUuid}/qrCodes`)
+        dt Destination Location
+        dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+        dt Components in Shipment
+        dd
+          table.table 
+            thead 
+              tr 
+                th.col-md-2 UUID 
+                th.col-md-1 Type
+                th.col-md-1 Number
+                th.col-md-3 QR Code Link 
+
+            tbody 
+              each info in collectionDetails
+                tr
+                  td
+                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
+                  td #{info[2]}
+                  td #{info[1]}
+                  td #{`${base_url}/c/${info[3]}`}
+
+        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; Print a set of the component's QR codes
+          | &nbsp; Print all sub-component QR codes
+    else if component.formId === 'GroundingMeshShipment'
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt Origin Location
+        dd #{dictionary_locations[component.data.originOfShipment]}
 
-      .hori-space-x2
-        a.btn.btn-primary(href = `/component/${component.componentUuid}/summary`)
+        dt Destination Location
+        dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+        dt Meshes in Shipment
+        dd
+          table.table 
+            thead 
+              tr 
+                th.col-md-2 UUID 
+                th.col-md-1 Factory ID
+                th.col-md-1 Part Number
+                th.col-md-3 QR Code Link 
+
+            tbody 
+              each info in collectionDetails
+                tr
+                  td
+                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
+                  td #{info[1]}
+                  td #{info[2]}
+                  td #{`${base_url}/c/${info[3]}`}
+
+        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; View and print the component's summary
+          | &nbsp; Print all sub-component QR codes
+    else if component.formId === 'PopulatedBoardShipment'
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt Origin Location
+        dd #{dictionary_locations[component.data.originOfShipment]}
 
-      if component.formId == 'AssembledAPA'
-        .hori-space-x2
-          a.btn.btn-primary(href = `/component/${component.componentUuid}/execSummary`)
+        dt Destination Location
+        dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+        dt Components in Kit
+        dd
+          table.table 
+            thead 
+              tr 
+                th.col-md-2 UUID 
+                th.col-md-1 Type
+                th.col-md-1 UW ID 
+                th.col-md-3 QR Code Link 
+
+            tbody 
+              each info in collectionDetails
+                tr
+                  td
+                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
+                  td #{info[2]}
+                  td #{info[1]}
+                  td #{`${base_url}/c/${info[3]}`}
+
+        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
+          img.small-icon(src = '/images/checklist_icon.svg')
+          | &nbsp; Print all sub-component QR codes
+    else if component.formId === 'CEAdapterBoardBatch' || component.formId === 'CRBoardBatch' || component.formId === 'GBiasBoardBatch' || component.formId === 'GeometryBoardBatch'
+      if component.formId === 'GeometryBoardBatch'
+        .vert-space-x1.border-success.border.rounded.p-2
+          #typeform
+
+      - let columnHeader = ''
+
+      if component.data.subComponent_formId == 'CEAdapterBoard' || component.data.subComponent_formId == 'CRBoard' || component.data.subComponent_formId == 'GBiasBoard'
+        - columnHeader = 'UW ID'
+      else 
+        - columnHeader = 'UK ID'
+
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt #{`Components in Batch (total = ${component.data.subComponent_count})`}
+        dd
+          table.table
+            thead
+              tr
+                th.col-md-3 UUID
+                th.col-md-1 #{columnHeader}
+                th.col-md-3 QR Code Link
+
+            tbody
+              each uuid, index in component.data.subComponent_fullUuids
+                tr
+                  td
+                    a(href = `/component/${uuid}`, target = '_blank') #{uuid}
+
+                  if component.data.subComponent_typeRecordNumbers
+                    td #{component.data.subComponent_typeRecordNumbers[index]}
+                  else
+                    td (not retrievable)
+
+                  td #{`${base_url}/c/${component.data.subComponent_shortUuids[index]}`}
+
+        .form-inline
+          a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
             img.small-icon(src = '/images/checklist_icon.svg')
-            | &nbsp; View and print this APA's executive summary
+            | &nbsp; Print all sub-component QR codes
+
+          .hori-space-x2 
+            a.btn.btn-secondary#download_links(onclick = 'DownloadLinks(component.data.subComponent_shortUuids)', download = `links_${component.data.orderNumber}.txt`, href = '') Download List of Links
+
+    else
+      .vert-space-x1.border-success.border.rounded.p-2
+        #typeform
 
     .vert-space-x2
       hr

--- a/app/pug/component_editTypeForm.pug
+++ b/app/pug/component_editTypeForm.pug
@@ -1,5 +1,8 @@
 extend template_editTypeForm
 
+block vars
+  - const page_title = 'Edit Component Type Form';
+
 block content_header
   p.h2 Edit Component Type Form
 

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -1,12 +1,12 @@
 extend default
 
 block vars
-  - const page_title = 'Search Page Descriptions';
+  - const page_title = 'Search Descriptions';
 
 block content
   .container-fluid
     .vert-space-x2
-      h2 Search Page Descriptions
+      h2 Search Descriptions
 
     .vert-space-x1
       p The following dedicated search pages can be accessed from this page, as well as through the links under the <b>Search for ...</b> section of the sidebar.

--- a/app/pug/splash.pug
+++ b/app/pug/splash.pug
@@ -1,7 +1,7 @@
 doctype html
 
 head
-  title DUNE APA Construction DB
+  title APA Construction Database
 
   link(rel = 'stylesheet', href = '/css/splash.css')
   link(rel = 'preload', href = 'https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css', as = 'style', 

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -1,9 +1,6 @@
 extend default
 include common.pug
 
-block vars
-  - const page_title = 'View Workflow Information';
-
 block extrascripts
   script(type = 'text/javascript').
     const workflow = !{JSON.stringify(workflow, null, 4)};
@@ -19,208 +16,214 @@ block extrascripts
   block workscripts
     script(src = '/pages/workflow.js')
 
+block vars
+  - const page_title = `Workflow: ${workflow.typeFormName}`;
+
 block content
   .container-fluid
     .vert-space-x2
-      h2 View Workflow Information
+      h2 #{workflow.typeFormName}
 
     .vert-space-x1
-      dl
-        dt Workflow Type
-        dd #{workflow.typeFormName}
+      .row 
+        .col-md-5
+          dl
+            dt Workflow ID
+            dd
+              a(href = `/workflow/${workflow.workflowId}`) #{workflow.workflowId}
 
-        dt Workflow ID
-        dd
-          a(href = `/workflow/${workflow.workflowId}`) #{workflow.workflowId}
+            dt Current Status 
 
-        dt Current Status 
+            if workflowStatus == 'Complete'
+              dd.text-success.font-weight-bold #{workflowStatus}
+            else
+              dd.text-danger.font-weight-bold #{workflowStatus}
 
-        if workflowStatus == 'Complete'
-          dd.text-success.font-weight-bold #{workflowStatus}
-        else
-          dd.text-danger.font-weight-bold #{workflowStatus}
+            dt Current Version:
+            dd This is version #{workflow.validity.version} of the workflow, and it was last edited on !{' '}
+              +dateTimeFormat(workflow.insertion.insertDate)
 
-        dt Workflow Data:
-        dd This is version #{workflow.validity.version} of the workflow, and it was last edited on !{' '}
-          +dateTimeFormat(workflow.insertion.insertDate)
+              if workflow.insertion.user
+                |  by !{' '}
+                a(href = `mailto:${user_email(workflow.insertion.user)}`) #{workflow.insertion.user.displayName}
 
-          if workflow.insertion.user
-            |  by !{' '}
-            a(href = `mailto:${user_email(workflow.insertion.user)}`) #{workflow.insertion.user.displayName}
+            .vert-space-x1
+              .panel.panel-default
+              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
+                | All Versions: 
+                i.chevron.fa.fa-fw 
 
-          .vert-space-x1.border-success.border.rounded.p-2
-            - let freeSection_bgn = -2;
-            - let freeSection_end = -1;
-            - let freeSection_complete = true 
+              .collapse#versionsBox
+                ul
+                  each v in workflowVersions
+                    li 
+                      a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
+                      |  on 
+                      +dateTimeFormat(v.insertion.insertDate)
 
-            if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
-              if workflow.typeFormId === 'workflow_1'
-                - freeSection_bgn = 2;
-                - freeSection_end = 4;
-              else 
-                - freeSection_bgn = 2;
-                - freeSection_end = 10;
+                      if v.insertion.user
+                        |  by !{' '}
+                        a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
 
-              each step in workflow.path.slice(freeSection_bgn - 1, freeSection_end)
-                if step.result.length === 0
-                  - freeSection_complete = false 
+        .col-md-1 
+        .col-md-3
+          .form-inline
+            a.btn.btn-warning(href = `/workflow/${workflow.workflowId}/edit`)
+              img.small-icon(src = '/images/edit_icon.svg')
+              | &nbsp; Edit Workflow
 
-            table.table
-              thead
-                tr 
-                  th.col-md-1 Step
-                  th.col-md-3 Type Form Name
-                  th.col-md-3 Result (Component Name or Action ID)
-                  th.col-md-3 Action Status
+            - let jsonURLString = `/json/workflow/${workflow.workflowId}`;
+            - if ('version' in queryDictionary) jsonURLString += `?version=${queryDictionary.version}`;
 
-              tbody
-                each step, index in workflow.path 
-                  tr 
-                    td #{index + 1}
-                    td #{step.formName}
+            .hori-space-x2
+              a.btn.btn-secondary(href = `${jsonURLString}`, target = '_blank')
+                img.small-icon(src = '/images/checklist_icon.svg')
+                | &nbsp; View JSON Record
 
-                    - const componentUuid = workflow.path[0].result;
-                    - let stepFormId = '';
+        .col-md-3
 
-                    if index === 0
-                      each typeFormId in Object.keys(componentTypeForms).sort()
-                        if componentTypeForms[typeFormId].formName == step.formName
-                          - stepFormId = componentTypeForms[typeFormId].formId
+    .vert-space-x1.border-success.border.rounded.p-2
+      - let freeSection_bgn = -2;
+      - let freeSection_end = -1;
+      - let freeSection_complete = true 
 
-                      if componentUuid.length > 0
-                        td
-                          a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
+      if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
+        if workflow.typeFormId === 'workflow_1'
+          - freeSection_bgn = 2;
+          - freeSection_end = 4;
+        else 
+          - freeSection_bgn = 2;
+          - freeSection_end = 10;
+
+        each step in workflow.path.slice(freeSection_bgn - 1, freeSection_end)
+          if step.result.length === 0
+            - freeSection_complete = false 
+
+      table.table
+        thead
+          tr 
+            th.col-md-1 Step
+            th.col-md-3 Type Form Name
+            th.col-md-3 Result (Component Name or Action ID)
+            th.col-md-3 Action Status
+
+        tbody
+          each step, index in workflow.path 
+            tr 
+              td #{index + 1}
+              td #{step.formName}
+
+              - const componentUuid = workflow.path[0].result;
+              - let stepFormId = '';
+
+              if index === 0
+                each typeFormId in Object.keys(componentTypeForms).sort()
+                  if componentTypeForms[typeFormId].formName == step.formName
+                    - stepFormId = componentTypeForms[typeFormId].formId
+
+                if componentUuid.length > 0
+                  td
+                    a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
+                else 
+                  td
+                    .form-inline 
+                      | (step not yet performed)
+
+                      .hori-space-x2
+                        a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
+                          img.small-icon(src = '/images/run_icon.svg')
+                          | &nbsp; Create Component 
+                td [n.a.]
+              else
+                each typeFormId in Object.keys(actionTypeForms).sort()
+                  if actionTypeForms[typeFormId].formName == step.formName
+                    - stepFormId = actionTypeForms[typeFormId].formId
+
+                if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
+                  if index >= freeSection_bgn - 1 && index < freeSection_end
+                    if componentUuid.length > 0
+                      if step.result.length > 0
+                        td 
+                          a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                        if actionsDictionary[index]
+                          td.text-success.font-weight-bold Complete
+                        else
+                          td.text-danger.font-weight-bold Not Complete
                       else 
                         td
                           .form-inline 
                             | (step not yet performed)
 
                             .hori-space-x2
-                              a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
+                              a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
                                 img.small-icon(src = '/images/run_icon.svg')
-                                | &nbsp; Create Component 
+                                | &nbsp; Perform Action
+                        td [n.a.]
+                    else 
+                      td
+                        .form-inline 
+                          | (step not yet performed)
+
+                          .hori-space-x2
+                            a.btn-sm.btn-danger
+                              | Create Component First
                       td [n.a.]
-                    else
-                      each typeFormId in Object.keys(actionTypeForms).sort()
-                        if actionTypeForms[typeFormId].formName == step.formName
-                          - stepFormId = actionTypeForms[typeFormId].formId
+                  else
+                    if !freeSection_complete
+                      td
+                        .form-inline 
+                          | (step not yet performed)
 
-                      if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
-                        if index >= freeSection_bgn - 1 && index < freeSection_end
-                          if componentUuid.length > 0
-                            if step.result.length > 0
-                              td 
-                                a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+                          .hori-space-x2
+                            a.btn-sm.btn-danger
+                              | Perform Steps #{freeSection_bgn} to #{freeSection_end} First
+                      td [n.a.]
+                    else 
+                      if step.result.length > 0
+                        td 
+                          a(href = `/action/${step.result}`, target = '_blank') #{step.result}
 
-                              if actionsDictionary[index]
-                                td.text-success.font-weight-bold Complete
-                              else
-                                td.text-danger.font-weight-bold Not Complete
-                            else 
-                              td
-                                .form-inline 
-                                  | (step not yet performed)
-
-                                  .hori-space-x2
-                                    a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
-                                      img.small-icon(src = '/images/run_icon.svg')
-                                      | &nbsp; Perform Action
-                              td [n.a.]
-                          else 
-                            td
-                              .form-inline 
-                                | (step not yet performed)
-
-                                .hori-space-x2
-                                  a.btn-sm.btn-danger
-                                    | Create Component First
-                            td [n.a.]
+                        if actionsDictionary[index]
+                          td.text-success.font-weight-bold Complete
                         else
-                          if !freeSection_complete
-                            td
-                              .form-inline 
-                                | (step not yet performed)
+                          td.text-danger.font-weight-bold Not Complete
+                      else 
+                        td
+                          .form-inline 
+                            | (step not yet performed)
 
-                                .hori-space-x2
-                                  a.btn-sm.btn-danger
-                                    | Perform Steps #{freeSection_bgn} to #{freeSection_end} First
-                            td [n.a.]
+                            .hori-space-x2
+                              if workflow.path[index - 1].result.length > 0
+                                a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                                  img.small-icon(src = '/images/run_icon.svg')
+                                  | &nbsp; Perform Action
+                              else 
+                                a.btn-sm.btn-danger
+                                  | Perform Previous Steps First
+                        td [n.a.]
+                else
+                  if step.result.length > 0
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if actionsDictionary[index]
+                      td.text-success.font-weight-bold Complete
+                    else
+                      td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          if workflow.path[index - 1].result.length > 0
+                            a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                              img.small-icon(src = '/images/run_icon.svg')
+                              | &nbsp; Perform Action
                           else 
-                            if step.result.length > 0
-                              td 
-                                a(href = `/action/${step.result}`, target = '_blank') #{step.result}
-
-                              if actionsDictionary[index]
-                                td.text-success.font-weight-bold Complete
-                              else
-                                td.text-danger.font-weight-bold Not Complete
-                            else 
-                              td
-                                .form-inline 
-                                  | (step not yet performed)
-
-                                  .hori-space-x2
-                                    if workflow.path[index - 1].result.length > 0
-                                      a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
-                                        img.small-icon(src = '/images/run_icon.svg')
-                                        | &nbsp; Perform Action
-                                    else 
-                                      a.btn-sm.btn-danger
-                                        | Perform Previous Steps First
-                              td [n.a.]
-                      else
-                        if step.result.length > 0
-                          td 
-                            a(href = `/action/${step.result}`, target = '_blank') #{step.result}
-
-                          if actionsDictionary[index]
-                            td.text-success.font-weight-bold Complete
-                          else
-                            td.text-danger.font-weight-bold Not Complete
-                        else 
-                          td
-                            .form-inline 
-                              | (step not yet performed)
-
-                              .hori-space-x2
-                                if workflow.path[index - 1].result.length > 0
-                                  a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
-                                    img.small-icon(src = '/images/run_icon.svg')
-                                    | &nbsp; Perform Action
-                                else 
-                                  a.btn-sm.btn-danger
-                                    | Perform Previous Steps First
-                          td [n.a.]
-
-    .vert-space-x1
-      .panel.panel-default
-      .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
-        | All Versions: 
-        i.chevron.fa.fa-fw 
-
-      .collapse#versionsBox
-        ul
-          each v in workflowVersions
-            li 
-              a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
-              |  on 
-              +dateTimeFormat(v.insertion.insertDate)
-
-              if v.insertion.user
-                |  by !{' '}
-                a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
-
-    .vert-space-x2.form-inline
-      a.btn.btn-warning(href = `/workflow/${workflow.workflowId}/edit`)
-        img.small-icon(src = '/images/edit_icon.svg')
-        | &nbsp; Edit Workflow
-
-      - let jsonURLString = `/json/workflow/${workflow.workflowId}`;
-      - if ('version' in queryDictionary) jsonURLString += `?version=${queryDictionary.version}`;
-
-      .hori-space-x2
-        a.btn.btn-secondary(href = `${jsonURLString}`, target = '_blank')
-          img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; View JSON Record
+                            a.btn-sm.btn-danger
+                              | Perform Previous Steps First
+                    td [n.a.]
 
     .vert-space-x2

--- a/app/pug/workflow_editTypeForm.pug
+++ b/app/pug/workflow_editTypeForm.pug
@@ -1,5 +1,8 @@
 extend template_editTypeForm
 
+block vars
+  - const page_title = 'Edit Workflow Type Form';
+
 block content_header
   p.h2 Edit Workflow Type Form
 

--- a/app/routes/api/users.js
+++ b/app/routes/api/users.js
@@ -146,16 +146,38 @@ router.get('/winderMaintenanceSignoff.json', async function (req, res, next) {
 });
 
 
-/// List all personnel who are authorised to sign-off on APA frame and grounding mesh intakes
-router.get('/frameMeshSignoff.json', async function (req, res, next) {
+/// List all personnel who are authorised to sign-off on APA frame and grounding mesh intake (including frame intake survey results)
+router.get('/frameIntakeSignoff.json', async function (req, res, next) {
   try {
     // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
     let data = [];
 
-    for (const person in utils.dictionary_frameMeshSignoff) {
+    for (const person in utils.dictionary_frameIntakeSignoff) {
       data.push({
         api_name: person,
-        display_name: utils.dictionary_frameMeshSignoff[person],
+        display_name: utils.dictionary_frameIntakeSignoff[person],
+      });
+    }
+
+    // Return the array in JSON format
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List all personnel who are authorised to sign-off on APA frame installation survey results
+router.get('/frameInstallationSignoff.json', async function (req, res, next) {
+  try {
+    // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
+    let data = [];
+
+    for (const person in utils.dictionary_frameInstallationSignoff) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_frameInstallationSignoff[person],
       });
     }
 


### PR DESCRIPTION
- adding page titles to those that don't currently have them, so that they are more easily identifiable in browser histories
- tweaking a couple of existing page titles for consistency

- adding framework for new Frame Installation Surveys Signoff personnel dictionary (to be populated at a later date)

Revamping component, action and workflow information pages
- more specific page titles, both in interface and for browser display / history - record type and type form name are now shown
- moved all interaction buttons (edit, JSON, etc.) to top of page, so that they can be accessed without needing to scroll through the entire type form
- moved versions list above type form display, to be grouped with other basic record information
- streamlined displayed basic record information ... only display UUID if needed, combine name and ID displays as appropriate for certain component types

Adding information about replaced wires to Tension Measurements action information pages
- tension measurements action now retrieves the number of replaced wires (per side) entered into the WINDING action for the same APA and layer
- number of replaced wires from winding is displayed alongside the number of re-tensioned wires determined by the DB