### PR TITLE
Tweaks and fixes to Frame Survey action interface pages ...

### DIFF
--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -214,7 +214,7 @@ block content
             - outOfSpecCount = 0
 
             for [key, value] of Object.entries(action.data.intake_xCorners)
-              if (value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance)
+              if (value.Actual < (-1.0 * value.Tolerance)) || (value.Actual > value.Tolerance)
                 - outOfSpecCount += 1
 
             .panel.panel-default
@@ -239,7 +239,7 @@ block content
                         tr
                           td #{value.Measurement}
 
-                          if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
+                          if (value.Actual >= (-1.0 * value.Tolerance)) && (value.Actual <= value.Tolerance)
                             td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
                           else
                             td.text-danger.font-weight-bold #{value.Actual.toFixed(3)}
@@ -259,8 +259,9 @@ block content
             - outOfSpecCount = 0
 
             for [key, value] of Object.entries(action.data.intake_planarity)
-              if (value.Actual !== '') && (value.Actual !== '-') && (value.Tolerance !== '-') && (value.Tolerance !== '') && ((value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance))
-                - outOfSpecCount += 1
+              if key < 19
+                if (value.Actual !== '') && (value.Actual !== '-') && (value.Tolerance !== '-') && (value.Tolerance !== '') && ((value.Actual < (-1.0 * value.Tolerance)) || (value.Actual > value.Tolerance))
+                  - outOfSpecCount += 1
 
             .panel.panel-default
             .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#planarityBox')
@@ -281,31 +282,32 @@ block content
 
                     tbody
                       for [key, value] of Object.entries(action.data.intake_planarity)
-                        tr
-                          td #{value.Measurement}
+                        if key < 19
+                          tr
+                            td #{value.Measurement}
 
-                          if (value.Actual !== '') && (value.Actual !== '-') && (value.Tolerance !== '-') && (value.Tolerance !== '')
-                            if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
-                              td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
+                            if (value.Actual === '') || (value.Actual === '-')
+                              td  #{value.Actual}
                             else
-                              td.text-danger.font-weight-bold #{value.Actual.toFixed(3)}
-                          else 
-                            if value.Tolerance !== '-'
-                              td #{value.Actual}
+                              if (value.Tolerance === '') || (value.Tolerance === '-')
+                                td #{value.Actual.toFixed(3)}
+                              else 
+                                if (value.Actual >= (-1.0 * value.Tolerance)) && (value.Actual <= value.Tolerance)
+                                  td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
+                                else
+                                  td.text-danger.font-weight-bold #{value.Actual.toFixed(3)}
+
+                            td #{value.Units}
+
+                            if (value.Tolerance === '') || (value.Tolerance === '-')
+                              td #{value.Tolerance}
                             else 
-                              td #{value.Actual.toFixed(2)}
+                              td #{value.Tolerance.toFixed(2)}
 
-                          td #{value.Units}
-
-                          if (value.Tolerance !== '') && (value.Tolerance !== '-')
-                            td #{value.Tolerance.toFixed(2)}
-                          else 
-                            td #{value.Tolerance}
-
-                          if value.Measurement === 'Cross corner deviation'
-                            td For completeness of calculations only - please refer to the 'Manual Cross Corner Measurements' above for the measured values
-                          else
-                            td #{value.Comment}
+                            if value.Measurement === 'Cross corner deviation'
+                              td For completeness of calculations only - please refer to the 'Manual Cross Corner Measurements' above for the measured values
+                            else
+                              td #{value.Comment}
         else
           .vert-space-x1
             .panel.panel-default
@@ -323,10 +325,10 @@ block content
             for [key, value] of Object.entries(action.data.install_envelope)
               if value['Tolerance (±)'] != '-'
                 if key === 3 || key === 4
-                  if value['Max Deviation From Nominal'] >= value['Tolerance (±)']
+                  if value['Max Deviation From Nominal'] > value['Tolerance (±)']
                     - outOfSpecCount += 1
                 else
