### PR TITLE
Follow-up tweak and bug fix ...

### DIFF
--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -237,9 +237,13 @@ async function list(match_condition, options) {
   // If listing any other type of workflow or all workflows regardless of type, no location matching is required and all workflows should 'pass' the filter
   let filtered_records = [];
 
-  if (options.location) {
-    for (let record of records) {
-      if (record.componentName.slice(6) === options.location) filtered_records.push(record);
+  if (options) {
+    if (options.location) {
+      for (let record of records) {
+        if (record.componentName.slice(6) === options.location) filtered_records.push(record);
+      }
+    } else {
+      filtered_records = [...records];
     }
   } else {
     filtered_records = [...records];

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -328,10 +328,10 @@ class ComponentUUID extends TextFieldComponent {
                       url: `/json/action/${actionIDsList[0]}`,
                       dataType: 'json',
                       success: function (action) {
-                        if (action.data.disposition === 'useAsIs') {
+                        if ((action.data.disposition === 'useAsIs') || (action.data.disposition === 'conformant')) {
                           info_target.text(`\xa0 This ${component.formName} is ready for use ... click here for this component's information page`);
                         } else {
-                          info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (QA Inspection disposition is not 'Use As Is')... click here for this component's information page`);
+                          info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (QA Inspection disposition is not 'Use As Is' or 'Conformant')... click here for this component's information page`);
                         }
                       },
                     }).fail();


### PR DESCRIPTION
- grounding mesh panels should additionally be set as 'ready to use' if their QA disposition is 'conformant'
- bug fix for the API workflow listing route ... this one does not use the 'options' parameter (unlike the equivalent interface route), so it was failing to find a non-existent 'location' field