### PR TITLE
Changes to the Search for Geometry Boards by Location or Part Number ...

### DIFF
--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -122,7 +122,7 @@ block content
     .vert-space-x1
       if (action.typeFormId == 'x_tension_testing')
         dt Comparison to this layer's winding action:
-        dd Found #{numberOfReplacedWires[0]} on Side A and #{numberOfReplacedWires[1]} on Side B 
+        dd The winding action indicates <u>#{numberOfReplacedWires[0]} replaced wires on Side A</u> and <u>#{numberOfReplacedWires[1]} replaced wires on Side B</u> 
 
         if (retensionedWires_versions[0] !== null)
           dt Most recently re-tensioned wires / wire segments (comparing versions #{retensionedWires_versions[1]} and #{retensionedWires_versions[0]}):

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -54,7 +54,10 @@ block content
 
       p Users may select one of the available board reception locations or part numbers from the appropriate list, and a summary of information about each found board will be displayed in the search results panel on the right side of the page.
         br
-        | The search may be optionally refined by the <b>board status</b> - that is, whether a board has been <b>rejected</b> (by performing a <u>Factory Rejection</u> action on it, and setting the action disposition to <u>Rejected</u>) or <b>accepted</b> (by either not performing a Factory Rejection action, or performing the action and setting the disposition to either <u>Use As Is</u> or <u>Remediatated</u>).
+        | The search may be optionally refined by the following parameters: 
+        ul
+          li <b>board acceptance status</b> - that is, whether a board has been <u>rejected</u> (by performing a <u>Factory Rejection</u> action on it, and setting the action disposition to <u>Rejected</u>) or <u>accepted</u> (by either not performing a Factory Rejection action, or performing the action and setting the disposition to either <u>Use As Is</u> or <u>Remediated</u>)
+          li <b>tooth strip attachment status</b> - whether a tooth strip has been attached to the board (by performing a <u>Tooth Strip Attachment</u> action on it)
 
       p Please note that a geometry board is only deemed to be at a given location if it has either been intaken there, or has been recorded as being received there via a successfully submitted <b>Board Shipment Reception</b> action.
 

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -45,15 +45,26 @@ block content
           .vert-space-x2
             hr
 
-            h4 Select Status
+            h4 Select Board Acceptance Status
 
             .vert-space-x1 
               p Select a status below ... this is an optional parameter.
 
-            select.form-control#statusSelection
+            select.form-control#acceptanceStatusSelection
               option(value = 'any') (any)
-              option(value = 'accepted') Accepted at Factory 
-              option(value = 'rejected') Rejected at Factory 
+              option(value = 'accepted') Board Accepted at Factory 
+              option(value = 'rejected') Board Rejected at Factory
+
+          .vert-space-x2
+            h4 Select Tooth Strip Attachment Status
+
+            .vert-space-x1 
+              p Select a status below ... this is an optional parameter.
+
+            select.form-control#toothStripStatusSelection
+              option(value = 'any') (any)
+              option(value = 'attached') Tooth Strip Attached
+              option(value = 'notAttached') Tooth Strip Not Yet Attached
 
         .col-md-3
           h4 Select Part Number

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -8,10 +8,10 @@ const utils = require('../../lib/utils');
 
 
 /// Search for geometry boards that have been received at a specified location
-router.get('/search/geoBoardsByLocation/:location/:status', async function (req, res, next) {
+router.get('/search/geoBoardsByLocation/:location/:acceptanceStatus/:toothStripStatus', async function (req, res, next) {
   try {
     // Retrieve a list of geometry boards, grouped by part number, that have been received at the specified location
-    const boardsByPartNumber = await Search_GeoBoards.boardsByLocation(req.params.location, req.params.status);
+    const boardsByPartNumber = await Search_GeoBoards.boardsByLocation(req.params.location, req.params.acceptanceStatus, req.params.toothStripStatus);
 
     // Return the list in JSON format
     return res.json(boardsByPartNumber);
@@ -23,10 +23,10 @@ router.get('/search/geoBoardsByLocation/:location/:status', async function (req,
 
 
 /// Search for geometry boards of a specified part number
-router.get('/search/geoBoardsByPartNumber/:partNumber/:status', async function (req, res, next) {
+router.get('/search/geoBoardsByPartNumber/:partNumber/:acceptanceStatus/:toothStripStatus', async function (req, res, next) {
   try {
     // Retrieve a list of geometry boards, grouped by reception location, of the specified part number
-    const boardsByLocation = await Search_GeoBoards.boardsByPartNumber(req.params.partNumber, req.params.status);
+    const boardsByLocation = await Search_GeoBoards.boardsByPartNumber(req.params.partNumber, req.params.acceptanceStatus, req.params.toothStripStatus);
 
     // Return the list in JSON format
     return res.json(boardsByLocation);

--- a/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
+++ b/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
@@ -1,7 +1,8 @@
-// Declare variables to hold the (initially empty) user-specified board location, part number and status
+// Declare variables to hold the (initially empty) user-specified board location, part number, board acceptance status and tooth strip attachment status
 let boardLocation = null;
 let boardPartNumber = null;
-let boardStatus = 'any';
+let acceptanceStatus = 'any';
+let toothStripStatus = 'any';
 
 
 // Run a specific function when the page is loaded
@@ -20,9 +21,14 @@ async function renderSearchForms() {
     boardPartNumber = $('#partNumberSelection').val();
   });
 
-  // When the selected status is changed, get the newly selected status
-  $('#statusSelection').on('change', async function () {
-    boardStatus = $('#statusSelection').val();
+  // When the selected board acceptance status is changed, get the newly selected status
+  $('#acceptanceStatusSelection').on('change', async function () {
+    acceptanceStatus = $('#acceptanceStatusSelection').val();
+  });
+
+  // When the selected tooth strip attachment status is changed, get the newly selected status
+  $('#toothStripStatusSelection').on('change', async function () {
+    toothStripStatus = $('#toothStripStatusSelection').val();
   });
 
   // When the 'Perform Search' button is pressed, perform the search using the appropriate jQuery 'ajax' call and the current values of the search parameters
@@ -34,7 +40,7 @@ async function renderSearchForms() {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/geoBoardsByLocation/${boardLocation}/${boardStatus}`,
+        url: `/json/search/geoBoardsByLocation/${boardLocation}/${acceptanceStatus}/${toothStripStatus}`,
         dataType: 'json',
         success: postSuccess_location,
       }).fail(postFail);
@@ -42,7 +48,7 @@ async function renderSearchForms() {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/geoBoardsByPartNumber/${boardPartNumber}/${boardStatus}`,
+        url: `/json/search/geoBoardsByPartNumber/${boardPartNumber}/${acceptanceStatus}/${toothStripStatus}`,
         dataType: 'json',
         success: postSuccess_partNumber,
       }).fail(postFail);
@@ -71,7 +77,7 @@ function postSuccess_location(result) {
 
   // If there are no search results, display a message to indicate this, but otherwise set up a table of the search results
   if (Object.keys(result).length === 0) {
-    $('#results').append('<b>There are no geometry boards at the specified location</b>');
+    $('#results').append('<b>There are no geometry boards at the given location with the specified options</b>');
   } else {
     for (const boardGroup of result) {
       const groupCount = `
@@ -141,7 +147,7 @@ function postSuccess_partNumber(result) {
 
   // If there are no search results, display a message to indicate this, but otherwise set up a table of the search results
   if (Object.keys(result).length === 0) {
-    $('#results').append('<b>No geometry boards of the given part number are at any location</b>');
+    $('#results').append('<b>There are no geometry boards of the given part number and specified options at any location</b>');
   } else {
     for (const boardGroup of result) {
       const groupCount = `


### PR DESCRIPTION
- added new optional parameter for checking if a tooth strip attachment action has been performed or not ... this can be selected in addition to the existing board acceptance status optional parameter
- corresponding changes to API routes and library function (rewrote the post-MongoDB parts of the latter for better logic when working with two optional parameters that can each take one of three values)
- fixed a bug where the displayed UKIDs in the search results did not always match the actual board that was being hyperlinked to (the results themselves were always correct - just the displayed UKIDs were sometimes wrong)
- updated Search Descriptions page
- [unrelated] small tweak to the newly added text for displaying how many changed wires were found in a particular layer's winding action from the tension measurement action