### PR TITLE
Possible bug fix for Exec Summary crash ...

### DIFF
--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -517,43 +517,47 @@ async function collateInfo(componentUUID) {
   if (results.length > 0) {
     for (const result of results) {
       for (const entry of result.missingWireData) {
-        let nonConfType = '';
+        if (entry.wireLayer !== '') {
+          let nonConfType = '';
 
-        for (const [key, value] of Object.entries(result.nonConf_type)) {
-          if (value) nonConfType = key;
+          for (const [key, value] of Object.entries(result.nonConf_type)) {
+            if (value) nonConfType = key;
+          }
+
+          const dictionary = {
+            type: dictionary_apaNCRs_types[nonConfType],
+            layerSide: entry.wireLayer.toUpperCase(),
+            boardPad: entry.headBoardAndPad,
+            endpoints: entry.endPointsForMissingSegment,
+            fembChannel: entry.coldElectronicsChannel,
+            offlineChannel: entry.offlineChannel,
+            actionId: result.actionId,
+          }
+
+          collatedInfo.apaNCRs_wires.push(dictionary);
         }
-
-        const dictionary = {
-          type: dictionary_apaNCRs_types[nonConfType],
-          layerSide: entry.wireLayer.toUpperCase(),
-          boardPad: entry.headBoardAndPad,
-          endpoints: entry.endPointsForMissingSegment,
-          fembChannel: entry.coldElectronicsChannel,
-          offlineChannel: entry.offlineChannel,
-          actionId: result.actionId,
-        }
-
-        collatedInfo.apaNCRs_wires.push(dictionary);
       }
 
       for (const entry of result.shortedWireData) {
-        let nonConfType = '';
+        if (entry.wireLayer !== '') {
+          let nonConfType = '';
 
-        for (const [key, value] of Object.entries(result.nonConf_type)) {
-          if (value) nonConfType = key;
+          for (const [key, value] of Object.entries(result.nonConf_type)) {
+            if (value) nonConfType = key;
+          }
+
+          const dictionary = {
+            type: dictionary_apaNCRs_types[nonConfType],
+            layerSide: entry.wireLayer.toUpperCase(),
+            boardPad: entry.headBoardAndPad,
+            endpoints: entry.endPointsForMissingSegment,
+            fembChannel: entry.coldElectronicsChannel,
+            offlineChannel: entry.offlineChannel,
+            actionId: result.actionId,
+          }
+
+          collatedInfo.apaNCRs_wires.push(dictionary);
         }
-
-        const dictionary = {
-          type: dictionary_apaNCRs_types[nonConfType],
-          layerSide: entry.wireLayer.toUpperCase(),
-          boardPad: entry.headBoardAndPad,
-          endpoints: entry.endPointsForMissingSegment,
-          fembChannel: entry.coldElectronicsChannel,
-          offlineChannel: entry.offlineChannel,
-          actionId: result.actionId,
-        }
-
-        collatedInfo.apaNCRs_wires.push(dictionary);
       }
     }
   }


### PR DESCRIPTION
- changed so that wire NCRs are only passed to the Exec. Summary if they actually contain information
- forgot that Formio automatically sets up a list containing a single, empty entry if a datagrid is part of the type form but is not used
- not 100% if this fixes the bug on Staging, since I can't replicate the crash on Dev ... but this change at least stops empty NCRs from being displayed