### PR TITLE
Requested Changes and Layout Tweaks

### DIFF
--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -453,17 +453,28 @@ async function apasByProductionLocationAndNumber(location, number) {
 
 
 /// Retrieve lists of all assembled APAs that have and have not been completed up to and including the specified step in their assembly workflows
-async function apasByLastCompletedAssemblyStep(assemblyStep) {
+async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
   let action_aggregation_stages = [];
 
-  // Match against the type form ID to get records of all 'Asssmbled APA QA Check' actions that have been performed and completed at the specified assembly step
-  action_aggregation_stages.push({
-    $match: {
+  // Depending on which assembly step string has been passed to this function, match against the type form ID to get:
+  // ... either records of all 'Assembled APA QA Check' actions that have been performed and completed at the specified assembly step
+  // ... or records of all 'Completed APA QA Checklist' actions that have been performed and completed
+  let match_condition = {};
+
+  if (assemblyStep === 'assemblyComplete') {
+    match_condition = {
+      'typeFormId': 'CompletedAPAQCChecklist',
+      'data.actionComplete': true,
+    };
+  } else {
+    match_condition = {
       'typeFormId': 'AssembledAPAQACheck',
       'data.workflowSectionBeingQAed': assemblyStep,
       'data.actionComplete': true,
-    }
-  });
+    };
+  }
+
+  action_aggregation_stages.push({ $match: match_condition });
 
   // Select the latest version of each record, and pass through only the fields required for later use
   action_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
@@ -476,37 +487,44 @@ async function apasByLastCompletedAssemblyStep(assemblyStep) {
   });
 
   // Query the 'actions' records collection using the aggregation stages defined above
-  let apasCompletedToStep = await db.collection('actions')
+  let apasCompletedToStep_allLocations = await db.collection('actions')
     .aggregate(action_aggregation_stages)
     .toArray();
 
-  // At this point, we have a list of completed 'Assembled APA QA Check' action records
-  // But we actually want a list of the Assembled APA components that these actions have been performed on
-  // Loop over the action records, retrieve the associated component record, and add the desired information to each record
-  let uuids_apasCompletedToStep = []
+  // At this point, we have a list of completed 'Assembled APA QA Check' or 'Completed APA QA Checklist' action records
+  // But we actually want a list of the Assembled APA components that have been produced at the specified location and on which these actions have been performed
+  // Loop over the action records, retrieve the associated component record, and add the desired information to each record if the APA production location matches the specified one
+  let apasCompletedToStep_atLocation = [];
+  let uuids_apasCompletedToStep_atLocation = []
 
-  for (let action of apasCompletedToStep) {
-    uuids_apasCompletedToStep.push(action.componentUuid);
-
+  for (let action of apasCompletedToStep_allLocations) {
     const component = await Components.retrieve(MUUID.from(action.componentUuid).toString());
-    const name_splits = component.data.name.split('-');
 
-    action.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
-    action.workflowId = component.workflowId;
+    if (component.data.apaAssemblyLocation === location) {
+      uuids_apasCompletedToStep_atLocation.push(action.componentUuid);
+
+      const name_splits = component.data.name.split('-');
+
+      action.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+      action.workflowId = component.workflowId;
+
+      apasCompletedToStep_atLocation.push(action);
+    }
   }
 
   // Re-sort the records by the component name, in reverse alphanumerical order
   // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  apasCompletedToStep.sort(byField('componentName'));
+  apasCompletedToStep_atLocation.sort(byField('componentName'));
 
   let comp_aggregation_stages = [];
 
-  // Now we also want a list of the Assembled APA components that these actions have NOT been performed on
-  // Match against the type form ID and component UUID to get records of all 'Assembled APA' components that the previously found 'Assembled APA QA Check' actions were NOT performed on
+  // Now we also want a list of the Assembled APA components that have been produced at the specified location and on which these actions have NOT been performed
+  // Match against the type form ID, component UUID and production location to get records of all 'Assembled APA' components that have a UUID that is NOT in the previously constructed list
   comp_aggregation_stages.push({
     $match: {
       'formId': 'AssembledAPA',
-      'componentUuid': { $nin: uuids_apasCompletedToStep }
+      'componentUuid': { $nin: uuids_apasCompletedToStep_atLocation },
+      'data.apaAssemblyLocation': location,
     }
   });
 
@@ -521,24 +539,24 @@ async function apasByLastCompletedAssemblyStep(assemblyStep) {
   });
 
   // Query the 'components' records collection using the aggregation stages defined above
-  let apasNotCompletedToStep = await db.collection('components')
+  let apasNotCompletedToStep_atLocation = await db.collection('components')
     .aggregate(comp_aggregation_stages)
     .toArray();
 
   // Add the corresponding shortened Assembled APA component name to each matching record
-  for (let record of apasNotCompletedToStep) {
+  for (let record of apasNotCompletedToStep_atLocation) {
     const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
     const name_splits = component.data.name.split('-');
     record.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
   }
 
   // Re-sort the records by the component name ... in reverse alphanumerical order
-  apasNotCompletedToStep.sort(byField('componentName'));
+  apasNotCompletedToStep_atLocation.sort(byField('componentName'));
 
   // Return a nested list, consisting of:
-  // - [0] the list of all assembled APAs that have had matching 'Assembled APA QA Check' actions performed on them and completed
+  // - [0] the list of all assembled APAs produced at the specified location that have had matching 'Assembled APA QA Check'  or 'Completed APA QA Checklist' actions performed on them and completed
   // - [1] the list of all assembled APAs that have NOT had such actions performed on them and/or completed
-  return [apasCompletedToStep, apasNotCompletedToStep];
+  return [apasCompletedToStep_atLocation, apasNotCompletedToStep_atLocation];
 }
 
 
@@ -579,6 +597,6 @@ module.exports = {
   meshesByPartNumber,
   boardKitComponentsByLocation,
   apasByProductionLocationAndNumber,
-  apasByLastCompletedAssemblyStep,
+  apasByProductionLocationAndAssemblyStep,
   componentsByTypeAndNumber,
 }

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -34,7 +34,7 @@ module.exports = {
   // The dictionaries below list various groups of UK and US personnel, whose names should be entered as appropriate in various component and action type forms
   // Using these centralised dictionaries allows names to be consistently displayed in the DB interface, and also for them to be selected via drop-down menu when filling out the type forms
 
-  // A dictionary of UK and US technicians 
+  // A dictionary of UK and US technicians working at the APA factories
   dictionary_technicians: {
     vincentBaker: 'Vincent Baker',
     davidBanner: 'David Banner',
@@ -74,6 +74,11 @@ module.exports = {
     anthonyWatling: 'Anthony Watling',
     lewisWatson: 'Lewis Watson',
     sotirisVlachos: 'Sotiris Vlachos',
+  },
+
+  // A dictionary of technicians specifically at Manchester, working on geometry board metrology
+  dictionary_manchesterTechnicians: {
+
   },
 
   // A dictionary of lead personnel at the UK and US APA factories

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -130,20 +130,20 @@ block content
       h4
         a(href = '/search/apasByProductionDetails') Assembled APAs by Production Details
 
-      p This page may be used to search specifically for <b>assembled APAs</b> under one of the following scenarios:
+      p This page may be used to search specifically for <b>assembled APAs</b> by one of the following filters:
         ul
-          li <b>either</b> any assembled APA that has a specified <u>production location</u> (the location at which the APA is being assembled) <b>and</b> <u>production number</u> (the order in which the APA has been assembled at the specified location)
-          li <b>or</b> all assembled APAs that have been completed up to and including a <u>specified assembly workflow step</u>
+          li <b>either</b> by <u>production number</u> (the order in which the APA has been assembled at a specified production location)
+          li <b>or</b> by the <u>last completed assembly workflow step</u>
 
-      p Users may select one of the production locations from the list, and manually enter an (integer) production number.  Please note that <b>both pieces of information must be provided</b> for the search to be performed.
-        br
-        |  If an existing assembled APA record matching both pieces of information is successfully found in the database, the user will be automatically redirected to the page for viewing the APA component record.
+      p Users <b>must</b> select a <u>production location</u> from the list - this is a <b>required</b> parameter for either search.  They may then either manually enter an (integer) production number, or select one of the pre-set assembly workflow steps from the list.
+
+      p When searching by production number, if an existing assembled APA record matching both pieces of information is successfully found in the database, the user will be automatically redirected to the page for viewing the APA component record.
         br
         |  If there is no such APA, i.e. the information does not match an existing APA record, a message to that effect will be displayed in the search results panel on the right side of the page.
         br
         |  It should not be possible for multiple APA records to match against both provided pieces of information, since they should uniquely identify a single APA.  However, in the unlikely case of this situation occurring, a message will also be displayed indicating so.
 
-      p Alternatively, users may select one of the provided assembly workflow steps.  A list of all assembled APAs that have been completed up to and including that step in their assembly workflows will be displayed in the search results panel on the right side of the page.
+      p When searching by the last completed assembly step, a list of all assembled APAs that have been produced at the specified location and completed up to <u>and including</u> that step in the assembly workflow will be displayed in the search results panel on the right side of the page.  Alongside this, a list of APAs that have <b>not</b> had the specified assembly step completed will also be displayed.
 
       hr
 

--- a/app/pug/search_actionsByIDOrReferencedUUID.pug
+++ b/app/pug/search_actionsByIDOrReferencedUUID.pug
@@ -15,47 +15,44 @@ block content
     .vert-space-x2 
       hr
 
-      .row
-        .col-md-6
-          h4 Search by Action ID
-
-          .vert-space-x1
-            p The input box below uses auto-complete - just start typing an action ID, and any matching options will be displayed.
-
-          .vert-space-x1
+      .row 
+        .col-md-5
           .row
-            .col-md-8
-              #actionidform
+            .col-md-12
+              h4 Search by Action ID
 
-          .vert-space-x2 
-            hr
+              .vert-space-x1
+                p Enter an action ID below.
 
-            h4 Search by Referenced Component UUID
+              .vert-space-x1
+                #actionidform
 
-            .vert-space-x1
-              p Enter a component UUID below or take a picture of the component's QR code.
+          hr
 
-            .vert-space-x1 
-              .row
-                .col-md-8
-                  #componentuuidform
+          .row 
+            .col-md-12
+              h4 Search by Referenced Component UUID
 
-            .vert-space-x1
-              p Select an action type below.
+              .vert-space-x1
+                p Enter a component UUID below or take a picture of the component's QR code.
 
-              .row
-                .col-md-8
-                  select.form-control#actionTypeSelection
-                    option(value = '')          
-                    option(value = 'boardInstall') Board Installation (any layer, any side, any position)
-                    option(value = 'winding') Winding (any layer)
+              .vert-space-x1 
+                #componentuuidform
 
-            .vert-space-x2
-              button.btn-primary.btn-lg#confirmButton Search by Action Type and UUID
+              .vert-space-x2
+                p Select an action type below.
+
+                select.form-control#actionTypeSelection
+                  option(value = '')          
+                  option(value = 'boardInstall') Board Installation (any layer, any side, any position) [Geometry Boards]
+                  option(value = 'winding') Winding (any layer) [Wire Bobbins]
+
+              .vert-space-x2
+                button.btn-primary.btn-lg#confirmButton Search by Action Type and UUID
 
         .col-md-1
 
-        .col-md-5
+        .col-md-6
           h4 Search Results
 
           .vert-space-x1

--- a/app/pug/search_apasByProductionDetails.pug
+++ b/app/pug/search_apasByProductionDetails.pug
@@ -19,50 +19,60 @@ block content
       hr
 
       .row
-        .col-md-3
-          h4 Search by Production Location and Number
-
+        .col-md-5
           .vert-space-x1
             p Select a production location below.
+              br
+              | <b>This is a <u>required</u> parameter for both searches.</b>
 
-          select.form-control#locationSelection
-            option(value = '')          
-            option(value = 'chicago') #{dictionary_locations['chicago']} 
-            option(value = 'daresbury') #{dictionary_locations['daresbury']} 
-            option(value = 'fermilab') #{dictionary_locations['fermilab']} 
-
-          .vert-space-x1
-            p Enter the production number of the APA below.
-
-          input.form-control#numberSelection
-
-          .vert-space-x2
-            button.btn-primary.btn-lg#confirmButton_locationNumber Search by Location and Number
+            select.form-control#locationSelection
+              option(value = '')          
+              option(value = 'chicago') #{dictionary_locations['chicago']} 
+              option(value = 'daresbury') #{dictionary_locations['daresbury']} 
+              option(value = 'fermilab') #{dictionary_locations['fermilab']} 
 
           .vert-space-x2
             hr
 
+            h4 Search by Production Number
+
+            .vert-space-x1
+              p <b>Either</b> enter an APA production number here <b>or</b> select a last completed assembly step below.
+                br
+                | <b>This is a <u>required</u> parameter.</b>
+
+            input.form-control#numberSelection
+
+            .vert-space-x2
+              button.btn-primary.btn-lg#confirmButton_number Search by Production Number
+
+          .vert-space-x2
+            hr  
+
             h4 Search by Last Completed Assembly Step
 
             .vert-space-x1
-              p Select an assembly step below.
+              p <b>Either</b> select a last completed assembly step here <b>or</b> enter an APA production number above.
+                br
+                | <b>This is a <u>required</u> parameter.</b>
 
             select.form-control#assemblyStepSelection
               option(value = '')
-              option(value = 'framePreparation') Assembled APA Quality Assurance Check (Frame Prep)
-              option(value = 'xLayerAssembly') Assembled APA Quality Assurance Check (X Layer)
-              option(value = 'vLayerAssembly') Assembled APA Quality Assurance Check (V Layer)
-              option(value = 'uLayerAssembly') Assembled APA Quality Assurance Check (U Layer)
-              option(value = 'gLayerAssembly') Assembled APA Quality Assurance Check (G Layer)
-              option(value = 'coverBoardsAndCaps') Assembled APA Quality Assurance Check (Cover Boards / Cap Installation)
-              option(value = 'shippingPreparation') Assembled APA Quality Assurance Check (Shipping Preparation)
+              option(value = 'framePreparation') Frame Preparation QA Check
+              option(value = 'xLayerAssembly') X Layer QA Check
+              option(value = 'vLayerAssembly') V Layer QA Check
+              option(value = 'uLayerAssembly') U Layer QA Check
+              option(value = 'gLayerAssembly') G Layer QA Check
+              option(value = 'coverBoardsAndCaps') Cover Boards / Cap Installation QA Check
+              option(value = 'shippingPreparation') Shipping Preparation QA Check
+              option(value = 'assemblyComplete') Completed APA QA Checklist
 
             .vert-space-x2
-              button.btn-primary.btn-lg#confirmButton_assemblyStep Search by Assembly Step
+              button.btn-primary.btn-lg#confirmButton_assemblyStep Search by Last Completed Assembly Step
 
         .col-md-1
 
-        .col-md-8
+        .col-md-6
           h4 Search Results
 
           .vert-space-x1 

--- a/app/pug/search_apasByProductionDetails.pug
+++ b/app/pug/search_apasByProductionDetails.pug
@@ -37,7 +37,7 @@ block content
             h4 Search by Production Number
 
             .vert-space-x1
-              p <b>Either</b> enter an APA production number here <b>or</b> select a last completed assembly step below.
+              p <b>Either</b> enter an APA production number here <b>or</b> select an assembly step below.
                 br
                 | <b>This is a <u>required</u> parameter.</b>
 
@@ -52,7 +52,7 @@ block content
             h4 Search by Last Completed Assembly Step
 
             .vert-space-x1
-              p <b>Either</b> select a last completed assembly step here <b>or</b> enter an APA production number above.
+              p <b>Either</b> select an assembly step here <b>or</b> enter an APA production number above.
                 br
                 | <b>This is a <u>required</u> parameter.</b>
 

--- a/app/pug/search_boardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_boardShipmentsByReceptionDetails.pug
@@ -36,9 +36,7 @@ block content
           h4 Select Origin Location
 
           .vert-space-x1
-            p Select a location below ... this is an optional parameter.
-              br
-              | &nbsp 
+            p Select a location below ... this is an optional parameter. 
 
           select.form-control#originLocationSelection
             option(value = '') (any)
@@ -56,8 +54,6 @@ block content
 
           .vert-space-x1
             p Select a location below ... this is an optional parameter.
-              br
-              | &nbsp
 
           select.form-control#destinationLocationSelection
             option(value = '') (any)
@@ -84,7 +80,7 @@ block content
           .vert-space-x1
             p Select a date below ... this is an optional parameter.
               br
-              | The search will match reception <b><u>on and after</u></b> this date.
+              | Dates <b><u>on and after</u></b> this will be matched.
 
             #earliestdateform
 
@@ -94,7 +90,7 @@ block content
           .vert-space-x1
             p Select a date below ... this is an optional parameter.
               br
-              | The search will match reception <b><u>on and before</u></b> this date.
+              | Dates <b><u>on and before</u></b> this will be matched.
 
             #latestdateform
 
@@ -111,7 +107,7 @@ block content
             option(value = 'noComment') Only shipments received with no comments 
             option(value = 'comment') Only shipments received with comments 
 
-    .vert-space-x2
+    .vert-space-x1
       hr
 
       h4 Search Results

--- a/app/pug/search_componentsByUUIDOrTypeAndNumber.pug
+++ b/app/pug/search_componentsByUUIDOrTypeAndNumber.pug
@@ -16,48 +16,40 @@ block content
       hr
 
       .row 
-        .col-md-6
-          h4 Search by UUID
+        .col-md-5
+          h4 Search by Component UUID
 
           .vert-space-x1
-            p The input box below uses auto-complete - just start typing a component UUID, and any matching options will be displayed.
-              br
-              | Alternatively, click on the camera icon (to the right of the box) to take a picture of the component's QR code if you have it available.
+            p Enter a component UUID below or take a picture of the component's QR code.
 
           .vert-space-x1
-            .row
-              .col-md-8
-                #componentuuidform
+            #componentuuidform
+
+        .col-md-1 
+
+        .col-md-5
+          h4 Search by Type and Number
+
+          .vert-space-x1
+            p Select a component type below.
+
+            select.form-control#componentTypeSelection
+              option(value = '')
+              option(value = 'CEAdapterBoard') CE Adapter Board
+              option(value = 'CRBoard') CR Board
+              option(value = 'CableHarness') Cable Harness
+              option(value = 'GBiasBoard') G-Bias Board
+              option(value = 'GeometryBoard') Geometry Board
+              option(value = 'GroundingMeshPanel') Grounding Mesh Panel
+              option(value = 'SHVBoard') SHV Board
 
           .vert-space-x2
-            hr
+            p Enter a type record number below.
 
-            h4 Search by Type and Number
+            input.form-control#typeRecordNumberSelection
 
-            .vert-space-x1
-              p Select a component type below.
-
-              .row
-                .col-md-8
-                  select.form-control#componentTypeSelection
-                    option(value = '')
-                    option(value = 'CEAdapterBoard') CE Adapter Board
-                    option(value = 'CRBoard') CR Board
-                    option(value = 'CableHarness') Cable Harness
-                    option(value = 'GBiasBoard') G-Bias Board
-                    option(value = 'GeometryBoard') Geometry Board
-                    option(value = 'GroundingMeshPanel') Grounding Mesh Panel
-                    option(value = 'SHVBoard') SHV Board
-
-            .vert-space-x2
-              p Enter a type record number below.
-
-              .row
-                .col-md-8
-                  input.form-control#typeRecordNumberSelection
-
-            .vert-space-x2
-              button.btn-primary.btn-lg#confirmButton Search by Type and Number
+          .vert-space-x2
+            button.btn-primary.btn-lg#confirmButton Search by Type and Number
 
       .vert-space-x1
         #messages

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -18,105 +18,107 @@ block content
     .vert-space-x2
       hr
 
-      .row
-        .col-md-3
-          h4 Select Location
+      .row 
+        .col-md-6 
+          .row
+            .col-md-6
+              h4 Select Location
 
-          .vert-space-x1
-            p Select <b>either</b> a location below <b>or</b> a part number to the right.
-              br
-              | <b>This is a <u>required</u> parameter.</b>
+              .vert-space-x1
+                p Select <b>either</b> a location below <b>or</b> a part number to the right.
+                  br
+                  | <b>This is a <u>required</u> parameter.</b>
 
-          select.form-control#locationSelection
-            option(value = '')
-            option(value = 'cambridge') #{dictionary_locations['cambridge']} 
-            option(value = 'chicago') #{dictionary_locations['chicago']} 
-            option(value = 'daresbury') #{dictionary_locations['daresbury']} 
-            option(value = 'in_transit') #{dictionary_locations['in_transit']} 
-            option(value = 'installed_on_APA') #{dictionary_locations['installed_on_APA']} 
-            option(value = 'lancaster') #{dictionary_locations['lancaster']} 
-            option(value = 'manchester') #{dictionary_locations['manchester']} 
-            option(value = 'merlin') #{dictionary_locations['merlin']} 
-            option(value = 'sheffield') #{dictionary_locations['sheffield']} 
-            option(value = 'sussex') #{dictionary_locations['sussex']} 
-            option(value = 'williamAndMary') #{dictionary_locations['williamAndMary']} 
-            option(value = 'wisconsin') #{dictionary_locations['wisconsin']} 
+              select.form-control#locationSelection
+                option(value = '')
+                option(value = 'cambridge') #{dictionary_locations['cambridge']} 
+                option(value = 'chicago') #{dictionary_locations['chicago']} 
+                option(value = 'daresbury') #{dictionary_locations['daresbury']} 
+                option(value = 'in_transit') #{dictionary_locations['in_transit']} 
+                option(value = 'installed_on_APA') #{dictionary_locations['installed_on_APA']} 
+                option(value = 'lancaster') #{dictionary_locations['lancaster']} 
+                option(value = 'manchester') #{dictionary_locations['manchester']} 
+                option(value = 'merlin') #{dictionary_locations['merlin']} 
+                option(value = 'sheffield') #{dictionary_locations['sheffield']} 
+                option(value = 'sussex') #{dictionary_locations['sussex']} 
+                option(value = 'williamAndMary') #{dictionary_locations['williamAndMary']} 
+                option(value = 'wisconsin') #{dictionary_locations['wisconsin']} 
 
-          .vert-space-x2
+              .vert-space-x2
+                button.btn-primary.btn-lg#confirmButton_location Search by Location
+
+            .col-md-6
+              h4 Select Part Number
+
+              .vert-space-x1
+                p Select <b>either</b> a part number below <b>or</b> a location to the left.
+                  br
+                  | <b>This is a <u>required</u> parameter.</b>
+
+              select.form-control#partNumberSelection
+                option(value = '')          
+                option(value = '8760051') 8760051 (G Foot Board Low Slot End) 
+                option(value = '8760054') 8760054 (G Foot Board Middle)
+                option(value = '8760062') 8760062 (G Foot Board High Slot End) 
+                option(value = '8760113') 8760113 (G Foot Board Position 4 & 7) 
+                option(value = '8760038') 8760038 (U Side Board End)
+                option(value = '8760040') 8760040 (U Side Board w/o Slot Middle) 
+                option(value = '8760042') 8760042 (U Side Board w/ Slot Middle) 
+                option(value = '8760044') 8760044 (U Foot Board High Slot End)
+                option(value = '8760057') 8760057 (U Foot Board Middle) 
+                option(value = '8760059') 8760059 (U Foot Board Low Slot End)
+                option(value = '8760111') 8760111 (U Foot Board Position 4 & 7)
+                option(value = '8760024') 8760024 (V Side Board End)
+                option(value = '8760026') 8760026 (V Middle Side Board w/o Slot)
+                option(value = '8760030') 8760030 (V Foot Board Middle)
+                option(value = '8760036') 8760036 (V Foot Board End)
+                option(value = '8760107') 8760107 (V Foot Board Middle Position 4 & 7)
+                option(value = '8760028') 8760028 (V Middle Side Board w/ Slot)
+                option(value = '8760032') 8760032 (X Foot Board End)
+                option(value = '8760034') 8760034 (X Foot Board Middle)
+                option(value = '8760109') 8760109 (X Foot Board Position 4 & 7)
+                option(value = '8760119') 8760119 (U Head Board Left End)
+                option(value = '8760115') 8760115 (U Head Board Middle)
+                option(value = '8760123') 8760123 (U Head Board Right End)
+                option(value = '8760122') 8760122 (G Head Board Left End)
+                option(value = '8760121') 8760121 (G Head Board Middle)
+                option(value = '8760120') 8760120 (G Head Board Right End)
+                option(value = '8760104') 8760104 (X Head Board)
+                option(value = '8760116') 8760116 (V Head Board Left End)
+                option(value = '8760108') 8760108 (V Head Board Middle & Right End)
+
+              .vert-space-x2
+                button.btn-primary.btn-lg#confirmButton_partNumber Search by Part Number 
+
+          .vert-space-x2 
             hr
 
-            h4 Select Board Acceptance Status
+          .row 
+            .col-md-6
+              h4 Board Acceptance Status
 
-            .vert-space-x1 
-              p Select a status below ... this is an optional parameter.
-                br
-                | It can be used alongside <b>either</b> required parameter.
+              .vert-space-x1 
+                p Select a status below ... this is an optional parameter.
+                  br
+                  | It can be used alongside <b>either</b> required parameter above.
 
-            select.form-control#acceptanceStatusSelection
-              option(value = 'any') (any)
-              option(value = 'accepted') Board Accepted at Factory 
-              option(value = 'rejected') Board Rejected at Factory
+              select.form-control#acceptanceStatusSelection
+                option(value = 'any') (any)
+                option(value = 'accepted') Board Accepted at Factory 
+                option(value = 'rejected') Board Rejected at Factory
 
-          .vert-space-x2
-            h4 Select Tooth Strip Attachment Status
+            .col-md-6
+              h4 Tooth Strip Attachment Status
 
-            .vert-space-x1 
-              p Select a status below ... this is an optional parameter.
-                br
-                | It can be used alongside <b>either</b> required parameter.
+              .vert-space-x1 
+                p Select a status below ... this is an optional parameter.
+                  br
+                  | It can be used alongside <b>either</b> required parameter above.
 
-            select.form-control#toothStripStatusSelection
-              option(value = 'any') (any)
-              option(value = 'attached') Tooth Strip Attached
-              option(value = 'notAttached') Tooth Strip Not Yet Attached
-
-        .col-md-3
-          h4 Select Part Number
-
-          .vert-space-x1
-            p Select <b>either</b> a part number below <b>or</b> a location to the left.
-              br
-              | <b>This is a <u>required</u> parameter.</b>
-
-          select.form-control#partNumberSelection
-            option(value = '')          
-            option(value = '8760051') 8760051 (G Foot Board Low Slot End) 
-            option(value = '8760054') 8760054 (G Foot Board Middle)
-            option(value = '8760062') 8760062 (G Foot Board High Slot End) 
-            option(value = '8760113') 8760113 (G Foot Board Position 4 & 7) 
-            option(value = '8760038') 8760038 (U Side Board End)
-            option(value = '8760040') 8760040 (U Side Board w/o Slot Middle) 
-            option(value = '8760042') 8760042 (U Side Board w/ Slot Middle) 
-            option(value = '8760044') 8760044 (U Foot Board High Slot End)
-            option(value = '8760057') 8760057 (U Foot Board Middle) 
-            option(value = '8760059') 8760059 (U Foot Board Low Slot End)
-            option(value = '8760111') 8760111 (U Foot Board Position 4 & 7)
-            option(value = '8760024') 8760024 (V Side Board End)
-            option(value = '8760026') 8760026 (V Middle Side Board w/o Slot)
-            option(value = '8760030') 8760030 (V Foot Board Middle)
-            option(value = '8760036') 8760036 (V Foot Board End)
-            option(value = '8760107') 8760107 (V Foot Board Middle Position 4 & 7)
-            option(value = '8760028') 8760028 (V Middle Side Board w/ Slot)
-            option(value = '8760032') 8760032 (X Foot Board End)
-            option(value = '8760034') 8760034 (X Foot Board Middle)
-            option(value = '8760109') 8760109 (X Foot Board Position 4 & 7)
-            option(value = '8760119') 8760119 (U Head Board Left End)
-            option(value = '8760115') 8760115 (U Head Board Middle)
-            option(value = '8760123') 8760123 (U Head Board Right End)
-            option(value = '8760122') 8760122 (G Head Board Left End)
-            option(value = '8760121') 8760121 (G Head Board Middle)
-            option(value = '8760120') 8760120 (G Head Board Right End)
-            option(value = '8760104') 8760104 (X Head Board)
-            option(value = '8760116') 8760116 (V Head Board Left End)
-            option(value = '8760108') 8760108 (V Head Board Middle and Right End)
-
-          .vert-space-x2
-            hr
-
-            .vert-space-x2
-              button.btn-primary.btn-lg.float-left#confirmButton_location Search by Location
-
-              button.btn-primary.btn-lg.float-right#confirmButton_partNumber Search by Part No. 
+              select.form-control#toothStripStatusSelection
+                option(value = 'any') (any)
+                option(value = 'attached') Tooth Strip Attached
+                option(value = 'notAttached') Tooth Strip Not Yet Attached
 
         .col-md-1
 

--- a/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
+++ b/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
@@ -16,11 +16,11 @@ block content
       hr
 
       .row
-        .col-md-4
-          h4 Select Disposition
+        .col-md-5
+          h4 Select Visual Inspection Disposition
 
           .vert-space-x1
-            p <b>Either</b> select a disposition below <b>or</b> set an order number to the right.
+            p <b>Either</b> select a disposition below <b>or</b> enter an order number to the right.
               br
               | <b>This is a <u>required</u> parameter.</b>
 
@@ -34,34 +34,11 @@ block content
             option(value = 'boardIsConformant') Board Is Conformant
 
           .vert-space-x2
-            hr
-
-            h4 Select Issue
-
-            .vert-space-x1
-              p Select an issue below ... this is an optional parameter.
-                br
-                | It is only used alongside the <b>disposition</b> required parameter.
-
-            select.form-control#issueSelection
-              option(value = 'any') (any)         
-              option(value = 'packagingDamaged') Packaging damaged 
-              option(value = 'scratches') Scratches 
-              option(value = 'exposedCopper') Exposed copper 
-              option(value = 'interruptedTraces') Copper trace(s) interrupted 
-              option(value = 'chipped') PCB chipped 
-              option(value = 'notFlat') PCB not flat
-              option(value = 'incorrectGeometry') Incorrect geometry 
-              option(value = 'incorrectThickness') Incorrect thickness
-              option(value = 'qrCodeProblem') QR code problem 
-              option(value = 'millMaxHolePlating') Issues with mill-max hole plating
-              option(value = 'extraneousMaterialOnBoard') Extraneous material on board 
-              option(value = 'fiducialPin') Fiducial pin more than 0.25 mm above board surface
-              option(value = 'other') Other
+            button.btn-primary.btn-lg#confirmButton_disposition Search by Disposition
 
         .col-md-1 
 
-        .col-md-4
+        .col-md-5
           h4 Enter Order Number
 
           .vert-space-x1
@@ -72,12 +49,34 @@ block content
           input.form-control#orderNumberSelection
 
           .vert-space-x2
-            hr
+            button.btn-primary.btn-lg#confirmButton_orderNumber Search by Order Number
 
-            .vert-space-x2
-              button.btn-primary.btn-lg.float-left#confirmButton_disposition Search by Disposition
+      .row 
+        .col-md-5
+          hr
 
-              button.btn-primary.btn-lg.float-right#confirmButton_orderNumber Search by Order Number
+          h4 Select Issue
+
+          .vert-space-x1
+            p Select an issue below ... this is an optional parameter.
+              br
+              | It is only used alongside the <b>disposition</b> required parameter above.
+
+          select.form-control#issueSelection
+            option(value = 'any') (any)         
+            option(value = 'packagingDamaged') Packaging damaged 
+            option(value = 'scratches') Scratches 
+            option(value = 'exposedCopper') Exposed copper 
+            option(value = 'interruptedTraces') Copper trace(s) interrupted 
+            option(value = 'chipped') PCB chipped 
+            option(value = 'notFlat') PCB not flat
+            option(value = 'incorrectGeometry') Incorrect geometry 
+            option(value = 'incorrectThickness') Incorrect thickness
+            option(value = 'qrCodeProblem') QR code problem 
+            option(value = 'millMaxHolePlating') Issues with mill-max hole plating
+            option(value = 'extraneousMaterialOnBoard') Extraneous material on board 
+            option(value = 'fiducialPin') Fiducial pin more than 0.25 mm above board surface
+            option(value = 'other') Other
 
     .vert-space-x2
       hr

--- a/app/pug/search_meshesByLocationOrPartNumber.pug
+++ b/app/pug/search_meshesByLocationOrPartNumber.pug
@@ -19,44 +19,44 @@ block content
       hr
 
       .row
-        .col-md-3
-          h4 Select Location
+        .col-md-6 
+          .row 
+            .col-md-6
+              h4 Select Location
 
-          .vert-space-x1
-            p Select <b>either</b> a location below <b>or</b> a part number to the right.
-              br
-              | <b>This is a <u>required</u> parameter.</b>
+              .vert-space-x1
+                p Select <b>either</b> a location below <b>or</b> a part number to the right.
+                  br
+                  | <b>This is a <u>required</u> parameter.</b>
 
-          select.form-control#locationSelection
-            option(value = '')
-            option(value = 'chicago') #{dictionary_locations['chicago']} 
-            option(value = 'in_transit') #{dictionary_locations['in_transit']} 
-            option(value = 'installed_on_APA') #{dictionary_locations['installed_on_APA']} 
-            option(value = 'ukWarehouse') #{dictionary_locations['ukWarehouse']} 
+              select.form-control#locationSelection
+                option(value = '')
+                option(value = 'chicago') #{dictionary_locations['chicago']} 
+                option(value = 'in_transit') #{dictionary_locations['in_transit']} 
+                option(value = 'installed_on_APA') #{dictionary_locations['installed_on_APA']} 
+                option(value = 'ukWarehouse') #{dictionary_locations['ukWarehouse']} 
 
-        .col-md-3
-          h4 Select Part Number
+              .vert-space-x2
+                button.btn-primary.btn-lg#confirmButton_location Search by Location
 
-          .vert-space-x1
-            p Select <b>either</b> a part number below <b>or</b> a location to the left.
-              br
-              | <b>This is a <u>required</u> parameter.</b>
+            .col-md-6
+              h4 Select Part Number
 
-          select.form-control#partNumberSelection
-            option(value = '')          
-            option(value = 'mesh29410560HeadEndLH') 294-10560 HEAD END - L/H 
-            option(value = 'mesh29410561HeadEndRH') 294-10561 HEAD END - R/H
-            option(value = 'mesh29410562FootEndRH') 294-10562 FOOT END - R/H 
-            option(value = 'mesh29410563FootEndLH') 294-10563 FOOT END - L/H 
-            option(value = 'mesh29410564Centre') 294-10564 CENTRE
+              .vert-space-x1
+                p Select <b>either</b> a part number below <b>or</b> a location to the left.
+                  br
+                  | <b>This is a <u>required</u> parameter.</b>
 
-          .vert-space-x2
-            hr
+              select.form-control#partNumberSelection
+                option(value = '')          
+                option(value = 'mesh29410560HeadEndLH') 294-10560 HEAD END - L/H 
+                option(value = 'mesh29410561HeadEndRH') 294-10561 HEAD END - R/H
+                option(value = 'mesh29410562FootEndRH') 294-10562 FOOT END - R/H 
+                option(value = 'mesh29410563FootEndLH') 294-10563 FOOT END - L/H 
+                option(value = 'mesh29410564Centre') 294-10564 CENTRE
 
-            .vert-space-x2
-              button.btn-primary.btn-lg.float-left#confirmButton_location Search by Location
-
-              button.btn-primary.btn-lg.float-right#confirmButton_partNumber Search by Part Number 
+              .vert-space-x2
+                button.btn-primary.btn-lg#confirmButton_partNumber Search by Part Number 
 
         .col-md-1
 

--- a/app/pug/search_nonConformanceByComponentTypeOrUUID.pug
+++ b/app/pug/search_nonConformanceByComponentTypeOrUUID.pug
@@ -16,7 +16,7 @@ block content
       hr
 
       .row
-        .col-md-4
+        .col-md-5
           h4 Select Component Type
 
           .vert-space-x1
@@ -30,37 +30,8 @@ block content
             option(value = 'apaFrame') APA Frame 
             option(value = 'groundingMeshPanel') Grounding Mesh Panel 
 
-          .vert-space-x2 
-            hr
-
-            h4 Select Disposition
-
-            .vert-space-x1 
-              p Select a disposition below ... this is an optional parameter.
-                br
-                | It is only used alongside the <b>component type</b> required parameter.
-
-            select.form-control#dispositionSelection
-              option(value = 'any') (any)
-              option(value = 'useAsIs') Use As Is 
-              option(value = 'repair') Repair 
-              option(value = 'rework') Rework 
-              option(value = 'returnToSupplier') Return to Supplier 
-              option(value = 'rejectRePurpose') Reject/Re-purpose
-              option(value = 'scrap') Scrap 
-
-          .vert-space-x2 
-            h4 Select Status
-
-            .vert-space-x1 
-              p Select a status below ... this is an optional parameter.
-                br
-                | It is only used alongside the <b>component type</b> required parameter.
-
-            select.form-control#statusSelection
-              option(value = 'any') (any)
-              option(value = 'open') Open 
-              option(value = 'closed') Closed 
+          .vert-space-x2
+            button.btn-primary.btn-lg#confirmButton_type Search by Component Type
 
         .col-md-1
 
@@ -75,13 +46,43 @@ block content
           .vert-space-x1 
             #componentUuidSelection
 
-          .vert-space-x2
-            hr
+          button.btn-primary.btn-lg#confirmButton_uuid Search by Component UUID
 
-            .vert-space-x2
-              button.btn-primary.btn-lg.float-left#confirmButton_type Search by Component Type
+      .vert-space-x2 
+        hr
 
-              button.btn-primary.btn-lg.float-right#confirmButton_uuid Search by Component UUID
+      .row.vert-space-x2 
+        .col-md-5
+          h4 Select Disposition
+
+          .vert-space-x1 
+            p Select a disposition below ... this is an optional parameter.
+              br
+              | It is only used alongside the <b>component type</b> required parameter.
+
+          select.form-control#dispositionSelection
+            option(value = 'any') (any)
+            option(value = 'useAsIs') Use As Is 
+            option(value = 'repair') Repair 
+            option(value = 'rework') Rework 
+            option(value = 'returnToSupplier') Return to Supplier 
+            option(value = 'rejectRePurpose') Reject/Re-purpose
+            option(value = 'scrap') Scrap 
+
+        .col-md-1 
+
+        .col-md-5
+          h4 Select Status
+
+          .vert-space-x1 
+            p Select a status below ... this is an optional parameter.
+              br
+              | It is only used alongside the <b>component type</b> required parameter.
+
+          select.form-control#statusSelection
+            option(value = 'any') (any)
+            option(value = 'open') Open 
+            option(value = 'closed') Closed 
 
     .vert-space-x2
       hr

--- a/app/pug/search_workflowsByIDOrUUID.pug
+++ b/app/pug/search_workflowsByIDOrUUID.pug
@@ -16,29 +16,25 @@ block content
       hr
 
       .row
-        .col-md-6 
+        .col-md-5 
           h4 Search by Workflow ID
 
           .vert-space-x1
-            p The input box below uses auto-complete - just start typing a workflow ID, and any matching options will be displayed.
+            p Enter a workflow ID below.
 
           .vert-space-x1
-            .row
-              .col-md-8
-                #workflowidform
+            #workflowidform
 
-          .vert-space-x2
-            hr
+        .col-md-1 
 
-            h4 Search by Component UUID 
+        .col-md-5
+          h4 Search by Component UUID 
 
-            .vert-space-x1
-              p Enter a component UUID below or take a picture of the component's QR code.
+          .vert-space-x1
+            p Enter a component UUID below or take a picture of the component's QR code.
 
-            .vert-space-x1
-              .row
-                .col-md-8
-                  #componentuuidform
+          .vert-space-x1
+            #componentuuidform
 
       .vert-space-x1
         #messages

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -172,13 +172,13 @@ router.get('/search/apasByProductionLocationAndNumber/:apaLocation/:apaNumber', 
 });
 
 
-/// Search for assembled APAs by last completed assembly step
-router.get('/search/apasByLastCompletedAssemblyStep/:assemblyStep', async function (req, res, next) {
+/// Search for assembled APAs by production location and last completed assembly step
+router.get('/search/apasByProductionLocationAndAssemblyStep/:apaLocation/:assemblyStep', async function (req, res, next) {
   try {
     // Retrieve a nested list, consisting of:
-    // - a list of all assembled APAs that have been completed up to and including the specified step in their assembly workflows
-    // - a list of all assembled APAs that have NOT yet reached the specified step in their assembly workflows
-    const assembledAPAs = await Search_OtherComponents.apasByLastCompletedAssemblyStep(req.params.assemblyStep);
+    // - a list of all assembled APAs at the specified location that have been completed up to and including the specified step in their assembly workflows
+    // - a list of all assembled APAs at the specified location that have NOT yet reached the specified step in their assembly workflows
+    const assembledAPAs = await Search_OtherComponents.apasByProductionLocationAndAssemblyStep(req.params.apaLocation, req.params.assemblyStep);
 
     // Return the list in JSON format
     return res.json(assembledAPAs);

--- a/app/routes/api/users.js
+++ b/app/routes/api/users.js
@@ -58,7 +58,7 @@ router.get('/users/list', permissions.checkPermissionJson('users:view'), async f
 });
 
 
-/// List all UK and US technicians
+/// List UK and US technicians working at the APA factories
 router.get('/technicians.json', async function (req, res, next) {
   try {
     // Convert the centralised list of technicians from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
@@ -80,7 +80,29 @@ router.get('/technicians.json', async function (req, res, next) {
 });
 
 
-/// List all lead personnel at the UK and US APA factories
+// List technicians specifically at Manchester, working on geometry board metrology
+router.get('/manchester_technicians.json', async function (req, res, next) {
+  try {
+    // Convert the centralised list of Manchester technicians from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
+    let data = [];
+
+    for (const person in utils.dictionary_manchesterTechnicians) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_manchesterTechnicians[person],
+      });
+    }
+
+    // Return the array in JSON format
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List lead personnel at the UK and US APA factories
 router.get('/apaFactoryLeads.json', async function (req, res, next) {
   try {
     // Convert the centralised list of lead personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
@@ -102,7 +124,7 @@ router.get('/apaFactoryLeads.json', async function (req, res, next) {
 });
 
 
-/// List all personnel who are authorised to sign-off on tension controls
+/// List personnel who are authorised to sign-off on tension controls
 router.get('/tensionControlSignoff.json', async function (req, res, next) {
   try {
     // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
@@ -124,7 +146,7 @@ router.get('/tensionControlSignoff.json', async function (req, res, next) {
 });
 
 
-/// List all personnel who are authorised to sign-off on winder maintenance
+/// List personnel who are authorised to sign-off on winder maintenance
 router.get('/winderMaintenanceSignoff.json', async function (req, res, next) {
   try {
     // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
@@ -146,7 +168,7 @@ router.get('/winderMaintenanceSignoff.json', async function (req, res, next) {
 });
 
 
-/// List all personnel who are authorised to sign-off on APA frame and grounding mesh intake (including frame intake survey results)
+/// List personnel who are authorised to sign-off on APA frame and grounding mesh intake (including both types of frame survey results)
 router.get('/frameIntakeSignoff.json', async function (req, res, next) {
   try {
     // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
@@ -156,28 +178,6 @@ router.get('/frameIntakeSignoff.json', async function (req, res, next) {
       data.push({
         api_name: person,
         display_name: utils.dictionary_frameIntakeSignoff[person],
-      });
-    }
-
-    // Return the array in JSON format
-    return res.json(data);
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-/// List all personnel who are authorised to sign-off on APA frame installation survey results
-router.get('/frameInstallationSignoff.json', async function (req, res, next) {
-  try {
-    // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
-    let data = [];
-
-    for (const person in utils.dictionary_frameInstallationSignoff) {
-      data.push({
-        api_name: person,
-        display_name: utils.dictionary_frameInstallationSignoff[person],
       });
     }
 

--- a/app/static/pages/search_actionsByIDOrReferencedUUID.js
+++ b/app/static/pages/search_actionsByIDOrReferencedUUID.js
@@ -87,7 +87,7 @@ function postSuccess(result) {
       <td colspan = "2">The following <b>${$('#actionTypeSelection option:selected').text()}</b> actions reference the specified component UUID.</td>
     </tr>
     <tr>
-      <td colspan = "5"><br></td>
+      <td colspan = "2"><br></td>
     </tr>`;
 
   $('#results').append(resultsStart);
@@ -98,8 +98,8 @@ function postSuccess(result) {
   } else {
     const tableStart = `
         <tr>
-          <th scope = 'col' width = '50%'>Action</th>
-          <th scope = 'col' width = '50%'>Performed On Component</th>
+          <th scope = 'col' width = '30%'>Component</th>
+          <th scope = 'col' width = '70%'>Action</th>
         </tr>`;
 
     $('#results').append(tableStart);
@@ -107,8 +107,8 @@ function postSuccess(result) {
     for (const action of result) {
       const actionText = `
           <tr>
-            <td><a href = '/action/${action.actionId}' target = '_blank'</a>${action.typeFormName}</td>
             <td><a href = '/component/${action.componentUuid}' target = '_blank'</a>${action.componentName}</td>
+            <td><a href = '/action/${action.actionId}' target = '_blank'</a>${action.typeFormName}</td>
           </tr>`;
 
       $('#results').append(actionText);

--- a/app/static/pages/search_apasByProductionDetails.js
+++ b/app/static/pages/search_apasByProductionDetails.js
@@ -24,8 +24,8 @@ async function renderSearchForms() {
 
   // When the appropriate confirmation button is pressed, perform the search by location and number using the appropriate jQuery 'ajax' call and the current values of the search parameters
   // Additionally, disable both confirmation buttons while the current search is being performed
-  $('#confirmButton_locationNumber').on('click', function () {
-    $('#confirmButton_locationNumber').prop('disabled', true);
+  $('#confirmButton_number').on('click', function () {
+    $('#confirmButton_number').prop('disabled', true);
     $('#confirmButton_assemblyStep').prop('disabled', true);
 
     if (apaLocation && apaNumber) {
@@ -39,19 +39,19 @@ async function renderSearchForms() {
     }
   });
 
-  // When the appropriate confirmation button is pressed, perform the search by assembly step using the appropriate jQuery 'ajax' call and the current values of the search parameters
+  // When the appropriate confirmation button is pressed, perform the search by location and assembly step using the appropriate jQuery 'ajax' call and the current values of the search parameters
   // Additionally, disable both confirmation buttons while the current search is being performed
   $('#confirmButton_assemblyStep').on('click', function () {
-    $('#confirmButton_locationNumber').prop('disabled', true);
+    $('#confirmButton_number').prop('disabled', true);
     $('#confirmButton_assemblyStep').prop('disabled', true);
 
-    if (assemblyStep) {
+    if (apaLocation && assemblyStep) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/apasByLastCompletedAssemblyStep/${assemblyStep}`,
+        url: `/json/search/apasByProductionLocationAndAssemblyStep/${apaLocation}/${assemblyStep}`,
         dataType: 'json',
-        success: postSuccess_assemblyStep,
+        success: postSuccess_locationAndAssemblyStep,
       }).fail(postFail);
     }
   });
@@ -87,8 +87,8 @@ function postSuccess_locationAndNumber(result) {
 };
 
 
-// Function to run for a successful search query by last completed assembly step
-function postSuccess_assemblyStep(result) {
+// Function to run for a successful search query by production location and last completed assembly step
+function postSuccess_locationAndAssemblyStep(result) {
   // Make sure that all page elements where information messages or search results will be displayed are empty
   $('#messages').empty();
   $('#results1').empty();
@@ -97,7 +97,7 @@ function postSuccess_assemblyStep(result) {
   // Display the information about APAs that have had the specified assembly step completed
   let resultsStart = `
   <tr>
-    <td colspan = "3">The specified assembly step has been completed for <b>${result[0].length} APAs</b>
+    <td colspan = "3">The specified assembly step <b><u>has been completed</u></b> for <b>${result[0].length} APAs</b>
       <br>
       <hr>
     </td>
@@ -107,9 +107,8 @@ function postSuccess_assemblyStep(result) {
 
   let tableStart = `
     <tr>
-      <th scope = 'col' width = '30%'>APA Name</th>
-      <th scope = 'col' width = '35%'>Component Info</th>
-      <th scope = 'col' width = '35%'>Assembly Workflow</th>
+      <th scope = 'col' width = '40%'>APA Name</th>
+      <th scope = 'col' width = '60%'>Assembly Workflow</th>
     </tr>`;
 
   $('#results1').append(tableStart);
@@ -117,8 +116,7 @@ function postSuccess_assemblyStep(result) {
   for (const apa of result[0]) {
     const apaText = `
       <tr>
-        <td>${apa.componentName}</td>
-        <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>[link]</td>
+        <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>${apa.componentName}</td>
         <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[link]</td>
       </tr>`;
 
@@ -128,7 +126,7 @@ function postSuccess_assemblyStep(result) {
   // Display the information about APAs that have not yet had the specified assembly step completed
   resultsStart = `
   <tr>
-    <td colspan = "3">The specified assembly step has not yet been completed for <b>${result[1].length} APAs</b>
+    <td colspan = "3">The specified assembly step <b><u>has not yet been completed</u></b> for <b>${result[1].length} APAs</b>
       <br>
       <hr>
     </td>
@@ -140,8 +138,7 @@ function postSuccess_assemblyStep(result) {
   for (const apa of result[1]) {
     const apaText = `
       <tr>
-        <td>${apa.componentName}</td>
-        <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>[link]</td>
+        <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>${apa.componentName}</td>
         <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[link]</td>
       </tr>`;
 
@@ -149,7 +146,7 @@ function postSuccess_assemblyStep(result) {
   }
 
   // Re-enable both confirmation buttons for the next search
-  $('#confirmButton_locationNumber').prop('disabled', false);
+  $('#confirmButton_number').prop('disabled', false);
   $('#confirmButton_assemblyStep').prop('disabled', false);
 }
 
@@ -164,6 +161,6 @@ function postFail(result, statusCode, statusMsg) {
   }
 
   // Re-enable both confirmation buttons for the next search
-  $('#confirmButton_locationNumber').prop('disabled', false);
+  $('#confirmButton_number').prop('disabled', false);
   $('#confirmButton_assemblyStep').prop('disabled', false);
 };

--- a/app/static/pages/search_boardShipmentsByReceptionDetails.js
+++ b/app/static/pages/search_boardShipmentsByReceptionDetails.js
@@ -109,10 +109,10 @@ function postSuccess(result) {
 
   const resultsStart = `
     <tr>
-      <td colspan = "4">The following geometry board shipments have been found matching the specified search criteria.</td>
+      <td colspan = "7">The following geometry board shipments have been found matching the specified search criteria.</td>
     </tr>
     <tr>
-      <td colspan = "4"><br><hr></td>
+      <td colspan = "7"><br><hr></td>
     </tr>`;
 
   $('#results').append(resultsStart);
@@ -123,7 +123,7 @@ function postSuccess(result) {
   } else {
     const resultsCount = `
       <tr>
-        <td colspan = "3"><b>Found ${result.length} matching geometry board shipments</b></td>
+        <td colspan = "7"><b>Found ${result.length} matching geometry board shipments</b></td>
       </tr>`;
 
     $('#results').append(resultsCount);
@@ -131,14 +131,13 @@ function postSuccess(result) {
 
     const tableStart = `
       <tr>
-        <th scope = 'col' width = '18%'>Shipment UUID</th>
-        <th scope = 'col' width = '7%'>Boards</th>
-        <th scope = 'col' width = '9%'>Origin</th>
-        <th scope = 'col' width = '9%'>Destination</th>
-        <th scope = 'col' width = '9%'>Creation Date</th>
-        <th scope = 'col' width = '9%'>Reception Date</th>
-        <th scope = 'col' width = '27%'>Shipment Reception Comment</th>
-        <th scope = 'col' width = '12%'>Search Comment</th>
+        <th scope = 'col' width = '16%'>Shipment Information</th>
+        <th scope = 'col' width = '13%'>Origin</th>
+        <th scope = 'col' width = '13%'>Destination</th>
+        <th scope = 'col' width = '12%'>Creation Date</th>
+        <th scope = 'col' width = '12%'>Reception Date</th>
+        <th scope = 'col' width = '24%'>Shipment Reception Comment</th>
+        <th scope = 'col' width = '10%'>Search Comment</th>
       </tr>`;
 
     $('#results').append(tableStart);
@@ -150,8 +149,7 @@ function postSuccess(result) {
 
       const boardText = `
         <tr>
-          <td><a href = '/component/${shipment.uuid}' target = '_blank'</a>${shipment.uuid}</td>
-          <td>${shipment.numberOfBoards}</td>
+          <td><a href = '/component/${shipment.uuid}' target = '_blank'</a>${shipment.numberOfBoards} Boards</td>
           <td>${dictionary_locations[shipment.origin]}</td>
           <td>${dictionary_locations[shipment.destination]}</td>
           <td>${shipment.creationDate}</td>

--- a/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
+++ b/app/static/pages/search_geoBoardsByLocationOrPartNumber.js
@@ -73,7 +73,7 @@ function postSuccess_location(result) {
       <td colspan = "3">The following geometry boards are at <b>${$('#locationSelection option:selected').text()}</b>.</td>
     </tr>
     <tr>
-      <td colspan = "3">They are grouped by board part number, and then ordered by increasing UK ID within each group.
+      <td colspan = "3">They are grouped by board part number, and then ordered by increasing UKID within each group.
         <br>
         <hr>
       </td>
@@ -144,7 +144,7 @@ function postSuccess_partNumber(result) {
       <td colspan = "3">The following geometry boards with part number <b>${$('#partNumberSelection option:selected').text()}</b> have been received.</td>
     </tr>
     <tr>
-      <td colspan = "3">They are grouped by location, and then ordered by increasing UK ID within each group.
+      <td colspan = "3">They are grouped by location, and then ordered by increasing UKID within each group.
         <br>
         <hr>
       </td>

--- a/app/static/pages/search_geoBoardsByVisInspectOrOrderNumber.js
+++ b/app/static/pages/search_geoBoardsByVisInspectOrOrderNumber.js
@@ -153,11 +153,11 @@ function postSuccess_disposition(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '10%'>Board UKID</th>
-          <th scope = 'col' width = '15%'>Order Number</th>
-          <th scope = 'col' width = '25%'>Visual Inspection Action</th>
-          <th scope = 'col' width = '25%'>Issue(s) Identified</th>
-          <th scope = 'col' width = '25%'>Repairs Description (if applicable)</th>
+          <th scope = 'col' width = '8%'>Board UKID</th>
+          <th scope = 'col' width = '10%'>Order Number</th>
+          <th scope = 'col' width = '17%'>Visual Inspection Action</th>
+          <th scope = 'col' width = '35%'>Issue(s) Identified</th>
+          <th scope = 'col' width = '30%'>Repairs Description (if applicable)</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -204,10 +204,10 @@ function postSuccess_orderNumber(result) {
 
   const resultsStart = `
     <tr>
-      <td colspan = "4">The following geometry boards with order number: <b>${$('#orderNumberSelection').val()}</b> and at least one recorded visual inspection have been found.</td>
+      <td colspan = "5">The following geometry boards with order number: <b>${$('#orderNumberSelection').val()}</b> and at least one recorded visual inspection have been found.</td>
     </tr>
     <tr>
-      <td colspan = "4"><b>Please note that only boards which have had a Visual Inspection action performed on them are shown here - there may be additional boards in this order that have not yet had inspections performed.</b><br><hr></td>
+      <td colspan = "5"><b>Please note that only boards which have had a Visual Inspection action performed on them are shown here - there may be additional boards in this order that have not yet had inspections performed.</b><br><hr></td>
     </tr>`;
 
   $('#results').append(resultsStart);
@@ -219,7 +219,7 @@ function postSuccess_orderNumber(result) {
     for (const boardGroup of result) {
       const groupCount = `
         <tr>
-          <td colspan = "4">Found ${boardGroup.actionIds.length} boards with disposition: <b>${dispositionsDictionary[boardGroup.disposition]}</b></td>
+          <td colspan = "5">Found ${boardGroup.actionIds.length} boards with disposition: <b>${dispositionsDictionary[boardGroup.disposition]}</b></td>
         </tr>`;
 
       $('#results').append(groupCount);
@@ -230,17 +230,18 @@ function postSuccess_orderNumber(result) {
     for (const boardGroup of result) {
       const groupTitle = `
         <tr>
-          <td colspan = "4"><b>Disposition: ${dispositionsDictionary[boardGroup.disposition]}</b></td>
+          <td colspan = "5"><b>Disposition: ${dispositionsDictionary[boardGroup.disposition]}</b></td>
         </tr>`;
 
       $('#results').append(groupTitle);
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '25%'>Board UKID</th>
-          <th scope = 'col' width = '25%'>Visual Inspection Action</th>
-          <th scope = 'col' width = '25%'>Issue(s) Identified</th>
-          <th scope = 'col' width = '25%'>Repairs Description (if applicable)</th>
+          <th scope = 'col' width = '8%'>Board UKID</th>
+          <th scope = 'col' width = '10%'></th>
+          <th scope = 'col' width = '17%'>Visual Inspection Action</th>
+          <th scope = 'col' width = '35%'>Issue(s) Identified</th>
+          <th scope = 'col' width = '30%'>Repairs Description (if applicable)</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -251,6 +252,7 @@ function postSuccess_orderNumber(result) {
         const boardText = `
           <tr>
             <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
+            <td></td>
             <td><a href = '/action/${boardGroup.actionIds[i]}' target = '_blank'</a>${boardGroup.actionIds[i]}</td>
             <td>${inspectionData.issues}</td>
             <td>${inspectionData.repairsDescription}</td>

--- a/app/static/pages/search_meshesByLocationOrPartNumber.js
+++ b/app/static/pages/search_meshesByLocationOrPartNumber.js
@@ -72,7 +72,7 @@ function postSuccess_location(result) {
       <td colspan = "3">The following grounding mesh panels are at <b>${$('#locationSelection option:selected').text()}</b>.</td>
     </tr>
     <tr>
-      <td colspan = "3">They are grouped by part number, and then ordered by increasing DUNE PID within each group.
+      <td colspan = "3">They are grouped by part number, and then ordered by increasing mesh number within each group.
         <br>
         <hr>
       </td>
@@ -105,9 +105,9 @@ function postSuccess_location(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '50%'>Mesh DUNE PID</th>
+          <th scope = 'col' width = '25%'>Mesh Number</th>
           <th scope = 'col' width = '25%'>Date at Location</th>
-          <th scope = 'col' width = '25%'>Installed on APA</th>
+          <th scope = 'col' width = '50%'>Installed on APA</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -115,7 +115,7 @@ function postSuccess_location(result) {
       for (const i in meshGroup.componentUuids) {
         const boardText = `
           <tr>
-            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.dunePids[i]}</td>
+            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.dunePids[i].split('-')[1]}</td>
             <td>${meshGroup.receptionDates[i]}</td>
             <td>${meshGroup.installedOnAPA[i]}</td>
           </tr>`;
@@ -143,7 +143,7 @@ function postSuccess_partNumber(result) {
       <td colspan = "3">The following grounding mesh panels with part number <b>${$('#partNumberSelection option:selected').text()}</b> have been received.</td>
     </tr>
     <tr>
-      <td colspan = "3">They are grouped by location, and then ordered by increasing DUNE PID within each group.
+      <td colspan = "3">They are grouped by location, and then ordered by increasing mesh number within each group.
         <br>
         <hr>
       </td>
@@ -176,9 +176,9 @@ function postSuccess_partNumber(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '50%'>Mesh DUNE PID</th>
+          <th scope = 'col' width = '25%'>Mesh Number</th>
           <th scope = 'col' width = '25%'>Date at Location</th>
-          <th scope = 'col' width = '25%'>Installed on APA</th>
+          <th scope = 'col' width = '50%'>Installed on APA</th>
         </tr>`;
 
       $('#results').append(tableStart);
@@ -186,7 +186,7 @@ function postSuccess_partNumber(result) {
       for (const i in meshGroup.componentUuids) {
         const boardText = `
           <tr>
-            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.dunePids[i]}</td>
+            <td><a href = '/component/${meshGroup.componentUuids[i]}' target = '_blank'</a>${meshGroup.dunePids[i].split('-')[1]}</td>
             <td>${meshGroup.receptionDates[i]}</td>
             <td>${meshGroup.installedOnAPA[i]}</td>
           </tr>`;

--- a/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
+++ b/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
@@ -124,9 +124,9 @@ function postSuccess(result) {
   } else {
     const tableStart = `
       <tr>
-        <th scope = 'col' width = '15%'>Component Type</th>
+        <th scope = 'col' width = '10%'>Component Type</th>
         <th scope = 'col' width = '20%'>Component Name</th>
-        <th scope = 'col' width = '25%'>Non-Conformance Title / Action ID</th>
+        <th scope = 'col' width = '30%'>Non-Conformance Title / Action ID</th>
         <th scope = 'col' width = '15%'>Disposition</th>
         <th scope = 'col' width = '10%'>Status</th>
       </tr>`;


### PR DESCRIPTION
Requested changes to Search for APAs by Production Details
- production location is now a required parameters for BOTH searches ... by production number and by last completed assembly step
- added 'Completed APA QA Checklist' to the available options for the last completed assembly step ... i.e. this will select only fully completed APAs
- changed displayed text for all 'last completed assembly step' options so that it's clear at the beginning of the text what each one is
- various formatting and layout improvements
- updated Search Descriptions page

Adding empty dictionary and API route for list of Manchester technicians
- dictionary will be populated at a later date, once I have the list of personnel

Tweaks and fixes to Search page layouts
- DB development now done on a true 1080p screen, much closer in resolution to those used in the APA factories (was previously using a sub-1080p Xserver display stretched to fill a 2k screen)
- fixed a number of bad layout issues, and made both the pages and client-side code more consistent and hopefully clearer to use
- no changes to any server-side search functions or routes
