### PR TITLE
Requested Changes from 2024-11-19 Meeting

### DIFF
--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -1,10 +1,8 @@
 const MUUID = require('uuid-mongodb');
 
-const Actions = require('./Actions');
 const Components = require('./Components');
 const { db } = require('./db');
 const Search_ActionsWorkflows = require('./Search_ActionsWorkflows');
-const Workflows = require('./Workflows');
 const utils = require('./utils');
 
 const layerSection_names = ['layer_x', 'layer_v', 'layer_u', 'layer_g'];
@@ -60,13 +58,8 @@ const dictionary_apaNCRs_types = {
   machiningIssue: 'Machining Issue',
   conduitIssue: 'Conduit Issue',
   incorrectFasteners: 'Incorrect Fasteners',
-};
-
-const dictionary_frameNCRs_types = {
-  machiningIssue: 'Machining Issue',
-  bow: 'Bow',
-  twist: 'Twist',
-  survey: 'Survey',
+  frameIssue: 'Issue with the Frame',
+  meshIssue: 'Issue with Mesh Panel',
 };
 
 const dictionary_meshPanelNCRs_types = {
@@ -154,7 +147,6 @@ async function collateInfo(componentUUID) {
 
   collatedInfo.apaNCRs_wires = [];
   collatedInfo.apaNCRs_other = [];
-  collatedInfo.frameNCRs = [];
   collatedInfo.meshPanelNCRs = [];
 
   /////////////////////////
@@ -690,9 +682,21 @@ async function collateInfo(componentUUID) {
     $match: {
       'typeFormId': 'APANonConformance',
       'componentUuid': MUUID.from(componentUUID),
-      'data.nonConformanceType.missingWireSegment': false,
-      'data.nonConformanceType.misplacedWireSegment': false,
-      'data.nonConformanceType.shortedWireSegment': false,
+      $or: [{
+        'data.nonConformanceType.geometryBoardIssue': true
+      }, {
+        'data.nonConformanceType.combIssue': true
+      }, {
+        'data.nonConformanceType.machiningIssue': true
+      }, {
+        'data.nonConformanceType.conduitIssue': true
+      }, {
+        'data.nonConformanceType.incorrectFasteners': true
+      }, {
+        'data.nonConformanceType.frameIssue': true
+      }, {
+        'data.nonConformanceType.meshIssue': true
+      }],
     }
   });
 
@@ -726,53 +730,6 @@ async function collateInfo(componentUUID) {
       }
 
       collatedInfo.apaNCRs_other.push(dictionary);
-    }
-  }
-
-  ////////////////////////////
-  // FRAME NON-CONFORMANCES //
-  ////////////////////////////
-  // Get information about any non-conformances on the APA frame  
-  aggregation_stages = [];
-  results = [];
-
-  aggregation_stages.push({
-    $match: {
-      'typeFormId': 'APANonConformance',
-      'componentUuid': MUUID.from(frameUUID),
-    }
-  });
-
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
-  aggregation_stages.push({
-    $group: {
-      _id: { actionId: '$actionId' },
-      actionId: { '$first': '$actionId' },
-      nonConf_type: { '$first': '$data.frameNonConformanceType' },
-      nonConf_description: { '$first': '$data.nonConformanceDescription' },
-    },
-  });
-
-  results = await db.collection('actions')
-    .aggregate(aggregation_stages)
-    .toArray();
-
-  if (results.length > 0) {
-    for (const result of results) {
-      let nonConfType = '';
-
-      for (const [key, value] of Object.entries(result.nonConf_type)) {
-        if (value) nonConfType = key;
-      }
-
-      const dictionary = {
-        component: 'APA Frame',
-        type: dictionary_frameNCRs_types[nonConfType],
-        description: result.nonConf_description,
-        actionId: result.actionId,
-      }
-
-      collatedInfo.frameNCRs.push(dictionary);
     }
   }
 

--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -2,12 +2,7 @@ const MUUID = require('uuid-mongodb');
 
 const Components = require('./Components');
 const { db } = require('./db');
