### PR TITLE
Miscellaneous Updates and Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ docker compose down
 The code in this respository is organised as follows (for simplicity, normally hidden directories and files are not listed here):
 
 * `/app` : contains all of the code required for the APA DB app
-    * `/lib` : JavaScript functions that operate directly on and with the MongoDB database
-    * `/pug` : Pug templates for the web interface pages
-    * `/routes` : JavaScript functions that dictate which `/lib` functions are called when a user accesses a specific web interface URL, and which `/pug` template is displayed for that URL
+    * `/lib` : server-side JavaScript functions that operate directly on and with the MongoDB database
+    * `/pug` : Pug templates for the client-side web interface pages
+    * `/routes` : JavaScript functions that connect the client-side web interface with the server-side functions
     * `/scss` : static CSS styling, compiled at DB startup
-    * `/static` : various functions that operate at the web interface's individual page level
-        * `/css` : additional CSS style guides for specific pages
+    * `/static` : various functions that operate within the client-side web interface
+        * `/css` : additional CSS style guides for specific web interface pages
         * `/formio` : JavaScript code that governs the behaviour and appearance of the various Formio form components used by the web interface
         * `/images` : images that are used by the web interface
-        * `/js` : non-specific page level JavaScript functions, as well as external third-party libraries
-        * `/pages` : JavaScript code that governs the behaviour of specific pages (with each file in this subdirectory corresponding to the same-named file in the `/pug` subdirectory)
+        * `/js` : non-specific client-side JavaScript functions, as well as external third-party libraries
+        * `/pages` : JavaScript code that governs the behaviour of specific web interface pages (with each file in this subdirectory corresponding to the same-named file in the `/pug` subdirectory)
     * `app.js` : the main APA DB app
     * `index.js` : the 'launch point' for starting, connecting to and stopping the APA DB app
-* `/m2m` : contains standalone Python code for the machine-to-machine ('M2M') client scripts ... please see the [dedicated README](https://github.com/DUNE/dunedb/tree/staging/m2m#readme) for full details
+* `/m2m` : contains standalone Python code for the machine-to-machine ('M2M') scripts ... please see the [dedicated README](https://github.com/DUNE/dunedb/tree/staging/m2m#readme) for full details
 * `/okd` : files required for deployment of the APA DB on the OKD system at Fermilab
 
 

--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -89,7 +89,7 @@ async function collateInfo(componentUUID) {
     dunePID: '[no information found]',
     productionSite: '[no information found]',
     configuration: '[no information found]',
-    assemblyStatus: '',
+    assemblyStatus: -99.9,
     workflowID: '',
   };
 
@@ -185,7 +185,7 @@ async function collateInfo(componentUUID) {
       }
     }
 
-    collatedInfo.general.assemblyStatus = (numberOfCompleteActions === workflow.path.length - 1) ? 'Complete' : 'In Progress';
+    collatedInfo.general.assemblyStatus = (numberOfCompleteActions * 100.0) / (workflow.path.length - 1);
     collatedInfo.general.workflowID = workflow.workflowId;
   }
 

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -199,7 +199,7 @@ async function list(match_condition, options) {
   // Re-sort the records by last edit date ... most recent first
   aggregation_stages.push({ $sort: { lastEditDate: -1 } });
 
-  // Add aggregation stages for any additionally specified options
+  // Add aggregation stages for any additionally specified options that should be dealt with at the MongoDB aggregation stage
   if (options) {
     if (options.limit) aggregation_stages.push({ $limit: options.limit });
   }
@@ -210,6 +210,8 @@ async function list(match_condition, options) {
     .toArray();
 
   // Add the corresponding component name to each matching record, adjusting it depending on component type for easier readability (i.e. use shortened DUNE PIDs)
+  // NOTE: all workflows must have some kind of component name in order to determine where they are being performed in the section below ...
+  // ... so any workflow that does not yet have an associated component will be given a temporary fake UK-based component name here, purely for location matching
   for (let record of records) {
     if (record.stepResultIDs[0] != '') {
       const component = await Components.retrieve(record.stepResultIDs[0]);
@@ -226,7 +228,21 @@ async function list(match_condition, options) {
           record.componentName = record.stepResultIDs[0];
         }
       }
+    } else {
+      record.componentName = '99999-UK';
     }
+  }
+
+  // If listing 'APA Assembly' workflows, a location will have been specified in the 'options' - use the component name to filter out those workflows that do not match that location
+  // If listing any other type of workflow or all workflows regardless of type, no location matching is required and all workflows should 'pass' the filter
+  let filtered_records = [];
+
+  if (options.location) {
+    for (let record of records) {
+      if (record.componentName.slice(6) === options.location) filtered_records.push(record);
+    }
+  } else {
+    filtered_records = [...records];
   }
 
   // If listing a single type of workflow (i.e. if a match condition was specified), re-sort the records by the component name ... in reverse alphanumerical order
@@ -237,10 +253,10 @@ async function list(match_condition, options) {
     }
   };
 
