### PR TITLE
Changes to Determination of Re-tensioned Wires

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -76,52 +76,6 @@ async function save(input, req) {
   newRecord.validity = commonSchema.validity(oldRecord);
   newRecord.validity.ancestor_id = input._id;
 
-  // If a tension measurements record is being EDITED, i.e. the new record's type form ID matches that of a tensions measurement action and there is an existing record ...
-  if ((newRecord.typeFormId === 'x_tension_testing') && (oldRecord)) {
-    // We want to know which tensions have changed between the version of the record that is currently being saved, and the most recent previous version which had at least one different tension
-    // However, this may not necessarily be the immediately preceding version - for example, if the action was edited only to change some non-tension information ...
-    // ... then it would show that no tensions have changed between this and the preceding version (which is true, but not very helpful)
-    const new_sideA = [...newRecord.data.measuredTensions_sideA];
-    const new_sideB = [...newRecord.data.measuredTensions_sideB];
-
-    // Retrieve all versions of the action (ordered from latest to earliest)
-    const actionVersions = await versions(input.actionId);
-
-    // For each version that contains measured tensions (starting from the most recent) ...
-    for (const action of actionVersions) {
-      let changedTensions_sideA = [];
-      let changedTensions_sideB = [];
-
-      if (action.data.hasOwnProperty('measuredTensions_sideA')) {
-        // Compare the tensions in this version with those in the new one, and save any that are different
-        const old_sideA = [...action.data.measuredTensions_sideA];
-
-        for (let i = 0; i < old_sideA.length; i++) {
-          if (old_sideA[i] !== new_sideA[i]) {
-            changedTensions_sideA.push([i, old_sideA[i], new_sideA[i]]);
-          }
-        }
-
-        const old_sideB = [...action.data.measuredTensions_sideB];
-
-        for (let i = 0; i < old_sideB.length; i++) {
-          if (old_sideB[i] !== new_sideB[i]) {
-            changedTensions_sideB.push([i, old_sideB[i], new_sideB[i]]);
-          }
-        }
-      }
-
-      // If any changed tensions have been found and saved, save them into the new record and break out of the loop ... if not, move to the next previous version of the action
-      if ((changedTensions_sideA.length > 0) || (changedTensions_sideB.length > 0)) {
-        newRecord.data.changedTensions_version = action.validity.version;
-        newRecord.data.changedTensions_sideA = [...changedTensions_sideA];
-        newRecord.data.changedTensions_sideB = [...changedTensions_sideB];
-
-        break;
-      }
-    }
-  }
-
   // Insert the new record into the 'actions' records collection, and throw an error if the insertion fails
   let _lock = await dbLock(`saveAction_${newRecord.actionId}`, 1000);
 

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -8,6 +8,8 @@ block extrascripts
     const actionTypeForm = !{JSON.stringify(actionTypeForm, null, 4)};
     const component = !{JSON.stringify(component, null, 4)};
     const queryDictionary = !{JSON.stringify(queryDictionary, null, 4)};
+    const retensionedWires_versions = !{JSON.stringify(retensionedWires_versions, null, 4)};
+    const retensionedWires_values = !{JSON.stringify(retensionedWires_values, null, 4)};
     const numberOfReplacedWires = !{JSON.stringify(numberOfReplacedWires, null, 4)};
 
   block workscripts
@@ -103,21 +105,18 @@ block content
       #typeform
 
     .vert-space-x1
-      if (action.typeFormId == 'x_tension_testing') && (action.data.changedTensions_sideA)
-        dt Most recently re-tensioned wires / wire segments (comparing this version [#{action.validity.version}] and version #{action.data.changedTensions_version}):
-
-        - let numberOfChangedTensions_sideA = action.data.changedTensions_sideA.length
-        - let numberOfChangedTensions_sideB = action.data.changedTensions_sideB.length
+      if (action.typeFormId == 'x_tension_testing') && (retensionedWires_versions[0] !== null)
+        dt Most recently re-tensioned wires / wire segments (comparing versions #{retensionedWires_versions[1]} and #{retensionedWires_versions[0]}):
 
         .row
           .col-md-6
             .panel.panel-default
             .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxA')
-              | #{numberOfChangedTensions_sideA} on side A (found #{numberOfReplacedWires[0]} in this layer's winding action): 
+              | #{retensionedWires_values[0].length} on side A (found #{numberOfReplacedWires[0]} in this layer's winding action): 
               i.chevron.fa.fa-fw 
 
             .collapse#reTensionsBoxA
-              if numberOfChangedTensions_sideA > 0
+              if retensionedWires_values[0].length > 0
                 .vert-space-x1.border-success.border.rounded.p-2
                   dd
                     table.table
@@ -128,23 +127,19 @@ block content
                           th.col-md-2 Latest Tension (N)
 
                       tbody
-                        each changedTension in action.data.changedTensions_sideA
+                        each changedTension in retensionedWires_values[0]
                           tr
-                            if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
-                              td #{changedTension[0] + 1}
-                            else 
-                              td #{changedTension[0] + 8}
-
+                            td #{changedTension[0]}
                             td #{changedTension[1]}
                             td #{changedTension[2]}
           .col-md-6
             .panel.panel-default
             .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxB')
-              | #{numberOfChangedTensions_sideB} on side B (found #{numberOfReplacedWires[1]} in this layer's winding action): 
+              | #{retensionedWires_values[1].length} on side B (found #{numberOfReplacedWires[1]} in this layer's winding action): 
               i.chevron.fa.fa-fw 
 
             .collapse#reTensionsBoxB
-              if numberOfChangedTensions_sideB > 0
+              if retensionedWires_values[1].length > 0
                 .vert-space-x1.border-success.border.rounded.p-2
                   dd
                     table.table
@@ -155,13 +150,9 @@ block content
                           th.col-md-2 Latest Tension (N)
 
                       tbody
-                        each changedTension in action.data.changedTensions_sideB
+                        each changedTension in retensionedWires_values[1]
                           tr
-                            if action.data.apaLayer === 'x' || action.data.apaLayer === 'g'
-                              td #{changedTension[0] + 1}
-                            else 
-                              td #{changedTension[0] + 8}
-
+                            td #{changedTension[0]}
                             td #{changedTension[1]}
                             td #{changedTension[2]}
 

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -99,6 +99,10 @@ block content
               img.small-icon(src = '/images/run_icon.svg')
               | &nbsp; Perform New Action of This Type
 
+          if (action.typeFormId == 'x_tension_testing')
+            .vert-space-x1 
+              a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${action.actionId}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
+
         .col-sm-3
 
     .vert-space-x1.border-success.border.rounded.p-2

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -101,7 +101,10 @@ block content
 
           if (action.typeFormId == 'x_tension_testing')
             .vert-space-x1 
-              a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${action.actionId}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
+              if retensionedWires_versions[0] !== null
+                a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${action.actionId}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
+              else 
+                a.btn.btn-secondary.disabled(href = '') Download List of Changed Tensions
 
         .col-sm-3
 

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -102,7 +102,10 @@ block content
           if (action.typeFormId == 'x_tension_testing')
             .vert-space-x1 
               if retensionedWires_versions[0] !== null
-                a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${action.actionId}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
+                - const name_splits = component.data.name.split('-');
+                - const apa = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+
+                a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${apa}_${action.data.apaLayer.toUpperCase()}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
               else 
                 a.btn.btn-secondary.disabled(href = '') Download List of Changed Tensions
 

--- a/app/pug/home.pug
+++ b/app/pug/home.pug
@@ -30,7 +30,7 @@ block content
         br
         |  Please note that all records from the  
         a(href = 'https://apa.dunedb.org') production
-        |  database are copied to this deployment every other Monday at 22:00 GMT, so any changes to records that are present here but not on the production deployment at that time will be lost.
+        |  database are copied to this deployment every Monday at 23:45 GMT, so any changes to records that are present here but not on the production deployment at that time will be lost.
 
   if NODE_ENV == 'production'
     .alert.alert-success 

--- a/app/pug/home.pug
+++ b/app/pug/home.pug
@@ -1,32 +1,36 @@
 extend default
 
 block vars
-  - const page_title = 'Dashboard';
+  - const page_title = 'APA Construction DB';
 
 block content
   if NODE_ENV == 'development'
     .alert.alert-warning
       br
-      p This is a <b>DEVELOPMENT</b> deployment of the DUNE APA Construction Database, hosted locally on your computer.  It is <b>not</b> connected to either the 
-        a(href = 'https://apa-dev.dunedb.org') staging
+      p This is a <b>DEVELOPMENT</b> deployment of the DUNE APA Construction Database, hosted locally on your computer.
+        br
+        | It is <b>not</b> connected to either the 
+        a(href = 'https://apa-staging.dunedb.org') staging
         |  or 
         a(href = 'https://apa.dunedb.org') production
-        |  deployments, so any additions and/or alterations to database records that are made through this web interface will not be reflected outside of this deployment.
+        |  deployments, so any additions and/or alterations to database records that are made through this web interface will <b>not</b> be reflected outside of this deployment.
         br
         | If you have any such content here that you wish moved to the staging and/or production deployments, please contact 
-        a(href = 'mailto:brebel@wisc.edu') Brian Rebel. 
-        |  Otherwise, this deployment is your own personal playground.
+        a(href = 'mailto:dune-fd-apa-db@fnal.gov') the DB Admin Team
+        | .  Otherwise, this deployment is your own personal playground.
       p
 
   if NODE_ENV == 'staging'
     .alert.alert-danger
       br
-      p This is the <b>STAGING</b> deployment of the DUNE APA Construction Database, hosted at Fermilab.  It uses a representative copy of the 
-        a(href = 'https://apa.dunedb.org') production
-        |  database, and is to be used <b>only</b> for testing and previewing purposes by selected individuals who will be granted access on a case-by-case basis.
+      p This is the <b>STAGING</b> deployment of the DUNE APA Construction Database, hosted at Fermilab.
         br
-        | Changes to the underlying code made by the developers will be automatically pushed to the production deployment, but it up to individual users to copy over any additions and/or alterations to database records that they make through this deployment's web interface.
-      p
+        |  It is to be used <b>only</b> for testing and previewing purposes by selected individuals, who will be granted access on a case-by-case basis by 
+        a(href = 'mailto:dune-fd-apa-db@fnal.gov') the DB Admin Team.
+        br
+        |  Please note that all records from the  
+        a(href = 'https://apa.dunedb.org') production
+        |  database are copied to this deployment every other Monday at 22:00 GMT, so any changes to records that are present here but not on the production deployment at that time will be lost.
 
   if NODE_ENV == 'production'
     .alert.alert-success 
@@ -41,17 +45,17 @@ block content
         li For documentation relating to the database itself (i.e. descriptions of the functionality, overviews of common usage, etc.), please see our 
           |
           a(href = 'https://github.com/DUNE/dunedb/wiki', target = '_blank') Github Wiki page
-          |  (a Github account is not required to view the Wiki).  Please note that this Wiki should always be considered 'in progress'.
+          |  (a Github account is <b>not</b> required to view the Wiki).
         li Documents and other files relating to APA construction (manufacturer invoices, procedure write-ups, etc.) should be stored externally in the 
           a(href = 'https://edms.cern.ch/ui/#!master/navigator/project?P:100233208:100233208:subDocs', target = '_blank') APA area
-          |  of CERN's EDMS system (a CERN account is not required to view documents).
+          |  of CERN's EDMS system (a CERN account may be required to view certain files).
 
         br
 
-        li Bugs and other errors with existing functionality should be reported at our 
+        li Bugs and other errors with existing functionality should be reported to the DB Admin Team at  
           |
-          a(href = 'https://github.com/DUNE/dunedb/issues', target = '_blank') Github Issues page
-          |  (a Github account is required to report issues).  Please give as much information as you can - an example page or link to where the bug occurs, how to reproduce the error (if appropriate), etc.
-        li Requests for new and/or additional features and functionality can also be made on the Issues page, but please first check if the addition and/or change can be made by users directly through the web interface.
+          a(href = 'mailto:dune-fd-apa-db@fnal.gov', target = '_blank') dune-fd-apa-db@fnal.gov
+          | .  Please give as much information as you can - an example page or link to where the bug occurs, how to reproduce the error (if appropriate), etc.
+        li Requests for new and/or additional features and functionality can also be made to the Admin Team, but please first check if the addition and/or change can be made by users directly through this web interface.
 
     .vert-space-x2

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -32,11 +32,45 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})', permissions.checkPermission('ac
     // Retrieve the record of the component that the action was performed on, using its component UUID (also found in the action record)
     const component = await Components.retrieve(action.componentUuid);
 
-    // When viewing a 'Single Layer Tension Measurements' type action, we also want to see the number of replaced wires from the layer's winding action ...
-    // ... so that this number can be compared (for each side) to the number of re-tensioned wires determined by the DB itself
+    // When viewing a 'Single Layer Tension Measurements' type action, we also want to see some additional information not directly contained in the action record:
+    // - the number of wires that have been re-tensioned since the last time measurements were uploaded
+    // - the number of replaced wires from the layer's winding action (which can be compared per side to the number of re-tensioned wires)
+    let retensionedWires_versions = [null, null];
+    let retensionedWires_values = [[], []];
     let numberOfReplacedWires = [null, null];
 
     if (action.typeFormId === 'x_tension_testing') {
+      // Retrieve all versions of the action (ordered from latest to earliest)
+      // Then filter the list of versions to only include those which were uploaded by the M2M Client (i.e. those where new tension measurements were uploaded)
+      const actionVersions = await Actions.versions(req.params.actionId);
+
+      let filteredVersions = [];
+
+      for (const action of actionVersions) {
+        if (action.insertion.user.displayName == 'M2M Client') filteredVersions.push(action);
+      }
+
+      // If there are at least two M2M-uploaded versions of the action (i.e. so that some comparison can actually be made) ...
+      if (filteredVersions.length > 1) {
+        // Save the version numbers of the two most recent versions (these are the ones whose tension measurements will be compared)
+        retensionedWires_versions = [filteredVersions[0].validity.version, filteredVersions[1].validity.version];
+
+        // Loop through the tension measurements on both sides, compare them across the versions, and save any that are different (including the wire or wire segment number)
+        // Note that we can use a single loop here, since the number of wire (segments) is always the same on both sides
+        // Also note that we want to see the wire or wire segment number instead of its index, so use an offset that converts from the latter to the former (dependent on the wire layer)
+        let offset_wireIndex = ((action.data.apaLayer === 'x') || (action.data.apaLayer === 'g')) ? 1 : 8;
+
+        for (let i = 0; i < filteredVersions[0].data.measuredTensions_sideA.length; i++) {
+          if (filteredVersions[1].data.measuredTensions_sideA[i] !== filteredVersions[0].data.measuredTensions_sideA[i]) {
+            retensionedWires_values[0].push([i + offset_wireIndex, filteredVersions[1].data.measuredTensions_sideA[i], filteredVersions[0].data.measuredTensions_sideA[i]]);
+          }
+
+          if (filteredVersions[1].data.measuredTensions_sideB[i] !== filteredVersions[0].data.measuredTensions_sideB[i]) {
+            retensionedWires_values[1].push([i + offset_wireIndex, filteredVersions[1].data.measuredTensions_sideB[i], filteredVersions[0].data.measuredTensions_sideB[i]]);
+          }
+        }
+      }
+
       // Set up a match condition dictionary, where we want to find the Winding action performed on the same APA component and the same side as the tension measurements being viewed
       // Then attempt to get a list of all matching actions ... this should return at least one action, since the winding should already have been performed before the tension measurements
       let match_condition = {
@@ -76,6 +110,8 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})', permissions.checkPermission('ac
       actionTypeForm,
       component,
       queryDictionary: req.query,
+      retensionedWires_versions,
+      retensionedWires_values,
       numberOfReplacedWires,
     });
   } catch (err) {

--- a/app/static/formio/BarPlot.js
+++ b/app/static/formio/BarPlot.js
@@ -96,28 +96,18 @@ class BarPlot extends TextFieldComponent {
   updateExtras(value) {
     gBarPlotComponent = this;
 
-    // Normalize the input values
+    // Normalize the input values, and fix the data range (x-axis limits on the bar graph)
     let arr = value || [];
-    let min = 1e99;
-    let max = -1e99;
+    let min = 3.5;
+    let max = 9.0;
 
-    if (arr.length < 1) {
-      min = 0
-      max = 0;
-    }
-
-    // Calculate the minimum and maximum entry values
+    // Calculate the data bounds, and set up the array of values to be plotted
     const bounds = this.getBounds();
 
     for (let i = 0; i < arr.length; i++) {
       const x = parseFloat(arr[i]);
 
-      if (!isNaN(x)) {
-        min = Math.min(min, x);
-        max = Math.max(max, x);
-
-        arr[i] = x;
-      }
+      if (!isNaN(x)) { arr[i] = x; }
     }
 
     // Draw the bar plot
@@ -128,9 +118,6 @@ class BarPlot extends TextFieldComponent {
     let hist = new CreateGoodHistogram(Math.round((max - min) / 0.1) + 1, min, max);
 
     for (const x of arr) { hist.Fill(x); }
-
-    hist.min = 3.0;    // Fix the default x-axis range of the bar plot (it can still be zoomed and moved through the interface)
-    hist.max = 9.5;
 
     this.LizardHistogram.SetHist(hist, colorscale);
     this.LizardHistogram.SetMarkers([bounds[0].lo, bounds[0].hi, bounds[1].lo, bounds[1].hi]);

--- a/app/static/formio/NumberArray.js
+++ b/app/static/formio/NumberArray.js
@@ -97,28 +97,18 @@ class NumberArray extends TextFieldComponent {
   updateExtras(value) {
     gNumberArrayComponent = this;
 
-    // Normalize the input values
+    // Normalize the input values, and fix the data range (x-axis limits on the bar graph, y-axis limits on the scatter plot)
     let arr = value || [];
-    let min = 1e99;
-    let max = -1e99;
+    let min = 3.5;
+    let max = 9.0;
 
-    if (arr.length < 1) {
-      min = 0
-      max = 0;
-    }
-
-    // Calculate the minimum and maximum entry values
+    // Calculate the data bounds, and set up the array of values to be plotted
     const bounds = this.getBounds();
 
     for (let i = 0; i < arr.length; i++) {
       const x = parseFloat(arr[i]);
 
-      if (!isNaN(x)) {
-        min = Math.min(min, x);
-        max = Math.max(max, x);
-
-        arr[i] = x;
-      }
+      if (!isNaN(x)) { arr[i] = x; }
     }
 
     const numberOfEntries = arr.length;
@@ -142,8 +132,8 @@ class NumberArray extends TextFieldComponent {
     let graph = new Histogram(numberOfEntries, firstWireNumber, numberOfEntries + firstWireNumber);
 
     graph.data = arr;
-    graph.min_content = 3.0;    // Fix the default y-axis range of the scatter plot (it can still be zoomed and moved through the interface)
-    graph.max_content = 9.5;
+    graph.min_content = min;
+    graph.max_content = max;
 
     this.LizardGraph.SetHist(graph, colorscale);
     this.LizardGraph.SetMarkers([bounds[0].lo, bounds[0].hi, bounds[1].lo, bounds[1].hi]);
@@ -156,9 +146,6 @@ class NumberArray extends TextFieldComponent {
     let hist = new CreateGoodHistogram(Math.round((max - min) / 0.1) + 1, min, max);
 
     for (const x of arr) { hist.Fill(x); }
-
-    hist.min = 3.0;    // Fix the default x-axis range of the bar plot (it can still be zoomed and moved through the interface)
-    hist.max = 9.5;
 
     this.LizardHistogram.SetHist(hist, colorscale);
     this.LizardHistogram.SetMarkers([bounds[0].lo, bounds[0].hi, bounds[1].lo, bounds[1].hi]);

--- a/app/static/formio/ScatterPlot.js
+++ b/app/static/formio/ScatterPlot.js
@@ -98,26 +98,16 @@ class ScatterPlot extends TextFieldComponent {
 
     // Normalize the input values
     let arr = value || [];
-    let min = 1e99;
-    let max = -1e99;
+    let min = 3.5;
+    let max = 9.0;
 
-    if (arr.length < 1) {
-      min = 0
-      max = 0;
-    }
-
-    // Calculate the minimum and maximum entry values
+    // Calculate the data bounds, and set up the array of values to be plotted
     const bounds = this.getBounds();
 
     for (let i = 0; i < arr.length; i++) {
       const x = parseFloat(arr[i]);
 
-      if (!isNaN(x)) {
-        min = Math.min(min, x);
-        max = Math.max(max, x);
-
-        arr[i] = x;
-      }
+      if (!isNaN(x)) { arr[i] = x; }
     }
 
     const numberOfEntries = arr.length;
@@ -141,8 +131,8 @@ class ScatterPlot extends TextFieldComponent {
     let graph = new Histogram(numberOfEntries, firstWireNumber, numberOfEntries + firstWireNumber);
 
     graph.data = arr;
-    graph.min_content = 3.0;    // Fix the default y-axis range of the scatter plot (it can still be zoomed and moved through the interface)
-    graph.max_content = 9.5;
+    graph.min_content = min;
+    graph.max_content = max;
 
     this.LizardGraph.SetHist(graph, colorscale);
     this.LizardGraph.SetMarkers([bounds[0].lo, bounds[0].hi, bounds[1].lo, bounds[1].hi]);

--- a/app/static/pages/action.js
+++ b/app/static/pages/action.js
@@ -31,6 +31,26 @@ function CopyID(actionID) {
 };
 
 
+// When the 'Download List of Changed Tensions' button is pressed, write a list of the changed tensions to a file and then download the file
+function DownloadChangedTensions(retensionedWires) {
+  let tensions_text = '';
+
+  for (const changedTension of retensionedWires[0]) {
+    const tensions_line = `A    ${changedTension[0]}    ${changedTension[1]}    ${changedTension[2]}\n`;
+    tensions_text = tensions_text.concat(tensions_line);
+  }
+
+  for (const changedTension of retensionedWires[1]) {
+    const tensions_line = `B    ${changedTension[0]}    ${changedTension[1]}    ${changedTension[2]}\n`;
+    tensions_text = tensions_text.concat(tensions_line);
+  }
+
+  const tensions_obj = window.URL.createObjectURL(new Blob([tensions_text], { type: 'text/plain' }));
+
+  $('#download_changedTensions').attr('href', tensions_obj);
+};
+
+
 // When one or more images is selected, display their name(s) in the space between the selection and confirmation buttons
 // Also change the colour and text of the confirmation button to indicate that at least one image has been selected
 function DisplayFileNames(element) {


### PR DESCRIPTION
- the list of re-tensioned wires is now determined at the route level ... removed code from library function
- comparison is done between the two versions of the action that were most recently uploaded via M2M, accounting for which version of the action is being viewed
- the list is now passed to the Single Layer Tension Measurements action information page, instead of being written into the tension measurements action record
- new button on action information page, allows users to download a text file containing the list of changed tension measurements (both sides, and only if a comparison has been made) ... the text file's name shows the APA number and wire layer, as well as which versions were compared to get the list of changed tensions

Bug fix for incorrect x-axis labels on tensions bar plot
- code was previously first binning the data based on the minimum and maximum tension values, and then redrawing the x-axis based on fixed limits without rebinning the data
- code now uses the fixed limits when binning the data

Small updates to homepage PUG file
- changed page title that shows up in browser history to something a little less generic
- direct users to contact the DB Admin Team by email in case of problems, instead of the Github Issues page ... people already use the former anyway, never the latter
- added information about the weekly backup of production records to staging
- updated link to staging, and cleaned up some other text for clarity