### PR TITLE
Adding new dictionaries of UW personnel as requested

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -34,7 +34,7 @@ module.exports = {
   // The dictionaries below list various groups of UK and US personnel, whose names should be entered as appropriate in various component and action type forms
   // Using these centralised dictionaries allows names to be consistently displayed in the DB interface, and also for them to be selected via drop-down menu when filling out the type forms
 
-  // A dictionary of UK and US technicians working at the APA factories
+  // General technicians at the UK and US APA factories
   dictionary_technicians: {
     vincentBaker: 'Vincent Baker',
     davidBanner: 'David Banner',
@@ -76,12 +76,66 @@ module.exports = {
     sotirisVlachos: 'Sotiris Vlachos',
   },
 
-  // A dictionary of technicians specifically at Manchester, working on geometry board metrology
+  // Personnel who are authorised to sign-off on APA frame and grounding mesh intake (including both types of frame survey results)
+  dictionary_frameIntakeSignoff: {
+    gedBell: 'Ged Bell',
+    callumHolt: 'Callum Holt',
+    gwennMouster: 'Gwenn Mouster',
+    sotirisVlachos: 'Sotiris Vlachos',
+    kyleZeug: 'Kyle Zeug',
+  },
+
+  // Geometry board metrology technicians at Manchester
   dictionary_manchesterTechnicians: {
 
   },
 
-  // A dictionary of lead personnel at the UK and US APA factories
+  // Personnel who are authorised to sign-off on tension controls
+  dictionary_tensionControlSignoff: {
+    vincentBaker: 'Vincent Baker',
+    carlosChavezBarajas: 'Carlos Chavez Barajas',
+    edBlucher: 'Ed Blucher',
+    albertoMarchionni: 'Alberto Marchionni',
+    benjaminOye: 'Benjamin Oye',
+    danielSalisbury: 'Daniel Salisbury',
+  },
+
+  // Personnel who are authorised to sign-off on winder maintenance
+  dictionary_winderMaintenanceSignoff: {
+    vincentBaker: 'Vincent Baker',
+    carlosChavezBarajas: 'Carlos Chavez Barajas',
+    edBlucher: 'Ed Blucher',
+    albertoMarchionni: 'Alberto Marchionni',
+    benjaminOye: 'Benjamin Oye',
+    danielSalisbury: 'Daniel Salisbury',
+    daveSim: 'Dave Sim',
+  },
+
+  // PCB technicians at UW
+  dictionary_uwPCBTechnicians: {
+    andyArbuckle: 'Andy Arbuckle',
+    krishnaLakkaraju: 'Krishna Lakkaraju',
+    marySeverson: 'Mary Severson',
+    christineVerdico: 'Christine Verdico',
+  },
+
+  // Personnel who are authorised to approve PCBs at UW
+  dictionary_uwPCBApproval: {
+    andyArbuckle: 'Andy Arbuckle',
+    pamMarrLaundrie: 'Pam Marr-Laundrie',
+  },
+
+  // Hardware installation technicians at UW
+  dictionary_uwInstallationTechnicians: {
+
+  },
+
+  // Personnel who are authorised to approve hardware installation at UW
+  dictionary_uwInstallationApproval: {
+    joeMunski: 'Joe Munski',
+  },
+
+  // Lead personnel at the UK and US APA factories
   dictionary_apaFactoryLeads: {
     edBlucher: 'Ed Blucher',
     albertoMarchionni: 'Alberto Marchionni',
@@ -99,34 +153,4 @@ module.exports = {
     'auth0|62c1f26dd68f53308071c91a', 'auth0|6247211d7ca173006f55b951',                                   // Brian Rebel (Staging, Production)
     'auth0|62366229e644f4006ff1b144', 'auth0|6236627bcd1229006a1e5c54', 'auth0|623662b39e63f500683a210f', // Krish Majumdar (Staging, Production, Development)
   ],
-
-  // A dictionary of personnel who are authorised to sign-off on tension controls
-  dictionary_tensionControlSignoff: {
-    vincentBaker: 'Vincent Baker',
-    carlosChavezBarajas: 'Carlos Chavez Barajas',
-    edBlucher: 'Ed Blucher',
-    albertoMarchionni: 'Alberto Marchionni',
-    benjaminOye: 'Benjamin Oye',
-    danielSalisbury: 'Daniel Salisbury',
-  },
-
-  // A dictionary of personnel who are authorised to sign-off on winder maintenance
-  dictionary_winderMaintenanceSignoff: {
-    vincentBaker: 'Vincent Baker',
-    carlosChavezBarajas: 'Carlos Chavez Barajas',
-    edBlucher: 'Ed Blucher',
-    albertoMarchionni: 'Alberto Marchionni',
-    benjaminOye: 'Benjamin Oye',
-    danielSalisbury: 'Daniel Salisbury',
-    daveSim: 'Dave Sim',
-  },
-
-  // A dictionary of personnel who are authorised to sign-off on APA frame and grounding mesh intake (including both types of frame survey results)
-  dictionary_frameIntakeSignoff: {
-    gedBell: 'Ged Bell',
-    callumHolt: 'Callum Holt',
-    gwennMouster: 'Gwenn Mouster',
-    sotirisVlachos: 'Sotiris Vlachos',
-    kyleZeug: 'Kyle Zeug',
-  },
 }

--- a/app/routes/api/users.js
+++ b/app/routes/api/users.js
@@ -58,10 +58,9 @@ router.get('/users/list', permissions.checkPermissionJson('users:view'), async f
 });
 
 
-/// List UK and US technicians working at the APA factories
+/// List general technicians at the UK and US APA factories
 router.get('/technicians.json', async function (req, res, next) {
   try {
-    // Convert the centralised list of technicians from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
     let data = [];
 
     for (const person in utils.dictionary_technicians) {
@@ -71,95 +70,6 @@ router.get('/technicians.json', async function (req, res, next) {
       });
     }
 
-    // Return the array in JSON format
-    return res.json(data);
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-// List technicians specifically at Manchester, working on geometry board metrology
-router.get('/manchester_technicians.json', async function (req, res, next) {
-  try {
-    // Convert the centralised list of Manchester technicians from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
-    let data = [];
-
-    for (const person in utils.dictionary_manchesterTechnicians) {
-      data.push({
-        api_name: person,
-        display_name: utils.dictionary_manchesterTechnicians[person],
-      });
-    }
-
-    // Return the array in JSON format
-    return res.json(data);
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-/// List lead personnel at the UK and US APA factories
-router.get('/apaFactoryLeads.json', async function (req, res, next) {
-  try {
-    // Convert the centralised list of lead personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
-    let data = [];
-
-    for (const person in utils.dictionary_apaFactoryLeads) {
-      data.push({
-        api_name: person,
-        display_name: utils.dictionary_apaFactoryLeads[person],
-      });
-    }
-
-    // Return the array in JSON format
-    return res.json(data);
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-/// List personnel who are authorised to sign-off on tension controls
-router.get('/tensionControlSignoff.json', async function (req, res, next) {
-  try {
-    // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
-    let data = [];
-
-    for (const person in utils.dictionary_tensionControlSignoff) {
-      data.push({
-        api_name: person,
-        display_name: utils.dictionary_tensionControlSignoff[person],
-      });
-    }
-
-    // Return the array in JSON format
-    return res.json(data);
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-/// List personnel who are authorised to sign-off on winder maintenance
-router.get('/winderMaintenanceSignoff.json', async function (req, res, next) {
-  try {
-    // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
-    let data = [];
-
-    for (const person in utils.dictionary_winderMaintenanceSignoff) {
-      data.push({
-        api_name: person,
-        display_name: utils.dictionary_winderMaintenanceSignoff[person],
-      });
-    }
-
-    // Return the array in JSON format
     return res.json(data);
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);
@@ -171,7 +81,6 @@ router.get('/winderMaintenanceSignoff.json', async function (req, res, next) {
 /// List personnel who are authorised to sign-off on APA frame and grounding mesh intake (including both types of frame survey results)
 router.get('/frameIntakeSignoff.json', async function (req, res, next) {
   try {
-    // Convert the centralised list of personnel from a dictionary to an array, with each element of the array being a sub-dictionary containing the API and display names of each person
     let data = [];
 
     for (const person in utils.dictionary_frameIntakeSignoff) {
@@ -181,7 +90,166 @@ router.get('/frameIntakeSignoff.json', async function (req, res, next) {
       });
     }
 
-    // Return the array in JSON format
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List geometry board metrology technicians at Manchester
+router.get('/manchesterTechnicians.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_manchesterTechnicians) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_manchesterTechnicians[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List personnel who are authorised to sign-off on tension controls
+router.get('/tensionControlSignoff.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_tensionControlSignoff) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_tensionControlSignoff[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List personnel who are authorised to sign-off on winder maintenance
+router.get('/winderMaintenanceSignoff.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_winderMaintenanceSignoff) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_winderMaintenanceSignoff[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List PCB technicians at UW
+router.get('/uwPCBTechnicians.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_uwPCBTechnicians) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_uwPCBTechnicians[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List personnel who are authorised to approve PCBs at UW
+router.get('/uwPCBApproval.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_uwPCBApproval) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_uwPCBApproval[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List hardware installation technicians at UW
+router.get('/uwInstallationTechnicians.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_uwInstallationTechnicians) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_uwInstallationTechnicians[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List personnel who are authorised to approve hardware installation at UW
+router.get('/uwInstallationApproval.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_uwInstallationApproval) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_uwInstallationApproval[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List lead personnel at the UK and US APA factories
+router.get('/apaFactoryLeads.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_apaFactoryLeads) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_apaFactoryLeads[person],
+      });
+    }
+
     return res.json(data);
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -230,6 +230,8 @@ class ComponentUUID extends TextFieldComponent {
     const matchedURL = qrCode.match('.*/([0-9a-zA-Z]{20,22})');
 
     if (matchedURL) {
+      console.log(`static/formio/ComponentUUID.js:233 - found 'matchedURL' (= ${matchedURL})`)
+      
       const shortuuid = matchedURL[1].match('[^\-]*')[0];
       let that = this;
 
@@ -244,7 +246,8 @@ class ComponentUUID extends TextFieldComponent {
           }
         },
       })
-
+    } else {
+      console.log(`static/formio/ComponentUUID.js:248 - cannot find 'matchedURL' (= ${matchedURL})`)
     }
 
     return true;


### PR DESCRIPTION
Also made the previously added API route to the list of Manchester geometry board metrology technicians CamelCase, to keep it consistent with the other routes (will need to change the type form on Production to match).

Also added some console output to the Formio Component UUID entity ... might be useful for debugging problems with the QR code scanning and decoding part of the DB interface.  Is permanent, but will only show up with 'persistent logs' enabled in the debug console, so it shouldn't get in anyone's way.