### PR TITLE
New Search for Components by DUNE PID

### DIFF
--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -560,6 +560,34 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
 }
 
 
+/// Retrieve a list of components that match the specified DUNE PID
+async function componentsByDUNEPID(dunePID) {
+  let aggregation_stages = [];
+
+  // Match against the DUNE PID to get records of all components that have the same name as the specified one
+  aggregation_stages.push({
+    $match: { 'data.name': dunePID }
+  });
+
+  // Select the latest version of each record, and pass through only the fields required for later use
+  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({
+    $group: {
+      _id: { componentUuid: '$componentUuid' },
+      componentUuid: { '$first': '$componentUuid' },
+    },
+  });
+
+  // Query the 'components' records collection using the aggregation stages defined above
+  let results = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
+
+  // Return the list of components
+  return results;
+}
+
+
 /// Retrieve a list of components that match the specified type and type record number
 async function componentsByTypeAndNumber(type, typeRecordNumber) {
   let aggregation_stages = [];
@@ -598,5 +626,6 @@ module.exports = {
   boardKitComponentsByLocation,
   apasByProductionLocationAndNumber,
   apasByProductionLocationAndAssemblyStep,
+  componentsByDUNEPID,
   componentsByTypeAndNumber,
 }

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -143,6 +143,8 @@ block content
           #qr-code
             +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, component.data.name)
 
+          p.small.text-center #{base_url}/c/#{component.shortUuid.toString()}
+
     if component.formId === 'BoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location 

--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -124,8 +124,8 @@ body(class = `deployment-${NODE_ENV}`)
 
               ul.nav.flex-column.ml-3.sub-bar
                 li.nav-item
-                  +navlink(href = '/search/componentsByUUIDOrTypeAndNumber')
-                    |      Components By UUID or Type and Number
+                  +navlink(href = '/search/componentsByIdentifier')
+                    |      Components By Identifier
 
                 li.nav-item
                   +navlink(href = '/search/geoBoardsByLocationOrPartNumber')

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -17,14 +17,15 @@ block content
 
     .vert-space-x2
       h4
-        a(href = '/search/componentsByUUIDOrTypeAndNumber') Components by UUID or Type and Number
+        a(href = '/search/componentsByIdentifier') Components by Identifier
 
       p This page may be used to search specifically for <b>components</b> under one of the following scenarios: 
         ul
           li <b>by component UUID</b>
+          li <b>by DUNE PID</b>
           li <b>by component type and type record number</b>
 
-      p Every component record includes a type record number, but only for specific component types is this number actually used.  For example, 'Geometry Board' type components use the type record number as their 'UKID' unique identifiers, and 'Grounding Mesh Panel' type components include the type record number within their DUNE PID identifiers.
+      p Some (but not all) component types use a DUNE PID in place of a component name.  Every component record includes a type record number, but only for specific component types is this number actually used.  For example, 'Geometry Board' type components use the type record number as their 'UKID' unique identifiers, and 'Grounding Mesh Panel' type components include the type record number within their DUNE PID.
 
       p In the first scenario, the UUID input box uses auto-complete, so users may begin manually entering a UUID, and any matching entries currently in the database will be displayed (up to 10 entries).  The auto-complete system is responsive - meaning that the list of displayed matches will be dynamically updated as more of the input is entered.
         br
@@ -32,14 +33,16 @@ block content
         br
         | If the entered UUID corresponds to a component record in the database, the user will be automatically redirected to the page for viewing the component information.  If there is no corresponding record, an error will be displayed.
 
-      p In the second scenario, users must specify the following information:
+      p In the second scenario, users must specify the component DUNE PID in the form D00300XXXXXX-XXXXX-XXXXX-01-00-00.
+
+      p In the third scenario, users must specify the following information:
         ul
           li the component type (from the dropdown list)
           li the type record number (as an integer)
 
       p If the specified information corresponds to a component record in the database, the user will be automatically redirected to the page for viewing the component information.  If there is no corresponding record, an error will be displayed.
         br
-        |  It should not be possible for multiple components of the same type to have the same type record number, since the numbers are assigned in sequence at component creation.  However, in the unlikely case of this situation occurring, a message will also be displayed indicating so.
+        |  It should not be possible for multiple components of the same type to have the same type record number (since the numbers are assigned in sequence at component creation) or for multiple components to have the same DUNE PID.  However, in the unlikely case of this situation occurring, a message will also be displayed indicating so.
 
       hr
 

