### PR TITLE
Bug Fix for missing changed tensions when only on side B

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -112,7 +112,7 @@ async function save(input, req) {
       }
 
       // If any changed tensions have been found and saved, save them into the new record and break out of the loop ... if not, move to the next previous version of the action
-      if ((changedTensions_sideA.length > 0) || (changedTensions_sideB > 0)) {
+      if ((changedTensions_sideA.length > 0) || (changedTensions_sideB.length > 0)) {
         newRecord.data.changedTensions_version = action.validity.version;
         newRecord.data.changedTensions_sideA = [...changedTensions_sideA];
         newRecord.data.changedTensions_sideB = [...changedTensions_sideB];


### PR DESCRIPTION
Lewis and Carlos found that the DB was not showing the expected list of re-tensionings on certain APA/layer combinations, even though the raw data showed that the values had been changed.

Found this mistake in the code, which would only occur if the re-tensioned wires were ONLY on side B.