-  if (match_condition) records.sort(byField('componentName'));
+  if (match_condition) filtered_records.sort(byField('componentName'));
 
   // Return the entire list of matching records
-  return records;
+  return filtered_records;
 }
 
 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -110,16 +110,6 @@ block content
                 img.small-icon(src = '/images/checklist_icon.svg')
                 | &nbsp; View JSON Record
 
-          .vert-space-x1 
-            if workflowComponent
-              a.btn.btn-secondary.disabled(href = '')
-                img.small-icon(src = '/images/run_icon.svg')
-                | &nbsp; Create New Components of This Type via Workflows
-            else
-              a.btn.btn-primary(href = `/component/${component.formId}`)
-                img.small-icon(src = '/images/run_icon.svg')
-                | &nbsp; Create New Component of This Type
-
           .vert-space-x1
             a.btn.btn-primary(href = `/component/${component.componentUuid}/qrCodes`)
               img.small-icon(src = '/images/checklist_icon.svg')
@@ -135,6 +125,19 @@ block content
               a.btn.btn-primary(href = `/component/${component.componentUuid}/execSummary`)
                 img.small-icon(src = '/images/checklist_icon.svg')
                 | &nbsp; View and print this APA's Executive Summary
+
+          .vert-space-x2
+            hr
+
+            .vert-space-x2   
+              if workflowComponent
+                a.btn.btn-secondary.disabled(href = '')
+                  img.small-icon(src = '/images/run_icon.svg')
+                  | &nbsp; Create New Components of This Type via Workflows
+              else
+                a.btn.btn-primary(href = `/component/${component.formId}`)
+                  img.small-icon(src = '/images/run_icon.svg')
+                  | &nbsp; Create New Component of This Type
 
         .col-sm-3
           #qr-code

--- a/app/pug/component_execSummary.pug
+++ b/app/pug/component_execSummary.pug
@@ -43,13 +43,13 @@ block allbody
               dd
                 a(href = `/component/${component.componentUuid}`, target = '_blank') #{component.componentUuid}
 
-              dt Assembly Status
+              dt Assembly Completion [%]
 
-              if ((collatedInfo.general.assemblyStatus) === '')
+              if ((collatedInfo.general.assemblyStatus) === -99.9)
                 dd [no associated workflow]
               else
                 dd
-                  a(href = `/workflow/${collatedInfo.general.workflowID}`, target = '_blank') #{collatedInfo.general.assemblyStatus}
+                  a(href = `/workflow/${collatedInfo.general.workflowID}`, target = '_blank') #{collatedInfo.general.assemblyStatus.toFixed(2)}
 
           .vert-space-x1.hori-space-x1
             p &nbsp; This summary generated on: 

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -32,12 +32,18 @@ block content
             dd
               a(href = `/workflow/${workflow.workflowId}`) #{workflow.workflowId}
 
-            dt Current Status 
+            dt Completion [%]
 
