### PR TITLE
Testing new development setup with some small commits

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -119,6 +119,7 @@ module.exports = {
   dictionary_frameIntakeSignoff: {
     gedBell: 'Ged Bell',
     callumHolt: 'Callum Holt',
+    gwennMouster: 'Gwenn Mouster',
     sotirisVlachos: 'Sotiris Vlachos',
     kyleZeug: 'Kyle Zeug',
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     build: .


### PR DESCRIPTION
- added Gwenn to the list of personnel who are allowed to sign off on frame intake
- removed 'version' attribute from docker-compose file ... apparently this has been deprecated for a while now, and no longer does anything.  And it was creating a warning message on the new dev setup