### PR TITLE
New action history setup for geometry boards ...

### DIFF
--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -368,6 +368,49 @@ block content
       .vert-space-x1.border-success.border.rounded.p-2
         #typeform
 
+    if component.formId === 'GeometryBoard'
+      .vert-space-x2.border-success.border.rounded.p-2
+        dt Geometry Board History
+        dd 
+          table.table 
+            thead 
+              tr 
+                th.col-md-2 Name 
+                th.col-md-2 Date Performed
+                th.col-md-2 Location / Shipment Origin 
+                th.col-md-2 Shipment Destination
+                th.col-md-2 Shipment Reception Date
+                th.col-md-2 Checks Passed
+
+            tbody 
+              each entry in actions
+                tr 
+                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Board Shipment')
+                    td 
+                      a(href = `/component/${entry.componentUuid}`) #{entry.typeFormName}
+                  else 
+                    td 
+                      a(href = `/action/${entry.actionId}`) #{entry.typeFormName}
+
+                  td #{entry.lastEditDate.toISOString().slice(0, 10)}
+                  td #{dictionary_locations[entry.data.originOfShipment]}
+
+                  if entry.typeFormName === 'Board Shipment'
+                    if entry.reception.location === 'in_transit'
+                      td #{dictionary_locations[entry.data.destinationOfShipment]}
+                      td [not yet received]
+                    else
+                      td #{dictionary_locations[entry.reception.location]}
+                      td #{entry.reception.date}
+                  else 
+                    td -
+                    td -
+
+                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Board Shipment')
+                    td -
+                  else 
+                    td #{entry.data.checksPassed}
+
     .vert-space-x2
       hr
 
@@ -388,31 +431,36 @@ block content
               p <b>Existing workflow actions can be accessed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
-          else 
+          else
             h4 Action History
+
+            if component.formId === 'GeometryBoard'
+              .vert-space-x1
+                p <b> Please see the table above for the action history of geometry boards</b>
 
           hr
 
           if !actions || actions.length == 0
             p None
           else
-            table.table
-              thead
-                tr
-                  th.col-md-2 Action Type Name
-                  th.col-md-2 Action ID
-                  th.col-md-2 Last Performed On:
-
-              tbody
-                each action in actions
+            if component.formId !== 'GeometryBoard'
+              table.table
+                thead
                   tr
-                    td #{action.typeFormName}
+                    th.col-md-2 Action Type Name
+                    th.col-md-2 Action ID
+                    th.col-md-2 Last Performed On:
 
-                    td
-                      a(href = `/action/${action.actionId}`) #{action.actionId}
+                tbody
+                  each action in actions
+                    tr
+                      td #{action.typeFormName}
 
-                    td
-                      +dateTimeFormat(action.lastEditDate)
+                      td
+                        a(href = `/action/${action.actionId}`) #{action.actionId}
+
+                      td
+                        +dateTimeFormat(action.lastEditDate)
 
         .col-sm-6
           if component.formId === 'AssembledAPA'

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -7,6 +7,7 @@ const Components_ExecSummary = require('../lib/Components_ExecSummary');
 const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
 const permissions = require('../lib/permissions');
+const Search_OtherComponents = require('../lib/Search_OtherComponents');
 const utils = require('../lib/utils');
 const Workflows = require('../lib/Workflows');
 
@@ -38,6 +39,58 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
     ]);
 
     if (!componentTypeForm) return res.status(404).send(`There is no component type form with form ID = ${component.formId}`);
+
+    // If the specified component is a 'Geometry Board' type, retrieve some more detailed information about any shipments that the board has been part of
+    // Add this information to the previously retrieved list of actions performed on the board, and make sure that all of the action entries contain the same (or equivalent) fields
+    // Add an entry for the board itself (again, containing the same fields as the action entries), and finally sort all entries in the combined array by the 'lastEditDate' field
+    if (component.formId === 'GeometryBoard') {
+      boardShipments = await Search_OtherComponents.boardShipmentsByBoardUUID(req.params.uuid);
+      actions = actions.concat(boardShipments);
+
+      for (let entry of actions) {
+        if (entry.typeFormId !== 'BoardShipment') {
+          entry.data = {};
+          entry.data.checksPassed = 'No';
+
+          const record = await Actions.retrieve(entry.actionId);
+
+          if (entry.typeFormId === 'BoardVisualInspection') {
+            entry.data.originOfShipment = 'lancaster';
+
+            if ((record.data.nonConformingDisposition === 'boardIsConformant') || (record.data.nonConformingDisposition === 'useAsIs')) {
+              entry.data.checksPassed = 'Yes';
+            }
+          } else if (entry.typeFormId === 'BoardToothStripAttachment') {
+            entry.data.originOfShipment = record.data.locationWorkPerformed;
+
+            if ((record.data.qcBoardDamage === 'no') && (record.data.qcGapWithBoard === 'no') && (record.data.qcToothStripDamage === 'no') && (record.data.qcStripFlushWithBoard === 'yes') && (record.data.qcCorrectEpoxyApplication === 'yes') && (record.data.qcSolderPadAlignment === 'yes')) {
+              entry.data.checksPassed = 'Yes';
+            }
+          } else if (entry.typeFormId === 'BoardMetrology') {
+            entry.data.originOfShipment = record.data.location;
+
+            if ((record.data.featurePositionChecks === 'passed') && (record.data.boardThicknessCheck === 'passed')) {
+              entry.data.checksPassed = 'Yes';
+            }
+          } else if (entry.typeFormId === 'FactoryBoardRejection') {
+            entry.data.originOfShipment = record.data.boardRejectionLocation;
+
+            if ((record.data.disposition === 'remediated') || (record.data.disposition === 'useAsIs')) {
+              entry.data.checksPassed = 'Yes';
+            }
+          }
+        }
+      }
+
+      actions.push({
+        'typeFormName': 'Board DB Record Created',
+        'componentUuid': req.params.uuid,
+        'lastEditDate': componentVersions[componentVersions.length - 1].validity.startDate,
+        'data': { 'originOfShipment': 'lancaster' },
+      });
+
+      actions.sort(utils.byField_increasing('lastEditDate'));
+    }
 
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only two workflow types, so we can do this explicitly)


### PR DESCRIPTION
- added a new 'action history' setup for geometry boards ... a new, more detailed table of actions that have been performed on each board is now shown on the component info pages
- new table replaces generic history list (only for geometry boards), and also contains information about any shipments that the board was part of