-            if workflowStatus == 'Complete'
-              dd.text-success.font-weight-bold #{workflowStatus}
-            else
-              dd.text-danger.font-weight-bold #{workflowStatus}
+            if workflowStatus < 50.0
+              dd.text-danger.font-weight-bold #{workflowStatus.toFixed(2)}
+            else if workflowStatus >= 50.0 && workflowStatus < 70.0
+              dd.text-warning.font-weight-bold #{workflowStatus.toFixed(2)}
+            else if workflowStatus >= 70.0 && workflowStatus < 90.0
+              dd.text-info.font-weight-bold #{workflowStatus.toFixed(2)}
+            else if workflowStatus >= 90.0 && workflowStatus < 100.0
+              dd.text-primary.font-weight-bold #{workflowStatus.toFixed(2)}
+            else 
+              dd.text-success.font-weight-bold #{workflowStatus.toFixed(2)}
 
             dt Current Version:
             dd This is version #{workflow.validity.version} of the workflow.

--- a/app/pug/workflow_list.pug
+++ b/app/pug/workflow_list.pug
@@ -23,7 +23,7 @@ block content
             th.col-md-1 Type Name
             th.col-md-1 Workflow ID
             th.col-md-1 Associated Component
-            th.col-md-1 Status
+            th.col-md-1 Completion [%]
             th.col-md-2 Next Action to Complete
             th.col-md-1
 
@@ -43,10 +43,16 @@ block content
                 else 
                   td (component not yet created)
 
-                if workflowStatuses[index] == 'Complete'
-                  td.text-success.font-weight-bold #{workflowStatuses[index]}
-                else
-                  td.text-danger.font-weight-bold #{workflowStatuses[index]}
+                if workflowStatuses[index] < 50.0
+                  td.text-danger.font-weight-bold #{workflowStatuses[index].toFixed(2)}
+                else if workflowStatuses[index] >= 50.0 && workflowStatuses[index] < 70.0
+                  td.text-warning.font-weight-bold #{workflowStatuses[index].toFixed(2)}
+                else if workflowStatuses[index] >= 70.0 && workflowStatuses[index] < 90.0
+                  td.text-info.font-weight-bold #{workflowStatuses[index].toFixed(2)}
+                else if workflowStatuses[index] >= 90.0 && workflowStatuses[index] < 100.0
+                  td.text-primary.font-weight-bold #{workflowStatuses[index].toFixed(2)}
+                else 
+                  td.text-success.font-weight-bold #{workflowStatuses[index].toFixed(2)}
 
                 td #{firstIncompleteActions[index]}
                 td

--- a/app/pug/workflow_listTypes.pug
+++ b/app/pug/workflow_listTypes.pug
@@ -50,8 +50,14 @@ block content
 
             if typeForm.tags && !typeForm.tags.includes('Trash')
               tr
-                td
-                  a(href = `/workflows/${typeFormId}/list`) #{typeForm.formName}
+                if typeFormId.slice(0, 12) === 'APA_Assembly'
+                  - const location = typeFormId.slice(13)
+
+                  td
+                    a(href = `/workflows/${typeForm.formId}/list?location=${location}`) #{typeForm.formName} (#{location})
+                else 
+                  td
+                    a(href = `/workflows/${typeForm.formId}/list`) #{typeForm.formName}
 
                 if typeForm.componentTypes && typeForm.componentTypes.length > 0
                   td 

--- a/app/routes/api/workflows.js
+++ b/app/routes/api/workflows.js
@@ -53,7 +53,7 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermissionJson('workf
     const workflows = await Workflows.list({ typeFormId: req.params.typeFormId });
 
     // Extract the ID field (in string format) from each workflow record, and save it into a list
-    // Additionally, determine if each workflow is complete or in progress, and save these statuses into a separate list
+    // Additionally, calculate the overall workflow status as the percentage of all action steps that have been completed, and save it into a separate list
     let workflowIDs = [];
     let workflowStatuses = [];
 
@@ -72,8 +72,7 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermissionJson('workf
         }
       }
 
-      const workflowStatus = (numberOfCompleteActions === workflow.stepResultIDs.length - 1) ? 'Complete' : 'In Progress';
-      workflowStatuses.push(workflowStatus);
+      workflowStatuses.push((numberOfCompleteActions * 100) / (workflow.stepResultIDs.length - 1));
     }
 
     // Return a list containing both the list of workflow IDs and the list of workflow statuses

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -46,8 +46,7 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
 
     // Retrieve and store the status of each action that has been performed (i.e. that has a result) - that is, the value (true or false) of the action's 'data.actionComplete' field
     // Note that this field is common across all action type forms that are used in workflows, and so it should always exist one way or the other