-                  if (value['Max Deviation From Nominal'] <= (-1.0 * value['Tolerance (±)'])) || (value['Max Deviation From Nominal'] >= value['Tolerance (±)'])
+                  if (value['Max Deviation From Nominal'] < (-1.0 * value['Tolerance (±)'])) || (value['Max Deviation From Nominal'] > value['Tolerance (±)'])
                     - outOfSpecCount += 1
 
             .panel.panel-default
@@ -374,12 +376,12 @@ block content
 
                           if value['Tolerance (±)'] != '-'
                             if key === 3 || key === 4
-                              if value['Max Deviation From Nominal'] < value['Tolerance (±)']
+                              if value['Max Deviation From Nominal'] <= value['Tolerance (±)']
                                 td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
                               else
                                 td.text-danger.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
                             else
-                              if (value['Max Deviation From Nominal'] > (-1.0 * value['Tolerance (±)'])) && (value['Max Deviation From Nominal'] < value['Tolerance (±)'])
+                              if (value['Max Deviation From Nominal'] >= (-1.0 * value['Tolerance (±)'])) && (value['Max Deviation From Nominal'] <= value['Tolerance (±)'])
                                 td.text-success.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
                               else
                                 td.text-danger.font-weight-bold #{value['Max Deviation From Nominal'].toFixed(2)}
@@ -399,7 +401,7 @@ block content
             - outOfSpecCount = 0
 
             for [key, value] of Object.entries(action.data.install_planarity)
-              if (value.Actual !== '') && (value.Actual !== '-') && (value.Tolerance !== '-') && (value.Tolerance !== '') && ((value.Actual <= (-1.0 * value.Tolerance)) || (value.Actual >= value.Tolerance))
+              if (value.Actual !== '') && (value.Actual !== '-') && (value.Tolerance !== '-') && (value.Tolerance !== '') && ((value.Actual < (-1.0 * value.Tolerance)) || (value.Actual > value.Tolerance))
                 - outOfSpecCount += 1
 
             .panel.panel-default
@@ -424,23 +426,23 @@ block content
                         tr
                           td #{value.Measurement}
 
-                          if (value.Actual !== '') && (value.Actual !== '-') && (value.Tolerance !== '-') && (value.Tolerance !== '')
-                            if (value.Actual > (-1.0 * value.Tolerance)) && (value.Actual < value.Tolerance)
-                              td.text-success.font-weight-bold #{value.Actual.toFixed(2)}
-                            else
-                              td.text-danger.font-weight-bold #{value.Actual.toFixed(2)}
-                          else 
-                            if value.Tolerance !== '-'
-                              td #{value.Actual}
+                          if (value.Actual === '') || (value.Actual === '-')
+                            td  #{value.Actual}
+                          else
+                            if (value.Tolerance === '') || (value.Tolerance === '-')
+                              td #{value.Actual.toFixed(3)}
                             else 
-                              td #{value.Actual.toFixed(2)}
+                              if (value.Actual >= (-1.0 * value.Tolerance)) && (value.Actual <= value.Tolerance)
+                                td.text-success.font-weight-bold #{value.Actual.toFixed(3)}
+                              else
+                                td.text-danger.font-weight-bold #{value.Actual.toFixed(3)}
 
                           td #{value.Units}
 
-                          if (value.Tolerance !== '') && (value.Tolerance !== '-')
-                            td #{value.Tolerance.toFixed(2)}
-                          else 
+                          if (value.Tolerance === '') || (value.Tolerance === '-')
                             td #{value.Tolerance}
+                          else 
+                            td #{value.Tolerance.toFixed(2)}
 
                           if value.Measurement === 'Cross corner deviation'
                             td For completeness of calculations only - please refer to the Intake Survey's 'Manual Cross Corner Measurements' for the measured values


### PR DESCRIPTION
- fixed a bug that would occur when both the actual and tolerance values in any row of either planarity results table are dashes (previously only accounted for the situation where one or the other was a dash)
- all calculated values now must satisfy the range given by: [-tolerance <= value <= +tolerance] to be acceptable (previously used < instead of <=)
- CERN-specific planarity results (LSS and Rib 1, etc.) are now hidden in the interface when displaying intake surveys ... they are still shown for the installation surveys, and the values still exist in the action records