### PR TITLE
Reworking logic for searches involving user-changeable parameters ...

### DIFF
--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -54,7 +54,7 @@ block content
 
       p Users may select one of the available board reception locations or part numbers from the appropriate list, and a summary of information about each found board will be displayed in the search results panel on the right side of the page.
         br
-        | The search may be optionally refined by the following parameters: 
+        | Both searches may be optionally refined by the following parameters: 
         ul
           li <b>board acceptance status</b> - that is, whether a board has been <u>rejected</u> (by performing a <u>Factory Rejection</u> action on it, and setting the action disposition to <u>Rejected</u>) or <u>accepted</u> (by either not performing a Factory Rejection action, or performing the action and setting the disposition to either <u>Use As Is</u> or <u>Remediated</u>)
           li <b>tooth strip attachment status</b> - whether a tooth strip has been attached to the board (by performing a <u>Tooth Strip Attachment</u> action on it)
@@ -69,14 +69,14 @@ block content
 
       p This page may be used to search specifically for <b>geometry boards</b> under one of the following scenarios:
         ul
-          li <b>either</b> all geometry boards of any batch order number that have a <u>specified visual inspection disposition</u>, and optionally a <u>specified visual inspection issue</u>
+          li <b>either</b> all geometry boards of any batch order number that have a <u>specified visual inspection disposition</u>
           li <b>or</b> all geometry boards of a <u>specified batch order number</u> that have any visual inspection disposition
 
-      p Users may select one of the available dispositions from the list, along with a specific inspection issue if desired, and a summary of information about each found board will be displayed in the search results panel below the selection boxes.  In this scenario, only the disposition is <b>required</b>.
+      p Users may select one of the available dispositions from the list or enter an order number into the provided input box, and a summary of information about each found board will be displayed in the search results panel at the bottom of the page.
         br
-        |  Alternatively, users may manually enter an order number, and a summary of boards in that order will be shown.
+        | The search by disposition may be optionally refined by selecting a <u>visual inspection issue</u> from the provided list.
 
-      p Please note that, in either scenario, <b>a geometry board will only be displayed in the search results if a <u>Visual Inspection</u> action has been performed on it</b>.
+      p Please note that <b>a geometry board will only be displayed in the search results if a <u>Visual Inspection</u> action has been performed on it</b>.
 
       hr
 

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -49,6 +49,8 @@ block content
 
             .vert-space-x1 
               p Select a status below ... this is an optional parameter.
+                br
+                | It can be used alongside <b>either</b> required parameter.
 
             select.form-control#acceptanceStatusSelection
               option(value = 'any') (any)
@@ -60,6 +62,8 @@ block content
 
             .vert-space-x1 
               p Select a status below ... this is an optional parameter.
+                br
+                | It can be used alongside <b>either</b> required parameter.
 
             select.form-control#toothStripStatusSelection
               option(value = 'any') (any)

--- a/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
+++ b/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
@@ -20,7 +20,9 @@ block content
           h4 Select Disposition
 
           .vert-space-x1
-            p Select a visual inspection disposition from the options below.
+            p <b>Either</b> select a disposition below <b>or</b> set an order number to the right.
+              br
+              | <b>This is a <u>required</u> parameter.</b>
 
           select.form-control#dispositionSelection
             option(value = '')          
@@ -31,40 +33,49 @@ block content
             option(value = 'toBeDetermined') To be determined 
             option(value = 'boardIsConformant') Board Is Conformant
 
+          .vert-space-x2
+            hr
+
+            h4 Select Issue
+
+            .vert-space-x1
+              p Select an issue below ... this is an optional parameter.
+                br
+                | It is only used alongside the <b>disposition</b> required parameter.
+
+            select.form-control#issueSelection
+              option(value = 'any') (any)         
+              option(value = 'packagingDamaged') Packaging damaged 
+              option(value = 'scratches') Scratches 
+              option(value = 'exposedCopper') Exposed copper 
+              option(value = 'interruptedTraces') Copper trace(s) interrupted 
+              option(value = 'chipped') PCB chipped 
+              option(value = 'notFlat') PCB not flat
+              option(value = 'incorrectGeometry') Incorrect geometry 
+              option(value = 'incorrectThickness') Incorrect thickness
+              option(value = 'qrCodeProblem') QR code problem 
+              option(value = 'millMaxHolePlating') Issues with mill-max hole plating
+              option(value = 'extraneousMaterialOnBoard') Extraneous material on board 
+              option(value = 'fiducialPin') Fiducial pin more than 0.25 mm above board surface
+              option(value = 'other') Other
+
         .col-md-1 
 
         .col-md-5
           h4 Enter Order Number
 
           .vert-space-x1