-    // At the same time, determine the overall status of the workflow - it is 'complete' only if every action is individually complete ...
-    // ... i.e. there are the same number of completed actions as there are total actions in the workflow path
+    // At the same time, calculate the overall status of the workflow as the percentage of all action steps that have been completed
     let actionsDictionary = {};
     let numberOfCompleteActions = 0;
 
@@ -63,7 +62,7 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
       }
     }
 
-    const workflowStatus = (numberOfCompleteActions === workflow.path.length - 1) ? 'Complete' : 'In Progress';
+    const workflowStatus = (numberOfCompleteActions * 100.0) / (workflow.path.length - 1);
 
     // Simultaneously retrieve lists of all component and action type forms that currently exist in their respective collections
     const [componentTypeForms, actionTypeForms] = await Promise.all([
@@ -240,8 +239,7 @@ router.get('/workflows/list', permissions.checkPermission('workflows:view'), asy
     // The first argument should be 'null' in order to match to any type form ID
     const workflows = await Workflows.list(null, { limit: 200 });
 
-    // For each workflow, determine its overall status - it is 'complete' only if every action is individually complete ...
-    // ... i.e. there are the same number of completed actions (specified by the value (true or false) of the action's 'data.actionComplete' field) as there are total actions in the workflow path
+    // For each workflow, calculate the overall status as the percentage of all action steps that have been completed
     // In addition, find which action (by type form name) is next to be completed, either because it hasn't yet been performed or because it is in progress
     let workflowStatuses = [];
     let firstIncompleteActions = [];
@@ -261,8 +259,7 @@ router.get('/workflows/list', permissions.checkPermission('workflows:view'), asy
         }
       }
 
-      const workflowStatus = (numberOfCompleteActions === workflow.stepResultIDs.length - 1) ? 'Complete' : 'In Progress';
-      workflowStatuses.push(workflowStatus);
+      workflowStatuses.push((numberOfCompleteActions * 100.0) / (workflow.stepResultIDs.length - 1));
 
       const firstIncompleteAction = (lastCompleteAction_stepIndex !== workflow.stepResultIDs.length - 1) ? (workflow.stepTypeForms[lastCompleteAction_stepIndex + 1]) : 'n.a.'
       firstIncompleteActions.push(firstIncompleteAction);
@@ -294,8 +291,7 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermission('workflows
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
     const workflows = await Workflows.list({ typeFormId: req.params.typeFormId }, { limit: 200 });
 
-    // For each workflow, determine its overall status - it is 'complete' only if every action is individually complete ...
-    // ... i.e. there are the same number of completed actions (specified by the value (true or false) of the action's 'data.actionComplete' field) as there are total actions in the workflow path
+    // For each workflow, calculate the overall status as the percentage of all action steps that have been completed
     // In addition, find which action (by type form name) is next to be completed, either because it hasn't yet been performed or because it is in progress
     let workflowStatuses = [];
     let firstIncompleteActions = [];
@@ -315,8 +311,7 @@ router.get('/workflows/:typeFormId/list', permissions.checkPermission('workflows
         }
       }
 
-      const workflowStatus = (numberOfCompleteActions === workflow.stepResultIDs.length - 1) ? 'Complete' : 'In Progress';
-      workflowStatuses.push(workflowStatus);
+      workflowStatuses.push((numberOfCompleteActions * 100.0) / (workflow.stepResultIDs.length - 1));
 
       const firstIncompleteAction = (lastCompleteAction_stepIndex !== workflow.stepResultIDs.length - 1) ? (workflow.stepTypeForms[lastCompleteAction_stepIndex + 1]) : 'n.a.'
       firstIncompleteActions.push(firstIncompleteAction);

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -282,8 +282,6 @@ class ComponentUUID extends TextFieldComponent {
         let info_target = $(this.refs.compUuidInfo[index]);
         info_target.prop('href', `/component/${value}`).text('link');
 
-        let componentTypeName = '[unknown type]';
-
         $.ajax({
           contentType: 'application/json',
           method: 'GET',
@@ -307,15 +305,47 @@ class ComponentUUID extends TextFieldComponent {
                         if (action.data.actionComplete) {
                           info_target.text(`\xa0 This ${component.formName} is ready for use ... click here for this component's information page`);
                         } else {
-                          info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (incomplete final QA checklist)... click here for this component's information page`);
+                          info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (Final QA Checklist is not complete)... click here for this component's information page`);
                         }
                       },
                     }).fail();
                   } else {
-                    info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (no final QA checklist)... click here for this component's information page`);
+                    info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (no Final QA Checklist)... click here for this component's information page`);
                   }
                 },
               }).fail();
