### PR TITLE
Improvements to interface level workflow display code ...

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -105,5 +105,7 @@ module.exports = {
 
   // A dictionary of personnel who are authorised to sign-off on APA frame installation survey results
   dictionary_frameInstallationSignoff: {
+    olgaBeltramello: 'Olga Beltramello',
+    denisDiyakov: 'Denis Diyakov',
   },
 }

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -88,17 +88,14 @@ block content
       - let freeSection_end = -1;
       - let freeSection_complete = true 
 
-      if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
-        if workflow.typeFormId === 'workflow_1'
-          - freeSection_bgn = 2;
-          - freeSection_end = 4;
-        else 
-          - freeSection_bgn = 2;
-          - freeSection_end = 10;
+      if workflow.typeFormId === 'APA_Assembly'
+        - freeSection_bgn = 3;
+        - freeSection_end = 9;
 
-        each step in workflow.path.slice(freeSection_bgn - 1, freeSection_end)
-          if step.result.length === 0
-            - freeSection_complete = false 
+        - for (let i = freeSection_bgn - 1; i < freeSection_end; i++) {
+          - if (!actionsDictionary[i])
+            - freeSection_complete = false
+        - }
 
       table.table
         thead
@@ -122,10 +119,7 @@ block content
                   if componentTypeForms[typeFormId].formName == step.formName
                     - stepFormId = componentTypeForms[typeFormId].formId
 
-                if componentUuid.length > 0
-                  td
-                    a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
-                else 
+                if componentUuid.length === 0
                   td
                     .form-inline 
                       | (step not yet performed)
@@ -134,42 +128,69 @@ block content
                         a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
                           img.small-icon(src = '/images/run_icon.svg')
                           | &nbsp; Create Component 
+                else 
+                  td
+                    a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
+
                 td [n.a.]
-              else
+              else if index === 1
                 each typeFormId in Object.keys(actionTypeForms).sort()
                   if actionTypeForms[typeFormId].formName == step.formName
                     - stepFormId = actionTypeForms[typeFormId].formId
 
-                if workflow.typeFormId === 'workflow_1' || workflow.typeFormId === 'APA_Assembly'
+                if step.result.length === 0
+                  td 
+                    .form-inline 
+                      | (step not yet performed)
+
+                      .hori-space-x2
+                        if componentUuid.length === 0
+                          a.btn-sm.btn-danger
+                            | Create Component First
+                        else 
+                          a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                            img.small-icon(src = '/images/run_icon.svg')
+                            | &nbsp; Perform Action
+
+                  td.text-danger.font-weight-bold Not Complete
+                else 
+                  td 
+                    a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                  if !actionsDictionary[index]
+                    td.text-danger.font-weight-bold Not Complete
+                  else
+                    td.text-success.font-weight-bold Complete
+              else 
+                each typeFormId in Object.keys(actionTypeForms).sort()
+                  if actionTypeForms[typeFormId].formName == step.formName
+                    - stepFormId = actionTypeForms[typeFormId].formId
+
+                if workflow.typeFormId === 'APA_Assembly'
                   if index >= freeSection_bgn - 1 && index < freeSection_end
-                    if componentUuid.length > 0
-                      if step.result.length > 0
-                        td 
-                          a(href = `/action/${step.result}`, target = '_blank') #{step.result}
-
-                        if actionsDictionary[index]
-                          td.text-success.font-weight-bold Complete
-                        else
-                          td.text-danger.font-weight-bold Not Complete
-                      else 
-                        td
-                          .form-inline 
-                            | (step not yet performed)
-
-                            .hori-space-x2
-                              a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
-                                img.small-icon(src = '/images/run_icon.svg')
-                                | &nbsp; Perform Action
-                        td [n.a.]
-                    else 
+                    if step.result.length === 0
                       td
                         .form-inline 
                           | (step not yet performed)
 
                           .hori-space-x2
