### PR TITLE
Another attempt at the bug fix for displaying completion status ...

### DIFF
--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -33,7 +33,7 @@ block content
 
             dt Completion [%]
 
-            if workflow.completionStatus !== null
+            if workflow.completionStatus != null
               if workflow.completionStatus < 50.0
                 dd.text-danger.font-weight-bold #{workflow.completionStatus.toFixed(2)}
               else if workflow.completionStatus >= 50.0 && workflow.completionStatus < 70.0

--- a/app/pug/workflow_list.pug
+++ b/app/pug/workflow_list.pug
@@ -43,7 +43,7 @@ block content
                 else 
                   td (component not yet created)
 
-                if workflow.completionStatus !== null
+                if workflow.completionStatus != null
                   if workflow.completionStatus < 50.0
                     td.text-danger.font-weight-bold #{workflow.completionStatus.toFixed(2)}
                   else if workflow.completionStatus >= 50.0 && workflow.completionStatus < 70.0


### PR DESCRIPTION
- at the moment, the completion statuses will mostly be 'undefined' ... and as per the previous attempt at this fix, if the status is exactly zero, JS interprets it as 'null'
- using the '!== null' comparison only checks if it is 'null', not 'undefined' ... but since they are the same type of value, using '!= null' catches both