+            } else if (component.formId === 'GroundingMeshPanel') {
+              $.ajax({
+                contentType: 'application/json',
+                method: 'GET',
+                url: `/json/actions/${'MeshQAInspection'}/list?uuid=${value}`,
+                dataType: 'json',
+                success: function (actionIDsList) {
+                  if (actionIDsList.length > 0) {
+                    $.ajax({
+                      contentType: 'application/json',
+                      method: 'GET',
+                      url: `/json/action/${actionIDsList[0]}`,
+                      dataType: 'json',
+                      success: function (action) {
+                        if (action.data.disposition === 'useAsIs') {
+                          info_target.text(`\xa0 This ${component.formName} is ready for use ... click here for this component's information page`);
+                        } else {
+                          info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (QA Inspection disposition is not 'Use As Is')... click here for this component's information page`);
+                        }
+                      },
+                    }).fail();
+                  } else {
+                    info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (no QA Inspection)... click here for this component's information page`);
+                  }
+                },
+              }).fail();
+            } else if (component.formId === 'wire_bobbin') {
+              if (component.data.meanBreakStrength >= 24.0) {
+                info_target.text(`\xa0 This ${component.formName} is ready for use ... click here for this component's information page`);
+              } else {
+                info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (mean break strength < 24.0 N)... click here for this component's information page`);
+              }
             } else {
               info_target.text(`\xa0 Click here for this component's information page`);
             }

--- a/m2m/README.md
+++ b/m2m/README.md
@@ -1,20 +1,20 @@
 # M2M Client Scripts
 
-A "machine-to-machine" (M2M) application is a way for a remote device (known as the "client") to communicate with the DB API directly, without the need for a human user and/or the web interface.
+A "machine-to-machine" (M2M) application is a way for a remote device (known as the "client") to communicate with the DB server directly, without the need for a human user and/or the web interface.
 
-An example of the usefulness of such an application might be where a computer is making many automated measurements of a particular component, and each of these measurements need to be uploaded (as an action performed on the component) to the DB.  Instead of a human user manually creating an action record for each measurement through the web interface, a M2M application connecting the computer and the DB API would allow each one to be uploaded in a completely automated fashion.
+An example of the usefulness of such an application might be where a computer is making many automated measurements of a particular component, and each of these measurements need to be uploaded (as an action performed on the component) to the DB.  Instead of a human user manually creating an action record for each measurement through the web interface, a M2M application connecting the computer and the DB server would allow each one to be uploaded in a completely automated fashion.
 
-This directory contains the code required to establish a connection between a client and the DB API, as well as a number of template scripts showing examples of how to use the M2M application.  All of the code is written in standard Python (**version 3.6** or above is recommended).
+This directory contains the code required to establish a connection between a client and the DB server, as well as a number of template scripts showing examples of how to use the M2M application.  All of the code is written in standard Python (**version 3.6** or above is recommended).
 
 
 ## Client Credentials
 
-Before any communication between client and API can take place, the client must prove that it is actually authorised to communicate with the API.  This is done via **client credentials**, which are stored in the `client_credentials.py` file, and consist of the following:
+Before any communication between client and server can take place, the client must prove that it is actually authorised to communicate with the server.  This is done via **client credentials**, which are stored in the `client_credentials.py` file, and consist of the following:
  
 * `client_id` : an ID string that identifies the client
 * `client_secret` : a long alphanumeric string that acts like a password
 * `auth0_domain` : the web address of the M2M application