-                            a.btn-sm.btn-danger
-                              | Create Component First
-                      td [n.a.]
+                            if !actionsDictionary[freeSection_bgn - 2]
+                              a.btn-sm.btn-danger
+                                | Complete Step #{freeSection_bgn - 2} First
+                            else 
+                              a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                                img.small-icon(src = '/images/run_icon.svg')
+                                | &nbsp; Perform Action
+
+                      td.text-danger.font-weight-bold Not Complete
+                    else 
+                      td 
+                        a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                      if !actionsDictionary[index]
+                        td.text-danger.font-weight-bold Not Complete
+                      else
+                        td.text-success.font-weight-bold Complete
                   else
                     if !freeSection_complete
                       td
@@ -178,53 +199,56 @@ block content
 
                           .hori-space-x2
                             a.btn-sm.btn-danger
-                              | Perform Steps #{freeSection_bgn} to #{freeSection_end} First
-                      td [n.a.]
-                    else 
-                      if step.result.length > 0
-                        td 
-                          a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+                              | Complete Steps #{freeSection_bgn} to #{freeSection_end} First
 
-                        if actionsDictionary[index]
-                          td.text-success.font-weight-bold Complete
-                        else
-                          td.text-danger.font-weight-bold Not Complete
-                      else 
-                        td
+                      td.text-danger.font-weight-bold Not Complete
+                    else 
+                      if step.result.length === 0
+                        td 
                           .form-inline 
                             | (step not yet performed)
 
                             .hori-space-x2
-                              if workflow.path[index - 1].result.length > 0
+                              if !actionsDictionary[index - 1]
+                                a.btn-sm.btn-danger
+                                  | Complete Previous Action First
+                              else 
                                 a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
                                   img.small-icon(src = '/images/run_icon.svg')
                                   | &nbsp; Perform Action
-                              else 
-                                a.btn-sm.btn-danger
-                                  | Perform Previous Steps First
-                        td [n.a.]
-                else
-                  if step.result.length > 0
-                    td 
-                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
 
-                    if actionsDictionary[index]
-                      td.text-success.font-weight-bold Complete
-                    else
-                      td.text-danger.font-weight-bold Not Complete
-                  else 
-                    td
+                        td.text-danger.font-weight-bold Not Complete
+                      else 
+                        td 
+                          a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                        if !actionsDictionary[index]
+                          td.text-danger.font-weight-bold Not Complete
+                        else
+                          td.text-success.font-weight-bold Complete
+                else
+                  if step.result.length === 0
+                    td 
                       .form-inline 
                         | (step not yet performed)
 
                         .hori-space-x2
-                          if workflow.path[index - 1].result.length > 0
+                          if !actionsDictionary[index - 1]
+                            a.btn-sm.btn-danger
+                              | Complete Previous Action First
+                          else 
                             a.btn-sm.btn-primary(href = `/action/${stepFormId}/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
                               img.small-icon(src = '/images/run_icon.svg')
                               | &nbsp; Perform Action
-                          else 
-                            a.btn-sm.btn-danger
-                              | Perform Previous Steps First
-                    td [n.a.]
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if !actionsDictionary[index]
+                      td.text-danger.font-weight-bold Not Complete
+                    else
+                      td.text-success.font-weight-bold Complete
 
     .vert-space-x2

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -58,6 +58,8 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
         actionsDictionary[stepIndex] = action.data.actionComplete;
 
         if (action.data.actionComplete) numberOfCompleteActions++;
+      } else {
+        actionsDictionary[stepIndex] = false;
       }
     }
 


### PR DESCRIPTION
- workflow steps are now unlocked only when the previous action has both been performed AND completed (for actions after free-form section, only when all free-form actions have been performed AND completed)
- tweaked displayed button and message text to clarify action performance vs. action completion
- changed designation of free-form section of APA Assembly workflow to account for new, non-free-form first action
- actions will now show as 'incomplete' if they have not yet been performed (previously showed as 'n.a.')
- general tweaks and improvements to interface code for workflow information pages ... clearer logic and separation of code depending on the step number and workflow type
- added Olga and Denis to list of personnel approved to sign off on Installation Survey results ... these two are a safe bet, and others can be added later