### PR TITLE
Miscellaneous Requested Changes and Tweaks

### DIFF
--- a/app/lib/Forms.js
+++ b/app/lib/Forms.js
@@ -122,6 +122,9 @@ async function list(collection) {
 
   aggregation_stages.push(grouping);
 
+  // Sort the records into alphabetical order
+  aggregation_stages.push({ $sort: { formName: 1 } });
+
   // Query the specified records collection using the aggregation stages defined above
   let records = await db.collection(collection)
     .aggregate(aggregation_stages)

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -380,7 +380,7 @@ async function boardKitComponentsByLocation(location) {
 
 
 /// Retrieve a list of assembled APAs that match the specified production location and number
-async function apasByProductionDetails(location, number) {
+async function apaByProductionDetails(location, number) {
   let aggregation_stages = [];
 
   // Retrieve all assembled APAs records that have the same production location and number as the specified values
@@ -453,6 +453,6 @@ module.exports = {
   meshesByLocation,
   meshesByPartNumber,
   boardKitComponentsByLocation,
-  apasByProductionDetails,
+  apaByProductionDetails,
   componentsByTypeAndNumber,
 }

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -94,10 +94,15 @@ block content
                 img.small-icon(src = '/images/checklist_icon.svg')
                 | &nbsp; View JSON Record
 
-          .vert-space-x1
-            a.btn.btn-primary(href = `/action/${action.typeFormId}/unspec`)
-              img.small-icon(src = '/images/run_icon.svg')
-              | &nbsp; Perform New Action of This Type
+          .vert-space-x1 
+            if workflowAction
+              a.btn.btn-secondary.disabled(href = '')
+                img.small-icon(src = '/images/run_icon.svg')
+                | &nbsp; Perform New Actions of This Type via Workflows
+            else
+              a.btn.btn-primary(href = `/action/${action.typeFormId}/unspec`)
+                img.small-icon(src = '/images/run_icon.svg')
+                | &nbsp; Perform New Action of This Type
 
           if (action.typeFormId == 'x_tension_testing')
             .vert-space-x1 

--- a/app/pug/action_list.pug
+++ b/app/pug/action_list.pug
@@ -8,9 +8,14 @@ block content
   .container-fluid
     .vert-space-x2
       if singleType && actionTypeForm.tags && !actionTypeForm.tags.includes('Trash')
-        a.btn.btn-primary(href = `/action/${actionTypeForm.formId}/unspec`)
-          img.small-icon(src = '/images/run_icon.svg')
-          | &nbsp; Perform New Action of This Type
+        if workflowAction
+          a.btn.btn-secondary.disabled(href = '')
+            img.small-icon(src = '/images/run_icon.svg')
+            | &nbsp; Perform New Actions of This Type via Workflows
+        else
+          a.btn.btn-primary(href = `/action/${actionTypeForm.formId}/unspec`)
+            img.small-icon(src = '/images/run_icon.svg')
+            | &nbsp; Perform New Action of This Type
 
         .vert-space-x2
 

--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -61,15 +61,22 @@ block content
                 each typeFormName, i in actionFormsGroup.formName
                   - const typeFormId = actionFormsGroup.formId[i];
                   - const typeFormTags = actionFormsGroup.tags[i];
+                  - const workflowAction = actionFormsGroup.workflowAction[i]
 
                   if typeFormTags && !typeFormTags.includes('Trash')
                     tr
                       td.col-md-4
                         a(href = `/actions/${typeFormId}/list`) #{typeFormName}
                       td.col-md-2
-                        a.btn-sm.btn-primary(href = `/action/${typeFormId}/unspec`)
-                          img.small-icon(src = '/images/run_icon.svg')
-                          | &nbsp; Perform Action on Component
+                        if workflowAction
+                          a.btn-sm.btn-secondary.disabled(href = '')
+                            img.small-icon(src = '/images/run_icon.svg')
+                            | &nbsp; Perform New Actions of This Type via Workflows
+                        else
+                          a.btn-sm.btn-primary(href = `/action/${typeFormId}/unspec`)
+                            img.small-icon(src = '/images/run_icon.svg')
+                            | &nbsp; Perform Action on Component
+
                       td.col-md-2
                         a.btn-sm.btn-warning(href = `/actionTypes/${typeFormId}/edit`)
                           img.small-icon(src = '/images/edit_icon.svg')

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -111,7 +111,7 @@ block content
                 | &nbsp; View JSON Record
 
           .vert-space-x1 
-            if (component.formId === 'AssembledAPA' || component.formId === 'APAFrame')
+            if workflowComponent
               a.btn.btn-secondary.disabled(href = '')
                 img.small-icon(src = '/images/run_icon.svg')
                 | &nbsp; Create New Components of This Type via Workflows

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -111,9 +111,14 @@ block content
                 | &nbsp; View JSON Record
 
           .vert-space-x1 
-            a.btn.btn-primary(href = `/component/${component.formId}`)
-              img.small-icon(src = '/images/run_icon.svg')
-              | &nbsp; Create New Component of This Type
+            if (component.formId === 'AssembledAPA' || component.formId === 'APAFrame')
+              a.btn.btn-secondary.disabled(href = '')
+                img.small-icon(src = '/images/run_icon.svg')
+                | &nbsp; Create New Components of This Type via Workflows
+            else
+              a.btn.btn-primary(href = `/component/${component.formId}`)
+                img.small-icon(src = '/images/run_icon.svg')
+                | &nbsp; Create New Component of This Type
 
           .vert-space-x1
             a.btn.btn-primary(href = `/component/${component.componentUuid}/qrCodes`)
@@ -345,5 +350,12 @@ block content
           each typeForm in actionTypeForms
             if typeForm.componentTypes.includes(component.formName) && !typeForm.tags.includes('Trash')
               a.actionbutton.btn.btn-success(href = `/action/${typeForm.formId}/${component.componentUuid}`) #{typeForm.formName}
+
+          if component.formId === 'AssembledAPA'
+            .vert-space-x1
+              p <b>Actions of types not shown here must be performed through this component's 'APA Assembly' workflow</b>
+          else if component.formId === 'APAFrame'
+            .vert-space-x1
+              p <b>Actions of types not shown here must be performed through this component's 'Frame Assembly' workflow</b>
 
     .vert-space-x2

--- a/app/pug/component_list.pug
+++ b/app/pug/component_list.pug
@@ -8,9 +8,14 @@ block content
   .container-fluid
     .vert-space-x2
       if singleType && componentTypeForm.tags && !componentTypeForm.tags.includes('Trash')
-        a.btn.btn-primary(href = `/component/${componentTypeForm.formId}`)
-          img.small-icon(src = '/images/run_icon.svg')
-          | &nbsp; Create New Component of This Type
+        if (componentTypeForm.formId === 'AssembledAPA' || componentTypeForm.formId === 'APAFrame')
+          a.btn.btn-secondary.disabled(href = '')
+            img.small-icon(src = '/images/run_icon.svg')
+            | &nbsp; Create New Components of This Type via Workflows
+        else
+          a.btn.btn-primary(href = `/component/${componentTypeForm.formId}`)
+            img.small-icon(src = '/images/run_icon.svg')
+            | &nbsp; Create New Component of This Type
 
         .vert-space-x2
 

--- a/app/pug/component_list.pug
+++ b/app/pug/component_list.pug
@@ -8,7 +8,7 @@ block content
   .container-fluid
     .vert-space-x2
       if singleType && componentTypeForm.tags && !componentTypeForm.tags.includes('Trash')
-        if (componentTypeForm.formId === 'AssembledAPA' || componentTypeForm.formId === 'APAFrame')
+        if workflowComponent
           a.btn.btn-secondary.disabled(href = '')
             img.small-icon(src = '/images/run_icon.svg')
             | &nbsp; Create New Components of This Type via Workflows

--- a/app/pug/component_listTypes.pug
+++ b/app/pug/component_listTypes.pug
@@ -59,9 +59,15 @@ block content
                   td 0
 
                 td
-                  a.btn-sm.btn-primary(href = `/component/${typeFormId}`)
-                    img.small-icon(src = '/images/run_icon.svg')
-                    | &nbsp; Create New Component of This Type
+                  if (typeFormId === 'AssembledAPA' || typeFormId === 'APAFrame')
+                    a.btn-sm.btn-secondary.disabled(href = '')
+                      img.small-icon(src = '/images/run_icon.svg')
+                      | &nbsp; Create New Components of This Type via Workflows
+                  else
+                    a.btn-sm.btn-primary(href = `/component/${typeFormId}`)
+                      img.small-icon(src = '/images/run_icon.svg')
+                      | &nbsp; Create New Component of This Type
+
                 td
                   a.btn-sm.btn-warning(href = `/componentTypes/${typeFormId}/edit`)
                     img.small-icon(src = '/images/edit_icon.svg')

--- a/app/pug/search_actionsByIDOrReferencedUUID.pug
+++ b/app/pug/search_actionsByIDOrReferencedUUID.pug
@@ -44,6 +44,7 @@ block content
             select.form-control#actionTypeSelection
               option(value = '')          
               option(value = 'boardInstall') Board Installation (any layer, any side, any position)
+              option(value = 'winding') Winding (any layer)
 
         .col-md-1
 

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -91,6 +91,9 @@ block content
       if workflow.typeFormId === 'APA_Assembly'
         - freeSection_bgn = 3;
         - freeSection_end = 9;
+      else if workflow.typeFormId === 'FrameAssembly'
+        - freeSection_bgn = 3;
+        - freeSection_end = 4;
 
         - for (let i = freeSection_bgn - 1; i < freeSection_end; i++) {
           - if (!actionsDictionary[i])
@@ -166,7 +169,7 @@ block content
                   if actionTypeForms[typeFormId].formName == step.formName
                     - stepFormId = actionTypeForms[typeFormId].formId
 
-                if workflow.typeFormId === 'APA_Assembly'
+                if (workflow.typeFormId === 'APA_Assembly') || (workflow.typeFormId === 'FrameAssembly')
                   if index >= freeSection_bgn - 1 && index < freeSection_end
                     if step.result.length === 0
                       td

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -165,7 +165,7 @@ router.get('/search/workflowsByUUID/' + utils.uuid_regex, async function (req, r
 router.get('/search/apaByProductionDetails/:apaLocation/:apaNumber', async function (req, res, next) {
   try {
     // Retrieve a list of assembled APAs that match the specified record details
-    const assembledAPAs = await Search_OtherComponents.apasByProductionDetails(req.params.apaLocation, req.params.apaNumber);
+    const assembledAPAs = await Search_OtherComponents.apaByProductionDetails(req.params.apaLocation, req.params.apaNumber);
 
     // Return the list in JSON format
     return res.json(assembledAPAs);

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -251,6 +251,8 @@ router.get('/search/actionsByReferencedUUID/' + utils.uuid_regex + '/:actionType
 
     if (req.params.actionType === 'boardInstall') {
       actions = await Search_ActionsWorkflows.boardInstallByReferencedComponent(req.params.uuid);
+    } else if (req.params.actionType === 'winding') {
+      actions = await Search_ActionsWorkflows.windingByReferencedComponent(req.params.uuid);
     }
 
     // Return the list in JSON format

--- a/m2m/upload_frameSurveys.py
+++ b/m2m/upload_frameSurveys.py
@@ -11,13 +11,13 @@ from common import ConnectToAPI, EditAction
 ######################################
 
 # For uploading new or revised survey results, the following information is required:
-actionId_intake        = '664b7666004486ec08abe2cb'    # ID of the existing 'Intake Surveys' action to be edited (get from DB)
-actionId_installation  = '664b51b8004486ec08abe2bd'    # ID of the existing 'Installation Surveys' action to be edited (get from DB)
-dataFile_intakeM4Holes = '/user/majumdar/Desktop/Frame_Surveys/UK_Frames/TEMPLATE_F000_m4Holes.xlsx'     
+actionId_intake        = '000000000000000000000000'    # ID of the existing 'Intake Surveys' action to be edited (get from DB)
+actionId_installation  = '000000000000000000000000'    # ID of the existing 'Installation Surveys' action to be edited (get from DB)
+dataFile_intakeM4Holes = 'D:/Documents/2016 - 2024 Liverpool/DUNE/2023-10 APA Frame Planarity Surveys/UK_Frames/F000_m4Holes.xlsx'     
                                                        # Full path to the input data file containing INTAKE M4 HOLES SURVEY results (must be a string ending in '.xlsx')
-values_intakeXCorners  = [0.15, 1.00, 0.85]
-                                                       # Manual CROSS-CORNER measurement values (these should be provided by either Callum Holt or Ged Bell alongside the input data files)
-dataFile_allAnalyses   = '/user/majumdar/Desktop/Frame_Surveys/UK_Frames/TEMPLATE_F000_analyses.xlsx'
+values_intakeXCorners  = [0.00, 0.00, 0.00]
+                                                       # Manual CROSS-CORNER measurement values (these should be copied from the frame's 'Delivered Frame QA Checklist' action)
+dataFile_allAnalyses   = 'D:/Documents/2016 - 2024 Liverpool/DUNE/2023-10 APA Frame Planarity Surveys/UK_Frames/F000_analyses.xlsx'
                                                        # Full path to the input data file containing ALL OF THE ANALYSES' results (must be a string ending in '.xlsx')
 
 ######################################

--- a/m2m/upload_tensions.py
+++ b/m2m/upload_tensions.py
@@ -2,6 +2,8 @@
 import pandas as pd
 import numpy as np
 import sys
+import warnings
+warnings.simplefilter(action = 'ignore', category = FutureWarning)
 
 # Local Python imports
 from common import ConnectToAPI, EditAction


### PR DESCRIPTION
- re-instating code to disable warnings when uploading tension measurements (accidentally removed it in a previous commit)
- changing default user parameters in frame survey M2M upload script, to make it easier for myself in the future
- buttons in the 'Select Action Type to Perform' section of any component information page will now always be displayed in fixed alphabetical order, instead of changing order every time the page is refreshed
- setting the intake and installation surveys to be a free-form section within the Frame Assembly workflows
- small change to one of the search library functions' names, to make it consistent with the search's URL and other routing (same as all other search functions)

Extending Search for Action by Referenced Component
- added new option on interface page to search for winding actions (intended for finding referenced wire bobbin components)
- corresponding change in API route, and new bespoke library function to find all winding type actions that reference the provided UUID in the expected field
- removed unnecessary code from function for searching for board installation actions by referenced board UUID ... these actions are only ever performed on APAs, so there is no need to check the format of the component name - it will always be DUNE PID like

Removing ability to create new workflow components or perform new workflow actions outside of workflows
- components that are the subject of workflows (currently Assembled APAs and APA Frames) can no longer be created from the component information, single type component listing or component type listing pages
- actions that are part of workflows can no longer be performed from the component information, action information, single type action listing or action type listing pages
- non-workflow actions are still available to perform directly from a component's information page if applicable to the component type