-
-var byField = function (field) {
-  return function (a, b) {
-    return ((a[field] > b[field]) ? -1 : ((a[field] < b[field]) ? 1 : 0));
-  }
-};
+const utils = require('./utils');
 
 
 /// Retrieve a list of workflows that involve a particular component, specified by its UUID
@@ -91,7 +86,7 @@ async function nonConformanceByComponentType(componentType, disposition, status)
 
   // Re-sort the records by the component name, in reverse alphanumerical order
   // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  results.sort(byField('componentName'));
+  results.sort(utils.byField_decreasing('componentName'));
 
   // Return the list of matching actions
   return results;
@@ -137,7 +132,7 @@ async function nonConformanceByUUID(componentUUID) {
 
   // Re-sort the records by the NCR action ID, in reverse alphanumerical order
   // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  results.sort(byField('actionId'));
+  results.sort(utils.byField_decreasing('actionId'));
 
   // Return the list of  atching actions
   return results;

--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -4,6 +4,25 @@ const Components = require('./Components');
 const { db } = require('./db');
 const utils = require('./utils');
 
+const dictionary_apaNCRs_types = {
+  missingWireSegment: 'Missing Wire Segment',
+  misplacedWireSegment: 'Misplaced Wire Segment',
+  shortedWireSegment: 'Shorted Wire Segment',
+  geometryBoardIssue: 'Geometry Board Issue',
+  combIssue: 'Comb Issue',
+  machiningIssue: 'Machining Issue',
+  conduitIssue: 'Conduit Issue',
+  incorrectFasteners: 'Incorrect Fasteners',
+  frameIssue: 'Issue with the Frame',
+  meshIssue: 'Issue with Mesh Panel',
+};
+
+const dictionary_meshPanelNCRs_types = {
+  holesInMesh: 'Holes in mesh',
+  frameIssue: 'Frame issue',
+  meshNotTight: 'Mesh not tight',
+};
+
 
 /// Retrieve a list of workflows that involve a particular component, specified by its UUID
 async function workflowsByUUID(componentUUID) {
@@ -56,6 +75,8 @@ async function nonConformanceByComponentType(componentType, disposition, status)
       componentUuid: { '$first': '$componentUuid' },
       title: { '$first': '$data.nonConformanceTitle' },
       componentType: { '$first': '$data.componentType' },
+      nonConfTypes_apas: { '$first': '$data.nonConformanceType' },
+      nonConfTypes_meshes: { '$first': '$data.frameNonConformanceType1' },
       disposition: { '$first': '$data.disposition' },
       status: { '$first': '$data.status' },
     },
@@ -79,9 +100,24 @@ async function nonConformanceByComponentType(componentType, disposition, status)
     .toArray();
 
   // Add the corresponding component name to each matching record
+  // Additionally, get the first 'true' non-conformance type in each record, convert it to something more readable and save this new string to the record
   for (let result of results) {
     const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
     result.componentName = component.data.name;
+
+    if (result.componentType === 'assembledApa') {
+      if (result.nonConfTypes_apas != null) {
+        result.nonConfType = dictionary_apaNCRs_types[Object.keys(result.nonConfTypes_apas).filter(k => result.nonConfTypes_apas[k])[0]];
+      } else {
+        result.nonConfType = '[No NC Type Found!]';
+      }
+    } else {
+      if (result.nonConfTypes_meshes != null) {
+        result.nonConfType = dictionary_meshPanelNCRs_types[Object.keys(result.nonConfTypes_meshes).filter(k => result.nonConfTypes_meshes[k])[0]];
+      } else {
+        result.nonConfType = '[No NC Type Found!]';
+      }
+    }
   }
 
   // Re-sort the records by the component name, in reverse alphanumerical order
@@ -114,6 +150,8 @@ async function nonConformanceByUUID(componentUUID) {
       componentUuid: { '$first': '$componentUuid' },
       title: { '$first': '$data.nonConformanceTitle' },
       componentType: { '$first': '$data.componentType' },
+      nonConfTypes_apas: { '$first': '$data.nonConformanceType' },
+      nonConfTypes_meshes: { '$first': '$data.frameNonConformanceType1' },
       disposition: { '$first': '$data.disposition' },
       status: { '$first': '$data.status' },
     },
@@ -125,9 +163,24 @@ async function nonConformanceByUUID(componentUUID) {
     .toArray();
 
   // Add the corresponding component name to each matching record
+  // Additionally, get the first 'true' non-conformance type in each record, convert it to something more readable and save this new string to the record
   for (let result of results) {
     const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
     result.componentName = component.data.name;
+
+    if (result.componentType === 'assembledApa') {
+      if (result.nonConfTypes_apas != null) {
+        result.nonConfType = dictionary_apaNCRs_types[Object.keys(result.nonConfTypes_apas).filter(k => result.nonConfTypes_apas[k])[0]];
+      } else {
+        result.nonConfType = '[No NC Type Found!]';
+      }
+    } else {
+      if (result.nonConfTypes_meshes != null) {
+        result.nonConfType = dictionary_meshPanelNCRs_types[Object.keys(result.nonConfTypes_meshes).filter(k => result.nonConfTypes_meshes[k])[0]];
+      } else {
+        result.nonConfType = '[No NC Type Found!]';
+      }
+    }
   }
 
   // Re-sort the records by the NCR action ID, in reverse alphanumerical order

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -2,12 +2,7 @@ const MUUID = require('uuid-mongodb');
 
 const Components = require('./Components');
 const { db } = require('./db');
-
-var byField = function (field) {
-  return function (a, b) {
-    return ((a[field] > b[field]) ? -1 : ((a[field] < b[field]) ? 1 : 0));
-  }
-};
+const utils = require('./utils');
 
 
 /// Retrieve a list of geometry board shipments that match the specified reception details
@@ -143,6 +138,45 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
       }
     }
   }