-            p Enter a board order number below and press the 'Enter' key.
+            p <b>Either</b> enter an order number below <b>or</b> select a disposition to the left.
+              br
+              | <b>This is a <u>required</u> parameter.</b>
 
           input.form-control#orderNumberSelection
 
-      .row.vert-space-x2
-        .col-md-4
-          h4 Select Issue
+          .vert-space-x2
+            hr
 
-          .vert-space-x1
-            p Select a visual inspection issue from the options below.
-
-          select.form-control#issueSelection
-            option(value = '') (any)         
-            option(value = 'packagingDamaged') Packaging damaged 
-            option(value = 'scratches') Scratches 
-            option(value = 'exposedCopper') Exposed copper 
-            option(value = 'interruptedTraces') Copper trace(s) interrupted 
-            option(value = 'chipped') PCB chipped 
-            option(value = 'notFlat') PCB not flat
-            option(value = 'incorrectGeometry') Incorrect geometry 
-            option(value = 'incorrectThickness') Incorrect thickness
-            option(value = 'qrCodeProblem') QR code problem 
-            option(value = 'millMaxHolePlating') Issues with mill-max hole plating
-            option(value = 'extraneousMaterialOnBoard') Extraneous material on board 
-            option(value = 'fiducialPin') Fiducial pin more than 0.25 mm above board surface
-            option(value = 'other') Other
-
-        .col-md-6
+            .vert-space-x2
+              button.btn-primary.btn-lg.float-right#confirmButton Perform Search
 
     .vert-space-x2
       hr

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -38,14 +38,10 @@ router.get('/search/geoBoardsByPartNumber/:partNumber/:acceptanceStatus/:toothSt
 
 
 /// Search for geometry boards that have a specified visual inspection disposition
-router.get('/search/geoBoardsByVisualInspection/:disposition', async function (req, res, next) {
+router.get('/search/geoBoardsByVisualInspection/:disposition/:issue', async function (req, res, next) {
   try {
-    // This search query can have an optional query string for a specific inspection issue
-    // Parse out the string if it has been provided (as a non-empty string), or otherwise set it to 'null'
-    const issue = (req.query.issue !== '') ? req.query.issue : null;
-
-    // Retrieve a list of geometry boards, grouped by part number, that have the specified visual inspection disposition and optional issue
-    const boardsByLocation = await Search_GeoBoards.boardsByVisualInspection(req.params.disposition, issue);
+    // Retrieve a list of geometry boards, grouped by part number, that have the specified visual inspection disposition
+    const boardsByLocation = await Search_GeoBoards.boardsByVisualInspection(req.params.disposition, req.params.issue);
 
     // Return the list in JSON format
     return res.json(boardsByLocation);


### PR DESCRIPTION
- the current search logic (shared by all searches) fails if one or more of the required parameters can be changed by users ... the search will return matching results for both the original and user-changed versions of the associated record
- this is because the aggregation stage for matching to the parameters is done before the stage for selecting only the latest version of the record
- attempting to fix this by splitting the matching stage into multiple stages ... the first one (matching to component or action type form ID and/or component UUID or action ID) will remain as is - before version selection ... a second matching stage will now be done after the version selection, and will perform the matching to any user-changeable parameters
- new logic has been applied to the 'Search for Geometry Boards by Order Number', since this was the one where the issue has been specifically identified, plus the 'Search for Geometry Boards by Visual Inspection Disposition', since it shares the same interface page as the former
- if it works, the same changes can be applied to all other searches that involve matching to user-changeable parameters