--- a/app/pug/search_componentsByIdentifier.pug
+++ b/app/pug/search_componentsByIdentifier.pug
@@ -1,29 +1,45 @@
 extend default
 
 block vars
-  - const page_title = 'Search for Components by UUID or Type and Number';
+  - const page_title = 'Search for Components by Identifier';
 
 block extrascripts
   block workscripts
-    script(src = '/pages/search_componentsByUUIDOrTypeAndNumber.js')
+    script(src = '/pages/search_componentsByIdentifier.js')
 
 block content
   .container-fluid
     .vert-space-x2
-      h2 Search for Components by UUID or Type and Number
+      h2 Search for Components by Identifier
 
     .vert-space-x2 
       hr
 
       .row 
         .col-md-5
-          h4 Search by Component UUID
+          .row 
+            .col-md-12 
+              h4 Search by Component UUID
 
-          .vert-space-x1
-            p Enter a component UUID below or take a picture of the component's QR code.
+              .vert-space-x1
+                p Enter a component UUID below or take a picture of the component's QR code.
 
-          .vert-space-x1
-            #componentuuidform
+              .vert-space-x1
+                #componentuuidform
+
+          hr
+
+          .row 
+            .col-md-12 
+              h4 Search by DUNE PID 
+
+              .vert-space-x1
+                p Enter a DUNE PID (in the form D00300XXXXXX-XXXXX-XXXXX-01-00-00) below.
+
+              input.form-control#dunePIDSelection
+
+              .vert-space-x2
+                button.btn-primary.btn-lg#confirmButton_dunePID Search by DUNE PID
 
         .col-md-1 
 
@@ -49,7 +65,10 @@ block content
             input.form-control#typeRecordNumberSelection
 
           .vert-space-x2
-            button.btn-primary.btn-lg#confirmButton Search by Type and Number
+            button.btn-primary.btn-lg#confirmButton_typeAndNumber Search by Type and Number
+
+      .vert-space-x2 
+        hr
 
       .vert-space-x1
         #messages

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -189,7 +189,22 @@ router.get('/search/apasByProductionLocationAndAssemblyStep/:apaLocation/:assemb
 });
 
 