+
+  // Return the list of shipments
+  return shipments;
+}
+
+
+/// Retrieve a list of geometry board shipments that reference a single component, specified by its UUID
+async function boardShipmentsByBoardUUID(componentUUID) {
+  let aggregation_stages = [];
+
+  // Match against the type form ID to get records of all 'Board Shipment' components
+  aggregation_stages.push({ $match: { 'formId': 'BoardShipment' } });
+
+  // Select the latest version of each record, and pass through only the fields required for later use
+  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({
+    $group: {
+      _id: { componentUuid: '$componentUuid' },
+      componentUuid: { '$first': '$componentUuid' },
+      typeFormId: { '$first': '$formId' },
+      typeFormName: { '$first': '$formName' },
+      data: { '$first': '$data' },
+      reception: { '$first': '$reception' },
+      lastEditDate: { '$first': '$validity.startDate' },
+    },
+  });
+
+  // Match against the specified component UUID
+  // Since the component UUIDs are stored as an ARRAY in the shipment record, this requires first unwinding the array (to temporarily produce a single record per array entry)
+  aggregation_stages.push({ $unwind: '$data.boardUuiDs' });
+
+  aggregation_stages.push({
+    $match: { 'data.boardUuiDs.component_uuid': MUUID.from(componentUUID).toString() }
+  });
+
+  // Query the 'components' records collection using the aggregation stages defined above
+  let shipments = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
 
   // Return the list of shipments
   return shipments;
@@ -514,7 +548,7 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
 
   // Re-sort the records by the component name, in reverse alphanumerical order
   // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  apasCompletedToStep_atLocation.sort(byField('componentName'));
+  apasCompletedToStep_atLocation.sort(utils.byField_decreasing('componentName'));
 
   let comp_aggregation_stages = [];
 
@@ -551,7 +585,7 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
   }
 
   // Re-sort the records by the component name ... in reverse alphanumerical order
-  apasNotCompletedToStep_atLocation.sort(byField('componentName'));
+  apasNotCompletedToStep_atLocation.sort(utils.byField_decreasing('componentName'));
 
   // Return a nested list, consisting of:
   // - [0] the list of all assembled APAs produced at the specified location that have had matching 'Assembled APA QA Check'  or 'Completed APA QA Checklist' actions performed on them and completed
