### PR TITLE
Miscellaneous Requested Changes

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -38,6 +38,14 @@ async function save(input, req) {
     }
   }
 
+  // Check that certain relevant fields do actually have some user-defined data in them if the action is being 'completed' (specific to the particular action type form)
+  // This is designed to stop users from performing and 'completing' blank actions in order to skip ahead in workflows, but this way it does not require any fields to be 'required' in the type form
+  if (input.data.actionComplete) {
+    if ((input.typeFormId === 'x_tension_testing') && (input.data.measuredTensions_sideA.length === 0) && (input.data.measuredTensions_sideB.length === 0)) {
+      throw new Error(`Actions:save() - this action does not contain any tension measurements, but has been set as 'complete' ... please uncheck the 'Action Complete' box to submit!`);
+    }
+  }
+
   // Set up a new record object, and immediately add information, either directly or inherited from the 'input' object
   // If no type form name has been specified in the 'input' object, use the value from the type form instead
   let newRecord = {};

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -76,6 +76,17 @@ module.exports = {
     sotirisVlachos: 'Sotiris Vlachos',
   },
 
+  // A list of Auth0 user IDs (across all DB instances that they have accounts on) for the personnel in the 'dictionary_apaFactoryLeads' dictionary above
+  // Also included are the current DB admins, so they can have access for testing and debugging any issues
+  listIDs_apaFactoryLeads: [
+    'auth0|64567419151ddf91659e4f3a',                                                                     // Ed Blucher (Production)
+    'auth0|6467c2cd7446c74d64aa82f6',                                                                     // Alberto Marchionni (Production)
+    'auth0|6543ac95a5b46c922b92fc5b',                                                                     // Radosav Pantelic (Production)
+    'auth0|6419d07e67b64413cd0679f5',                                                                     // Sotiris Vlachos (Production)
+    'auth0|62c1f26dd68f53308071c91a', 'auth0|6247211d7ca173006f55b951',                                   // Brian Rebel (Staging, Production)
+    'auth0|62366229e644f4006ff1b144', 'auth0|6236627bcd1229006a1e5c54', 'auth0|623662b39e63f500683a210f', // Krish Majumdar (Staging, Production, Development)
+  ],
+
   // A dictionary of personnel who are authorised to sign-off on tension controls
   dictionary_tensionControlSignoff: {
     vincentBaker: 'Vincent Baker',

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -120,56 +120,60 @@ block content
       #typeform
 
     .vert-space-x1
-      if (action.typeFormId == 'x_tension_testing') && (retensionedWires_versions[0] !== null)
-        dt Most recently re-tensioned wires / wire segments (comparing versions #{retensionedWires_versions[1]} and #{retensionedWires_versions[0]}):
+      if (action.typeFormId == 'x_tension_testing')
+        dt Comparison to this layer's winding action:
+        dd Found #{numberOfReplacedWires[0]} on Side A and #{numberOfReplacedWires[1]} on Side B 
 
-        .row
-          .col-md-6
-            .panel.panel-default
-            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxA')
-              | #{retensionedWires_values[0].length} on side A (found #{numberOfReplacedWires[0]} in this layer's winding action): 
-              i.chevron.fa.fa-fw 
+        if (retensionedWires_versions[0] !== null)
+          dt Most recently re-tensioned wires / wire segments (comparing versions #{retensionedWires_versions[1]} and #{retensionedWires_versions[0]}):
 
-            .collapse#reTensionsBoxA
-              if retensionedWires_values[0].length > 0
-                .vert-space-x1.border-success.border.rounded.p-2
-                  dd
-                    table.table
-                      thead
-                        tr
-                          th.col-md-2 Wire / Wire Segment
-                          th.col-md-2 Original Tension (N)
-                          th.col-md-2 Latest Tension (N)
+          .row
+            .col-md-6
+              .panel.panel-default
+              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxA')
+                | #{retensionedWires_values[0].length} on side A: 
+                i.chevron.fa.fa-fw 
 
-                      tbody
-                        each changedTension in retensionedWires_values[0]
+              .collapse#reTensionsBoxA
+                if retensionedWires_values[0].length > 0
+                  .vert-space-x1.border-success.border.rounded.p-2
+                    dd
+                      table.table
+                        thead
                           tr
-                            td #{changedTension[0]}
-                            td #{changedTension[1]}
-                            td #{changedTension[2]}
-          .col-md-6
-            .panel.panel-default
-            .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxB')
-              | #{retensionedWires_values[1].length} on side B (found #{numberOfReplacedWires[1]} in this layer's winding action): 
-              i.chevron.fa.fa-fw 
+                            th.col-md-2 Wire / Wire Segment
+                            th.col-md-2 Original Tension (N)
+                            th.col-md-2 Latest Tension (N)
 
-            .collapse#reTensionsBoxB
-              if retensionedWires_values[1].length > 0
-                .vert-space-x1.border-success.border.rounded.p-2
-                  dd
-                    table.table
-                      thead
-                        tr
-                          th.col-md-2 Wire / Wire Segment
-                          th.col-md-2 Original Tension (N)
-                          th.col-md-2 Latest Tension (N)
+                        tbody
+                          each changedTension in retensionedWires_values[0]
+                            tr
+                              td #{changedTension[0]}
+                              td #{changedTension[1]}
+                              td #{changedTension[2]}
+            .col-md-6
+              .panel.panel-default
+              .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#reTensionsBoxB')
+                | #{retensionedWires_values[1].length} on side B: 
+                i.chevron.fa.fa-fw 
 
-                      tbody
-                        each changedTension in retensionedWires_values[1]
+              .collapse#reTensionsBoxB
+                if retensionedWires_values[1].length > 0
+                  .vert-space-x1.border-success.border.rounded.p-2
+                    dd
+                      table.table
+                        thead
                           tr
-                            td #{changedTension[0]}
-                            td #{changedTension[1]}
-                            td #{changedTension[2]}
+                            th.col-md-2 Wire / Wire Segment
+                            th.col-md-2 Original Tension (N)
+                            th.col-md-2 Latest Tension (N)
+
+                        tbody
+                          each changedTension in retensionedWires_values[1]
+                            tr
+                              td #{changedTension[0]}
+                              td #{changedTension[1]}
+                              td #{changedTension[2]}
 
         .vert-space-x2 
 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -320,7 +320,22 @@ block content
     .vert-space-x1
       .row
         .col-sm-6
-          h4 Action History
+          if component.formId === 'AssembledAPA'
+            h4 Action History (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>Existing workflow actions can be accessed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
+                | workflow</b>
+          else if component.formId === 'APAFrame'
+            h4 Action History (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>Existing workflow actions can be accessed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
+                | workflow</b>
+          else 
+            h4 Action History
 
           hr
 
@@ -346,19 +361,27 @@ block content
                       +dateTimeFormat(action.lastEditDate)
 
         .col-sm-6
-          h4 Select an Action Type to Perform
+          if component.formId === 'AssembledAPA'
+            h4 Select an Action Type to Perform (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>New workflow actions must be performed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
+                | workflow</b>
+          else if component.formId === 'APAFrame'
+            h4 Select an Action Type to Perform (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>New workflow actions must be performed through this component's Frame Assembly 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
+                | workflow</b>
+          else 
+            h4 Select an Action Type to Perform
 
           hr
 
           each typeForm in actionTypeForms
             if typeForm.componentTypes.includes(component.formName) && !typeForm.tags.includes('Trash')
               a.actionbutton.btn.btn-success(href = `/action/${typeForm.formId}/${component.componentUuid}`) #{typeForm.formName}
-
-          if component.formId === 'AssembledAPA'
-            .vert-space-x1
-              p <b>Actions of types not shown here must be performed through this component's 'APA Assembly' workflow</b>
-          else if component.formId === 'APAFrame'
-            .vert-space-x1
-              p <b>Actions of types not shown here must be performed through this component's 'Frame Assembly' workflow</b>
 
     .vert-space-x2

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -53,6 +53,8 @@ block content
           li <b>or</b> all geometry boards of a <u>specified board part number</u> that have been received at any location
 
       p Users may select one of the available board reception locations or part numbers from the appropriate list, and a summary of information about each found board will be displayed in the search results panel on the right side of the page.
+        br
+        | The search may be optionally refined by the <b>board status</b> - that is, whether a board has been <b>rejected</b> (by performing a <u>Factory Rejection</u> action on it, and setting the action disposition to <u>Rejected</u>) or <b>accepted</b> (by either not performing a Factory Rejection action, or performing the action and setting the disposition to either <u>Use As Is</u> or <u>Remediatated</u>).
 
       p Please note that a geometry board is only deemed to be at a given location if it has either been intaken there, or has been recorded as being received there via a successfully submitted <b>Board Shipment Reception</b> action.
 

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -19,11 +19,13 @@ block content
       hr
 
       .row
-        .col-md-4
+        .col-md-3
           h4 Select Location
 
           .vert-space-x1
-            p Select a location from the options below.
+            p Select <b>either</b> a location below <b>or</b> a part number to the right.
+              br
+              | <b>This is a <u>required</u> parameter.</b>
 
           select.form-control#locationSelection
             option(value = '')
@@ -43,46 +45,65 @@ block content
           .vert-space-x2
             hr
 
-            h4 Select Part Number
+            h4 Select Status
 
-            .vert-space-x1
-              p Select a part number from the options below.
+            .vert-space-x1 
+              p Select a status below ... this is an optional parameter.
 
-            select.form-control#partNumberSelection
-              option(value = '')          
-              option(value = '8760051') 8760051 (G Foot Board Low Slot End) 
-              option(value = '8760054') 8760054 (G Foot Board Middle)
-              option(value = '8760062') 8760062 (G Foot Board High Slot End) 
-              option(value = '8760113') 8760113 (G Foot Board Position 4 & 7) 
-              option(value = '8760038') 8760038 (U Side Board End)
-              option(value = '8760040') 8760040 (U Side Board w/o Slot Middle) 
-              option(value = '8760042') 8760042 (U Side Board w/ Slot Middle) 
-              option(value = '8760044') 8760044 (U Foot Board High Slot End)
-              option(value = '8760057') 8760057 (U Foot Board Middle) 
-              option(value = '8760059') 8760059 (U Foot Board Low Slot End)
-              option(value = '8760111') 8760111 (U Foot Board Position 4 & 7)
-              option(value = '8760024') 8760024 (V Side Board End)
-              option(value = '8760026') 8760026 (V Middle Side Board w/o Slot)
-              option(value = '8760030') 8760030 (V Foot Board Middle)
-              option(value = '8760036') 8760036 (V Foot Board End)
-              option(value = '8760107') 8760107 (V Foot Board Middle Position 4 & 7)
-              option(value = '8760028') 8760028 (V Middle Side Board w/ Slot)
-              option(value = '8760032') 8760032 (X Foot Board End)
-              option(value = '8760034') 8760034 (X Foot Board Middle)
-              option(value = '8760109') 8760109 (X Foot Board Position 4 & 7)
-              option(value = '8760119') 8760119 (U Head Board Left End)
-              option(value = '8760115') 8760115 (U Head Board Middle)
-              option(value = '8760123') 8760123 (U Head Board Right End)
-              option(value = '8760122') 8760122 (G Head Board Left End)
-              option(value = '8760121') 8760121 (G Head Board Middle)
-              option(value = '8760120') 8760120 (G Head Board Right End)
-              option(value = '8760104') 8760104 (X Head Board)
-              option(value = '8760116') 8760116 (V Head Board Left End)
-              option(value = '8760108') 8760108 (V Head Board Middle and Right End)
+            select.form-control#statusSelection
+              option(value = 'any') (any)
+              option(value = 'accepted') Accepted at Factory 
+              option(value = 'rejected') Rejected at Factory 
+
+        .col-md-3
+          h4 Select Part Number
+
+          .vert-space-x1
+            p Select <b>either</b> a part number below <b>or</b> a location to the left.
+              br
+              | <b>This is a <u>required</u> parameter.</b>
+
+          select.form-control#partNumberSelection
+            option(value = '')          
+            option(value = '8760051') 8760051 (G Foot Board Low Slot End) 
+            option(value = '8760054') 8760054 (G Foot Board Middle)
+            option(value = '8760062') 8760062 (G Foot Board High Slot End) 
+            option(value = '8760113') 8760113 (G Foot Board Position 4 & 7) 
+            option(value = '8760038') 8760038 (U Side Board End)
+            option(value = '8760040') 8760040 (U Side Board w/o Slot Middle) 
+            option(value = '8760042') 8760042 (U Side Board w/ Slot Middle) 
+            option(value = '8760044') 8760044 (U Foot Board High Slot End)
+            option(value = '8760057') 8760057 (U Foot Board Middle) 
+            option(value = '8760059') 8760059 (U Foot Board Low Slot End)
+            option(value = '8760111') 8760111 (U Foot Board Position 4 & 7)
+            option(value = '8760024') 8760024 (V Side Board End)
+            option(value = '8760026') 8760026 (V Middle Side Board w/o Slot)
+            option(value = '8760030') 8760030 (V Foot Board Middle)
+            option(value = '8760036') 8760036 (V Foot Board End)
+            option(value = '8760107') 8760107 (V Foot Board Middle Position 4 & 7)
+            option(value = '8760028') 8760028 (V Middle Side Board w/ Slot)
+            option(value = '8760032') 8760032 (X Foot Board End)
+            option(value = '8760034') 8760034 (X Foot Board Middle)
+            option(value = '8760109') 8760109 (X Foot Board Position 4 & 7)
+            option(value = '8760119') 8760119 (U Head Board Left End)
+            option(value = '8760115') 8760115 (U Head Board Middle)
+            option(value = '8760123') 8760123 (U Head Board Right End)
+            option(value = '8760122') 8760122 (G Head Board Left End)
+            option(value = '8760121') 8760121 (G Head Board Middle)
+            option(value = '8760120') 8760120 (G Head Board Right End)
+            option(value = '8760104') 8760104 (X Head Board)
+            option(value = '8760116') 8760116 (V Head Board Left End)
+            option(value = '8760108') 8760108 (V Head Board Middle and Right End)
+
+          .vert-space-x2
+            hr
+
+            .vert-space-x2
+              button.btn-primary.btn-lg.float-right#confirmButton Perform Search
 
         .col-md-1
 
-        .col-md-7
+        .col-md-5
           h4 Search Results
 
           .vert-space-x1

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -8,10 +8,10 @@ const utils = require('../../lib/utils');
 
 
 /// Search for geometry boards that have been received at a specified location
-router.get('/search/geoBoardsByLocation/:location', async function (req, res, next) {
+router.get('/search/geoBoardsByLocation/:location/:status', async function (req, res, next) {
   try {
     // Retrieve a list of geometry boards, grouped by part number, that have been received at the specified location
-    const boardsByPartNumber = await Search_GeoBoards.boardsByLocation(req.params.location);
+    const boardsByPartNumber = await Search_GeoBoards.boardsByLocation(req.params.location, req.params.status);
 
     // Return the list in JSON format
     return res.json(boardsByPartNumber);
@@ -23,10 +23,10 @@ router.get('/search/geoBoardsByLocation/:location', async function (req, res, ne
 
 
 /// Search for geometry boards of a specified part number
-router.get('/search/geoBoardsByPartNumber/:partNumber', async function (req, res, next) {
+router.get('/search/geoBoardsByPartNumber/:partNumber/:status', async function (req, res, next) {
   try {
     // Retrieve a list of geometry boards, grouped by reception location, of the specified part number
-    const boardsByLocation = await Search_GeoBoards.boardsByPartNumber(req.params.partNumber);
+    const boardsByLocation = await Search_GeoBoards.boardsByPartNumber(req.params.partNumber, req.params.status);
 
     // Return the list in JSON format
     return res.json(boardsByLocation);

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -47,6 +47,10 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
     // If the specified component type is one that is the subject of a workflow, filter out any action types that should be performed through the workflow
     // First, retrieve the workflow type form, and then build an array of the workflow's action type form names from its path steps
     // Finally loop through the dictionary of all currently available action type forms, and remove those whose type form name appears in the array of workflow action type form names
+    // Then create a list of only the non-workflow actions that have already been performed on the component, using the same array of workflow action type form names from above
+    // For component types that are not the subject of a workflow, the list of action types remains unchanged, and the list of non-workflow actions is the same as the overall list retrieved above
+    let nonWorkflowActions = [];
+
     if (workflowComponent) {
       let workflowTypeForm = null;
 
@@ -69,6 +73,12 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
           delete actionTypeForms[typeFormID];
         }
       }
+
+      for (const action of actions) {
+        if (!(list_workflowActions.includes(action.typeFormName))) nonWorkflowActions.push(action);
+      }
+    } else {
+      nonWorkflowActions = actions;
     }
 
     // Most shipment and batch type components only hold very basic information (i.e. only the full UUIDs) about the individual sub-components that they contain
@@ -160,7 +170,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
       componentVersions,
       componentTypeForm,
       collectionDetails,
-      actions,
+      actions: nonWorkflowActions,
       actionTypeForms,
       dictionary_queries: req.query,
       dictionary_locations: utils.dictionary_locations,

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -346,6 +346,32 @@ class ComponentUUID extends TextFieldComponent {
               } else {
                 info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (mean break strength < 24.0 N)... click here for this component's information page`);
               }
+            } else if (component.formId === 'GeometryBoard') {
+              $.ajax({
+                contentType: 'application/json',
+                method: 'GET',
+                url: `/json/actions/${'FactoryBoardRejection'}/list?uuid=${value}`,
+                dataType: 'json',
+                success: function (actionIDsList) {
+                  if (actionIDsList.length == 0) {
+                    info_target.text(`\xa0 This ${component.formName} has been accepted and is ready for use ... click here for this component's information page`);
+                  } else {
+                    $.ajax({
+                      contentType: 'application/json',
+                      method: 'GET',
+                      url: `/json/action/${actionIDsList[0]}`,
+                      dataType: 'json',
+                      success: function (action) {
+                        if ((action.data.disposition === 'useAsIs') || (action.data.disposition === 'remediated')) {
+                          info_target.text(`\xa0 This ${component.formName} has been accepted and is ready for use ... click here for this component's information page`);
+                        } else {
+                          info_target.text(`\xa0 This ${component.formName} HAS BEEN REJECTED (via Factory Rejection action) ... click here for this component's information page`);
+                        }
+                      },
+                    }).fail();
+                  }
+                },
+              }).fail();
             } else {
               info_target.text(`\xa0 Click here for this component's information page`);
             }

--- a/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
+++ b/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
@@ -1,42 +1,54 @@
-// Declare variables to hold the (initially empty) user-specified board location and/or part number
+// Declare variables to hold the (initially empty) user-specified board location, part number and status
 let boardLocation = null;
 let boardPartNumber = null;
+let boardStatus = 'any';
 
 
-// Main function
-$(function () {
-  // When the selected location is changed, get the newly selected location from the corresponding page element
-  // If the location is valid, perform the appropriate jQuery 'ajax' call to make the search
+// Run a specific function when the page is loaded
+window.addEventListener('load', renderSearchForms);
+
+
+// Function to run when the page is loaded
+async function renderSearchForms() {
+  // When the selected location is changed, get the newly selected location
   $('#locationSelection').on('change', async function () {
     boardLocation = $('#locationSelection').val();
+  });
+
+  // When the selected board part number is changed, get the newly selected part number
+  $('#partNumberSelection').on('change', async function () {
+    boardPartNumber = $('#partNumberSelection').val();
+  });
+
+  // When the selected status is changed, get the newly selected status
+  $('#statusSelection').on('change', async function () {
+    boardStatus = $('#statusSelection').val();
+  });
+
+  // When the 'Perform Search' button is pressed, perform the search using the appropriate jQuery 'ajax' call and the current values of the search parameters
+  // Additionally, disable the 'Perform Search' button while the current search is being performed
+  $('#confirmButton').on('click', function () {
+    $('#confirmButton').prop('disabled', true);
 
     if (boardLocation) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/geoBoardsByLocation/${boardLocation}`,
+        url: `/json/search/geoBoardsByLocation/${boardLocation}/${boardStatus}`,
         dataType: 'json',
         success: postSuccess_location,
       }).fail(postFail);
-    }
-  });
-
-  // When the selected board part number is changed, get the newly selected part number from the corresponding page element
-  // If the part number is valid, perform the appropriate jQuery 'ajax' call to make the search
-  $('#partNumberSelection').on('change', async function () {
-    boardPartNumber = $('#partNumberSelection').val();
-
-    if (boardPartNumber) {
+    } else if (boardPartNumber) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/geoBoardsByPartNumber/${boardPartNumber}`,
+        url: `/json/search/geoBoardsByPartNumber/${boardPartNumber}/${boardStatus}`,
         dataType: 'json',
         success: postSuccess_partNumber,
       }).fail(postFail);
     }
-  });
-});
+  })
+}
 
 
 // Function to run for a successful search query by location
@@ -103,6 +115,9 @@ function postSuccess_location(result) {
       $('#results').append('<br>');
     }
   }
+
+  // Re-enable the 'Perform Search' button for the next search
+  $('#confirmButton').prop('disabled', false);
 };
 
 
@@ -170,6 +185,9 @@ function postSuccess_partNumber(result) {
       $('#results').append('<br>');
     }
   }
+
+  // Re-enable the 'Perform Search' button for the next search
+  $('#confirmButton').prop('disabled', false);
 };
 
 
@@ -181,4 +199,7 @@ function postFail(result, statusCode, statusMsg) {
   } else {
     console.log('POSTFAIL: ', `${statusMsg} (${statusCode})`);
   }
+
+  // Re-enable the 'Perform Search' button for the next search
+  $('#confirmButton').prop('disabled', false);
 };

--- a/m2m/upload_frameSurveys.py
+++ b/m2m/upload_frameSurveys.py
@@ -13,11 +13,11 @@ from common import ConnectToAPI, EditAction
 # For uploading new or revised survey results, the following information is required:
 actionId_intake        = '000000000000000000000000'    # ID of the existing 'Intake Surveys' action to be edited (get from DB)
 actionId_installation  = '000000000000000000000000'    # ID of the existing 'Installation Surveys' action to be edited (get from DB)
-dataFile_intakeM4Holes = 'D:/Documents/2016 - 2024 Liverpool/DUNE/2023-10 APA Frame Planarity Surveys/UK_Frames/F000_m4Holes.xlsx'     
+dataFile_intakeM4Holes = 'C:/Users/krish/Documents/2016 - 2024 Liverpool/DUNE/2023-10 APA Frame Planarity Surveys/UK_Frames/F000_m4Holes.xlsx'     
                                                        # Full path to the input data file containing INTAKE M4 HOLES SURVEY results (must be a string ending in '.xlsx')
 values_intakeXCorners  = [0.00, 0.00, 0.00]
                                                        # Manual CROSS-CORNER measurement values (these should be copied from the frame's 'Delivered Frame QA Checklist' action)
-dataFile_allAnalyses   = 'D:/Documents/2016 - 2024 Liverpool/DUNE/2023-10 APA Frame Planarity Surveys/UK_Frames/F000_analyses.xlsx'
+dataFile_allAnalyses   = 'C:/Users/krish/Documents/2016 - 2024 Liverpool/DUNE/2023-10 APA Frame Planarity Surveys/UK_Frames/F000_analyses.xlsx'
                                                        # Full path to the input data file containing ALL OF THE ANALYSES' results (must be a string ending in '.xlsx')
 
 ######################################


### PR DESCRIPTION
Updating default file locations in Frame Surveys M2M upload script

Changes relating to Geometry Board Rejection at Factories
- added new optional parameter to 'Search for Geometry Boards by Location or Part Number' to allow filtering by board status - accepted or rejected
- changes to API routes and library functions
- changes to interface page .pug and .js codes ... reworked layout, cleaned up static code, and search must now be explicitly started using the interface button
- updated Search Descriptions page
- when referencing a geometry board using the Formio Component UUID entity, the info message will now indicate if the board has been accepted or rejected

Changing action history display on information pages of workflow-related components
- for workflow-related component types (Assembled APAs and APA Frames), the 'action history' section of the component information page will now only show non-workflow actions
- a message is also now shown, directing users to view the component's workflow for accessing workflow actions (and the workflow is hyperlinked)
- non-workflow components are unchanged - all actions are shown in the action history section
- added hyperlink to workflow information page in the existing message that is displayed under the 'Select Action to Perform' section for workflow-related components
- made the section titles more explicit regarding workflow vs. non-workflow actions for workflow-related components

Requested tweak to Single Layer Tension Measurement action information pages
- the number of changed wires found in the corresponding winding action is now always shown, even if no inter-version tension comparison is available

Additional security checks when performing or editing certain action types
- it has been reported that certain people have been submitting empty APA QA Check actions on behalf of factory leads, in order to unlock APA Assembly workflow steps ahead of the current progress
- changed DB action submission function so that it now checks if the submitting user (i.e. the person who is logged in) is actually one of the factory leads (or DB admins) ... if not, the user will not be permitted to submit the action, and a message will be shown
- check is done on the user's Auth0 account ID, which cannot be changed ... better than the user's display name
- currently only applicable to 'Assembled APA QA Checks' actions ... all other actions can still be submitted by anyone with the correct basic permissions ... but this check can be extended to other action types if needed

Additional checks on user-submitted data when performing or editing certain action types
- similarly to previous commit, it has been reported that certain people have been submitting empty but 'completed' actions, in order to unlock APA Assembly workflow steps ahead of the current progress
- changed DB action submission function so that it now checks for the presence of actual data in certain fields if the action is set to 'complete' (specific to particular action types) ... if there is no data, the submission is denied and a message will be shown
- currently this only applies to 'Single Layer Tension Measurement' actions that have no tension measurements, but it can be extended to other action type / field combinations