-/// Search for components of a specified type and type record number
+/// Search for components by DUNE PID
+router.get('/search/componentsByDUNEPID/:dunePID', async function (req, res, next) {
+  try {
+    // Retrieve a list of components that match the specified record details
+    const components = await Search_OtherComponents.componentsByDUNEPID(req.params.dunePID);
+
+    // Return the list in JSON format
+    return res.json(components);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// Search for components by type and type record number
 router.get('/search/componentsByTypeAndNumber/:type/:number', async function (req, res, next) {
   try {
     // Retrieve a list of components that match the specified record details

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -10,10 +10,10 @@ router.get('/search', async function (req, res, next) {
 });
 
 
-/// Search for components by UUID, or of a specified type and type record number
-router.get('/search/componentsByUUIDOrTypeAndNumber', async function (req, res, next) {
+/// Search for components by UUID, DUNE PID, or type and type record number
+router.get('/search/componentsByIdentifier', async function (req, res, next) {
   // Render the interface page
-  res.render('search_componentsByUUIDOrTypeAndNumber.pug');
+  res.render('search_componentsByIdentifier.pug');
 });
 
 

--- a/app/static/pages/search_componentsByIdentifier.js
+++ b/app/static/pages/search_componentsByIdentifier.js
@@ -1,4 +1,5 @@
 // Declare variables to hold the user-specified search parameters
+let dunePID = null;
 let componentType = null;
 let typeRecordNumber = null;
 
@@ -32,6 +33,10 @@ async function renderSearchForms() {
   });
 
   // Get and set the value of any search parameter that is changed
+  $('#dunePIDSelection').on('change', async function () {
+    dunePID = $('#dunePIDSelection').val();
+  });
+
   $('#componentTypeSelection').on('change', async function () {
     componentType = $('#componentTypeSelection').val();
   });
@@ -40,10 +45,28 @@ async function renderSearchForms() {
     typeRecordNumber = $('#typeRecordNumberSelection').val();
   });
 
-  // When the confirmation button is pressed, perform the search using the appropriate jQuery 'ajax' call and the current values of the search parameters
-  // Additionally, disable the button while the current search is being performed
-  $('#confirmButton').on('click', function () {
-    $('#confirmButton').prop('disabled', true);
+  // When the appropriate confirmation button is pressed, perform the search by DUNE PID using the appropriate jQuery 'ajax' call and the current values of the search parameters
+  // Additionally, disable both confirmation buttons while the current search is being performed
+  $('#confirmButton_dunePID').on('click', function () {
+    $('#confirmButton_dunePID').prop('disabled', true);
+    $('#confirmButton_typeAndNumber').prop('disabled', true);
+
+    if (dunePID) {
+      $.ajax({
+        contentType: 'application/json',
+        method: 'GET',
+        url: `/json/search/componentsByDUNEPID/${dunePID}`,
+        dataType: 'json',
+        success: postSuccess,
+      }).fail(postFail);
+    }
+  })
+
+  // When the appropriate confirmation button is pressed, perform the search by component type and type record number using the appropriate jQuery 'ajax' call and the current values of the search parameters
+  // Additionally, disable both confirmation buttons while the current search is being performed
+  $('#confirmButton_typeAndNumber').on('click', function () {
+    $('#confirmButton_dunePID').prop('disabled', true);
+    $('#confirmButton_typeAndNumber').prop('disabled', true);
 
     if (componentType && typeRecordNumber) {
       $.ajax({
@@ -58,32 +81,34 @@ async function renderSearchForms() {
 }
 
 
-// Function to run for a successful search query
+// Function to run for a successful search query of either scenario
 function postSuccess(result) {
   // Make sure that the page element where any information messages will be displayed is empty
   $('#messages').empty();
 
-  // If there are no search results, display a message to indicate this, and then re-enable the confirmation button for the next search
-  // Similarly, if there is more than one search result (i.e. the specified type record number matches multiple components of the specified type), also display a message and re-enable the button
+  // If there are no search results, display a message to indicate this, and then re-enable both confirmation buttons for the next search
+  // Similarly, if there is more than one search result, also display a message and re-enable both buttons
   // Otherwise (i.e. there is exactly one component in the search results), redirect the user to the page for viewing the component record
   if (result.length === 0) {
-    $('#messages').append('<b>The specified type record number does not match an existing component of the specified type.</b>');
-    $('#confirmButton').prop('disabled', false);
+    $('#messages').append('<b>The specified search parameters do not match an existing component.</b>');
+    $('#confirmButton_dunePID').prop('disabled', false);
+    $('#confirmButton_typeAndNumber').prop('disabled', false);
   } else if (result.length > 1) {
     const output = `
-      <b>The specified type record number matches <u>multiple</u> components of the specified type.</b>
-      <br>This should not happen, since each component of a single type should have a unique type record number.
-      <br>Please bring this to the attention of one of the database development team, indicating the component type and type record number that you specified above.`;
+      <b>The specified search parameters match <u>multiple</u> components.</b>
+      <br>This should not happen, since each component should have a unique DUNE PID, and each component of a single type should have a unique type record number.
+      <br>Please bring this to the attention of one of the database development team, indicating the search parameters that you specified above.`;
 
     $('#messages').append(output);
-    $('#confirmButton').prop('disabled', false);
+    $('#confirmButton_dunePID').prop('disabled', false);
+    $('#confirmButton_typeAndNumber').prop('disabled', false);
   } else {
     window.location.href = `/component/${result[0].componentUuid}`;
   }
 };
 
 
-// Function to run for a failed search query
+// Function to run for a failed search query of either scenario
 function postFail(result, statusCode, statusMsg) {
   // If the query result contains a response message, display it, and if not, display any status message and error code instead
   if (result.responseText) {
@@ -92,6 +117,7 @@ function postFail(result, statusCode, statusMsg) {
     console.log('POSTFAIL: ', `${statusMsg} (${statusCode})`);
   }
 
-  // Re-enable the confirmation button for the next search
-  $('#confirmButton').prop('disabled', false);
+  // Re-enable both confirmation buttons for the next search
+  $('#confirmButton_dunePID').prop('disabled', false);
+  $('#confirmButton_typeAndNumber').prop('disabled', false);
 };


### PR DESCRIPTION
QR code URL is now displayed on all component information pages

New Search for Components by DUNE PID
- renamed previous 'Search for Components by UUID or Type and Record Number' to 'Search for Components by Identifier' in interface pages and route
- added new input box for DUNE PID, and corresponding interface page JS code for retrieving the input string and passing it through the (new) route
- added route and library function for new search, and updated Search Descriptions page

Changes have been tested on Staging