-* `db_domain` : the web address of the DB API
+* `db_domain` : the web address of the DB server
 
 Each of the DB instances (development, staging and production) has its own set of credentials.
 
@@ -28,11 +28,12 @@ The *backend* code, located in the `common.py` file, governs the underlying func
 However, users will still need to call the various backend functions in their own user-created scripts.  The available functions and required arguments are as follows:
 
 * `ConnectToAPI()` : establish a connection between the client and the database API, returning the `connection` object and associated `headers`.  **This function must be called once at the start of every user-created script, and the connection must be manually closed at the end of the script.**
-* `ConvertShortUUID(shortUUID, connection, headers)` : convert a short UUID into a full one, and check if the full UUID corresponds to an existing component record, returning the full UUID as a string if so, or an error message if not
+
+* `ConvertShortUUID(shortUUID, connection, headers)` : convert a short UUID into a full one and check if it corresponds to an existing component record, returning the full UUID as a string if so, or an error message if not
     * `shortUUID` (string) : an existing short UUID, must be between 20 and 22 alphanumeric characters
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `CreateComponent(componentTypeFormID, componentData, connection, headers)` : create a new component, returning the full UUID as a string
+* `CreateComponent(componentTypeFormID, componentData, connection, headers)` : create a new component, returning the component's full UUID as a string
     * `componentTypeFormID` (string) : the type form ID of the component to be created
     * `componentData` (Python dictionary) : the data to be entered into the new component record's `component.data` section, arranged as a dictionary of `field: value` pairs  ... this is the same data that would be entered into the component's type form through the web interface
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
@@ -40,15 +41,15 @@ However, users will still need to call the various backend functions in their ow
 * `EditComponent(componentUUID, componentData_fields, componentData_values, connection, headers)` : edit an existing component record, returning the component's full UUID as a string
     * `componentUUID` (string) : the UUID of the component to be edited
     * `componentData_fields` (list of strings) : the component's type form field names which will have their values edited
-    * `componentData_values` (list) : the new values of the fields specified in the `componentData_fields` list
+    * `componentData_values` (list of variables) : the new values of the fields specified in the `componentData_fields` list
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `GetComponent(componentUUID, connection, headers [, version])` : get a specified version of an existing component record, returning the record as a Python dictionary
+* `GetComponent(componentUUID, connection, headers [, version])` : retrieve a specific version of an existing component record, returning the record as a Python dictionary
     * `componentUUID` (string) : the UUID of the component to be retrieved
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
     * `version` (integer) : [OPTIONAL] the desired version of the record to retrieve ... if not specified or set to '0', the most recent version will be retrieved
 
-* `GetListOfComponents(componentTypeFormID, connection, headers)` : get a list of the UUIDs of all components of the specified component type, returning a Python list of the UUIDs
+* `GetListOfComponents(componentTypeFormID, connection, headers)` : retrieve a list of all components of the specified type, returning a Python list of the component UUIDs
     * `componentTypeFormID` (string) : the type form ID of the components to be listed
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
@@ -61,23 +62,23 @@ However, users will still need to call the various backend functions in their ow
 * `EditAction(actionID, actionData_fields, actionData_values, connection, headers)` : edit an existing action record, returning the action ID as a string
     * `actionID` (string) : the ID of the action to be edited
     * `actionData_fields` (list of strings) : the action's type form field names which will have their values edited
-    * `actionData_values` (list) : the new values of the fields specified in the `actionData_fields` list
+    * `actionData_values` (list of variables) : the new values of the fields specified in the `actionData_fields` list
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `GetAction(actionID, connection, headers [, version])` : get a specified version of an existing action record, returning the record as a Python dictionary
+* `GetAction(actionID, connection, headers [, version])` : retrieve a specific version of an existing action record, returning the record as a Python dictionary
     * `actionID` (string) : the ID of the action to be retrieved
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
     * `version` (integer) : [OPTIONAL] the desired version of the record to retrieve ... if not specified or set to '0', the most recent version will be retrieved
 