@@ -621,6 +655,7 @@ async function componentsByTypeAndNumber(type, typeRecordNumber) {
 
 module.exports = {
   boardShipmentsByReceptionDetails,
+  boardShipmentsByBoardUUID,
   meshesByLocation,
   meshesByPartNumber,
   boardKitComponentsByLocation,

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -7,12 +7,7 @@ const { db } = require('./db');
 const dbLock = require('./dbLock');
 const Forms = require('./Forms');
 const permissions = require('./permissions');
-
-var byField = function (field) {
-  return function (a, b) {
-    return ((a[field] > b[field]) ? -1 : ((a[field] < b[field]) ? 1 : 0));
-  }
-};
+const utils = require('./utils');
 
 
 /// Save a new or edited workflow record
@@ -317,7 +312,7 @@ async function list(match_condition, options) {
 
   // If listing a single type of workflow (i.e. if a match condition was specified), re-sort the records by the component name ... in reverse alphanumerical order
   // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  if (match_condition) filtered_records.sort(byField('componentName'));
+  if (match_condition) filtered_records.sort(utils.byField_decreasing('componentName'));
 
   // Return the entire list of matching records
   return filtered_records;

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -5,6 +5,20 @@ module.exports = {
   // A 20 to 22 character long shortened UUID
   short_uuid_regex: ':shortuuid([0-9a-bA-Z-]{20,22})',
 
+  // Function to sort an array of objects by a common object key, in increasing order
+  byField_increasing: function (field) {
+    return function (a, b) {
+      return ((a[field] < b[field]) ? -1 : ((a[field] > b[field]) ? 1 : 0));
+    }
+  },
+
+  // Function to sort an array of objects by a common object key, in decreasing order
+  byField_decreasing: function (field) {
+    return function (a, b) {
+      return ((a[field] > b[field]) ? -1 : ((a[field] < b[field]) ? 1 : 0));
+    }
+  },
+
   // A dictionary of locations that are used across all component and action type forms
   // Using this centralised dictionary allows locations to be consistently displayed in the DB interface
   dictionary_locations: {
@@ -83,6 +97,13 @@ module.exports = {
     gwennMouster: 'Gwenn Mouster',
     sotirisVlachos: 'Sotiris Vlachos',
     kyleZeug: 'Kyle Zeug',
+  },
+
+  // Personnel who are authorised to sign-off on APA frame NCR concessions
+  dictionary_frameNCRSignoff: {
+    olgaBeltramello: 'Olga Beltramello',
+    ericJames: 'Eric James',
+    radosavPantelic: 'Radosav Pantelic',
   },
 
   // Geometry board metrology technicians at Manchester

--- a/app/pug/component_execSummary.pug
+++ b/app/pug/component_execSummary.pug
@@ -108,16 +108,9 @@ block allbody
     .entry_otherNCRs_header 
       .form_otherNCRs_header(data-record = [])
 
-    if (collatedInfo.apaNCRs_other.length > 0) || (collatedInfo.frameNCRs.length > 0) || (collatedInfo.meshPanelNCRs.length > 0)
+    if (collatedInfo.apaNCRs_other.length > 0) || (collatedInfo.meshPanelNCRs.length > 0)
       if collatedInfo.apaNCRs_other.length > 0
         each ncrInfo, index in collatedInfo.apaNCRs_other
-          .entry_otherNCRs.vert-space-x1
-            .form_otherNCRs(data-record = [ncrInfo])
-
-          hr
-
-      if collatedInfo.frameNCRs.length > 0
-        each ncrInfo, index in collatedInfo.frameNCRs
           .entry_otherNCRs.vert-space-x1
             .form_otherNCRs(data-record = [ncrInfo])
 

--- a/app/pug/search_nonConformanceByComponentTypeOrUUID.pug
+++ b/app/pug/search_nonConformanceByComponentTypeOrUUID.pug
@@ -27,7 +27,6 @@ block content
           select.form-control#componentTypeSelection
             option(value = '')
             option(value = 'assembledApa') Assembled APA 
-            option(value = 'apaFrame') APA Frame 
             option(value = 'groundingMeshPanel') Grounding Mesh Panel 
 
           .vert-space-x2

--- a/app/routes/api/users.js
+++ b/app/routes/api/users.js
@@ -98,6 +98,26 @@ router.get('/frameIntakeSignoff.json', async function (req, res, next) {
 });
 
 
+/// List personnel who are authorised to sign-off on APA frame NCR concessions
+router.get('/frameNCRSignoff.json', async function (req, res, next) {
+  try {
+    let data = [];
+
+    for (const person in utils.dictionary_frameNCRSignoff) {
+      data.push({
+        api_name: person,
+        display_name: utils.dictionary_frameNCRSignoff[person],
+      });
+    }
+
+    return res.json(data);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
 /// List geometry board metrology technicians at Manchester
 router.get('/manchesterTechnicians.json', async function (req, res, next) {
   try {

--- a/app/static/pages/component_execSummary.js
+++ b/app/static/pages/component_execSummary.js
@@ -1948,7 +1948,7 @@ async function populateExecutiveSummary() {
     Formio.createForm(form_otherNCRs_header[0], schema_otherNCRs_header, { readOnly: true, });
   })
 
-  // Render forms for the other non-conformances ... covering non wire-related assembled APA, frame and mesh panel NCRs
+  // Render forms for the other non-conformances ... covering non wire-related assembled APA and mesh panel NCRs
   $('div.entry_otherNCRs').each(function () {
     const form_otherNCRs = $('.form_otherNCRs', this);
     const ncrInfo = form_otherNCRs.data('record');

--- a/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
+++ b/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
@@ -124,11 +124,12 @@ function postSuccess(result) {
   } else {
     const tableStart = `
       <tr>
-        <th scope = 'col' width = '10%'>Component Type</th>
-        <th scope = 'col' width = '20%'>Component Name</th>
-        <th scope = 'col' width = '30%'>Non-Conformance Title / Action ID</th>
-        <th scope = 'col' width = '15%'>Disposition</th>
-        <th scope = 'col' width = '10%'>Status</th>
+        <th scope = 'col' width = '12%'>Component Type</th>
+        <th scope = 'col' width = '23%'>Component Name</th>
+        <th scope = 'col' width = '15%'>NC Type</th>
+        <th scope = 'col' width = '22%'>NC Title</th>
+        <th scope = 'col' width = '10%'>Disposition</th>
+        <th scope = 'col' width = '8%'>Status</th>
       </tr>`;
 
     $('#results').append(tableStart);
@@ -138,6 +139,7 @@ function postSuccess(result) {
         <tr>
           <td>${componentTypesDictionary[action.componentType]}</td>
           <td><a href = '/component/${action.componentUuid}' target = '_blank'</a>${action.componentName}</td>
+          <td>${action.nonConfType}</td>
           <td><a href = '/action/${action.actionId}' target = '_blank'</a>${action.title ? action.title : action.actionId}</td>
           <td>${dispositionsDictionary[action.disposition]}</td>
           <td>${statusDictionary[action.status]}</td>


### PR DESCRIPTION
- adding new personnel list for APA frame NCR concessions signoff
- adding general sorting functions to 'utils' library - these are exactly the same as the sorting functions that were previously in the various search-related libraries, but now they are centralised to avoid code duplication
- changed various libraries to use the new general sorting functions in 'utils' library
- added new APA NCR types to dictionary of types in library function (frame and mesh issues)

- removed APA frame NCRs from executive summaries ... we have decided not to put frame NCRs into the APA DB, so no attempt needs to be made to retrieve and display them
- fixed apparent bug in executive summaries library function that was stopping non-wire APA NCRs from being retrieved ... surprised that this wasn't spotted sooner

- removed 'APA Frame' option from Search for NCRs by Component Type ... same reason as for removing APA frame NCRs from executive summaries
- added NC type to the displayed results when performing a Search for NCRs by either Component Type or UUID, and adjusted layout and formatting accordingly

- added new library function to search for board shipments that reference a specific geometry board by UUID ... this is NOT a new search - it will be used to retrieve more detail about a geometry board's history, but it fits best alongside the various component-related searches