-* `GetListOfActions(actionTypeFormID, connection, headers)` : get a list of the action IDs of all actions of the specified action type, returning a Python list of the IDs
+* `GetListOfActions(actionTypeFormID, connection, headers)` : retrieve a list of all actions of the specified type, returning a Python list of the action IDs
     * `actionTypeFormID` (string) : the type form ID of the actions to be listed
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `GetWorkflow(workflowID, connection, headers)` : get the latest version of an existing action record, returning the record as a Python dictionary
+* `GetWorkflow(workflowID, connection, headers)` : retrieve the latest version of an existing workflow record, returning the record as a Python dictionary
     * `workflowID` (string) : the ID of the workflow to be retrieved
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `GetListOfWorkflows(workflowTypeFormID, connection, headers)` : get a list of the workflow IDs of all workflows of the specified workflow type, returning a Python list of the IDs
+* `GetListOfWorkflows(workflowTypeFormID, connection, headers)` : get a list of all workflows of the specified type, returning Python lists of the workflow IDs and workflow statuses
     * `workflowTypeFormID` (string) : the type form ID of the workflows to be listed
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
@@ -105,8 +106,8 @@ As noted above, one of the best use cases for the M2M application is uploading m
 * `ExtractResults_IntakePlanarity(dataFile)` (in `upload_frameSurveys.py`) : extract frame intake planarity analysis results, returning a Python dictionary containing the results arranged as `field: value` pairs
     * `dataFile` (string) : an input file, in `.xlsx` format, containing the calculated planarity analysis results
 
-* `SetupResults_IntakeXCorners(values)` (in `upload_frameSurveys.py`) : set up and return a Python dictionary of frame intake cross-corner measurement results
-    * `values` (list) : a Python list of cross-corner measurements, provided alongside the input data file(s) containing other survey results
+* `SetupResults_IntakeXCorners(values)` (in `upload_frameSurveys.py`) : set up and return a Python dictionary of frame intake cross-corner measurement results arranged as `field: value` pairs
+    * `values` (list) : a Python list of cross-corner measurements, which can be found in the APA frame's 'Delivered Frame QA Checks' action
 
 * `ExtractResults_InstallationSurveys(dataFile)` (in `upload_frameSurveys.py`) : extract APA frame installation envelope and planarity analysis results, returning Python dictionaries containing the results arranged as `field: value` pairs
     * `dataFile` (string) : an input file, in `.xlsx` format, containing the calculated envelope and planarity analysis results

--- a/m2m/template_getRecords.py
+++ b/m2m/template_getRecords.py
@@ -1,11 +1,11 @@
 # Local Python imports
-from common import ConnectToAPI, GetComponent, GetListOfComponents, GetAction, GetListOfActions
+from common import ConnectToAPI, GetComponent, GetListOfComponents, GetAction, GetListOfActions, GetWorkflow, GetListOfWorkflows
 
 
 # Main script function
 if __name__ == '__main__':
     print()
-    
+
     # Set up a connection to the database API and get the connection request headers
     # This must be done at the beginning of this main script function, but ONLY ONCE
     connection, headers = ConnectToAPI()
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     # User-defined script functionality goes here
 
     # Retrieving a single existing component record requires only the UUID
-    # Call the component retrieval function, which take the UUID as its first argument
+    # Call the component retrieval function, which takes the UUID as its first argument
     # The second and third arguments must ALWAYS be 'connection' and 'headers' respectively
     # The optional fourth argument is the desired version of the component record ... if this is not specified or set to '0', the most recent version will be retrieved
     # If successful, the function returns the latest version of the component record as a Python dictionary (if not, an error message is automatically displayed)
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     print()
 
     # Retrieving a list of all components of a single type requires only the component type form ID (NOT THE TYPE FORM NAME!)
-    # Call the component listing function, which take the type form ID as its first argument
+    # Call the component listing function, which takes the type form ID as its first argument
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
     # If successful, the function returns a list of component UUIDs, with each UUID being an individual string
     componentTypeFormID = 'basic_component_2'
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     print(componentUUIDs)
 
     # Retrieving a single existing action record requires only the ID
-    # Call the action retrieval function, which take the ID as its first argument
+    # Call the action retrieval function, which takes the ID as its first argument
     # The second and third arguments must ALWAYS be 'connection' and 'headers' respectively
     # The optional fourth argument is the desired version of the action record ... if this is not specified or set to '0', the most recent version will be retrieved
     # If successful, the function returns the latest version of the action record as a Python dictionary (if not, an error message is automatically displayed)
@@ -44,9 +44,9 @@ if __name__ == '__main__':
     action = GetAction(actionID, connection, headers, version = 0)
     print(action)
     print()
-    
+
     # Retrieving a list of all actions of a single type requires only the action type form ID (NOT THE TYPE FORM NAME!)
-    # Call the action listing function, which take the type form ID as its first argument
+    # Call the action listing function, which takes the type form ID as its first argument
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
     # If successful, the function returns a list of action IDs, with each ID being an individual string
     actionTypeFormID = 'my_action'
@@ -54,6 +54,27 @@ if __name__ == '__main__':
     actionIDs = GetListOfActions(actionTypeFormID, connection, headers)
     print(f" Found {len(actionIDs)} actions with type form ID: '{actionTypeFormID}'")
     print(actionIDs)
+
+    # Retrieving a single existing workflow record requires only the ID
+    # Call the workflow retrieval function, which takes the ID as its first argument
+    # The second and third arguments must ALWAYS be 'connection' and 'headers' respectively
+    # If successful, the function returns the latest version of the workflow record as a Python dictionary (if not, an error message is automatically displayed)
+    workflowID = '668ed67ee7db83204afd723f'
+
+    workflow = GetWorkflow(workflowID, connection, headers)
+    print(workflow)
+    print()
+
+    # Retrieving a list of all workflows of a single type requires only the workflow type form ID (NOT THE TYPE FORM NAME!)
+    # Call the workflow listing function, which takes the type form ID as its first argument
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    # If successful, the function returns two lists - one of workflow IDs (with each ID being an individual string), and the other of workflow statuses
+    workflowTypeFormID = 'APA_Assembly'
+
+    workflowIDs, workflowStatuses = GetListOfWorkflows(workflowTypeFormID, connection, headers)
+    print(f" Found {len(workflowIDs)} workflows with type form ID: '{workflowTypeFormID}'")
+    print(workflowIDs)
+    print(workflowStatuses)
 
     ########################################
 


### PR DESCRIPTION
Small updates to M2M scripts and README
- all backend M2M functions now use the 'json.loads' function to deserialise the server response ... previously some were using explicit string manipulations instead, which does work but isn't really the correct way to do it
- increased the M2M connection timeout to 60 seconds ... found that some retrieval requests relating to workflows take more than the previously used 10 seconds
- added examples for the recently added GetWorkflow and GetListOfWorkflows backend functions to the GetRecords template script
- updated M2M and general READMEs with some requested changes for clarity

Additional component usability checks (requested by Sotiris)
- grounding mesh panels should have had a QA Inspection performed, and the inspection disposition should be 'use as is'
- wire bobbins should have a mean break strength >= 24 N

Changes to determination of workflow status
- status is now given as the percentage of all action steps that have been completed, instead of just a binary complete vs. incomplete string
- when displayed on the workflow information and listing pages, the completion percentage is colour-coded for convenience

Splitting listings of UK vs. US APA Assembly workflows (requested by Sotiris)
- the workflow type listing page now has separate entries for UK and US APA Assembly workflows
- each of these entries now links to a list of ONLY the APA Assembly workflows that have been performed in the corresponding location
- location matching is based on the DUNE PID of the corresponding APA component ... workflows that do not have an associated APA are by default put into the UK list
- overall all-types workflow listing page and listing pages for other workflow types are unchanged

Small change to component information page layout (requested by Brian)
- the 'create new component of this type' button is now positioned below the others, and with a space between them to avoid accidental usage
