### PR TITLE
New backend code for geometry board counts ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -322,6 +322,84 @@ async function list(match_condition, options) {
 }
 
 
+/// Get a list of geometry board rejection counts across all [board part number, rejection location] combinations
+/// This function is intended to be used ONLY for 'Factory Board Rejection' type actions, and therefore does not take any user-specified arguments
+async function boardRejectionCounts_byPartNumberAndLocation() {
+  let aggregation_stages = [];
+
+  // Match against the type form ID and disposition to get records of all 'Factory Board Rejection' actions that result in a completely rejected board
+  aggregation_stages.push({
+    $match: {
+      'typeFormId': 'FactoryBoardRejection',
+      'data.disposition': 'rejected',
+    }
+  });
+
+  // Select only the latest version of each record
+  // First sort the matching records by validity ... highest version first
+  // Then group the records by the action ID (i.e. each group contains all versions of the same action), and select only the first (highest version number) entry in each group
+  // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
+  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({
+    $group: {
+      _id: { actionId: '$actionId' },
+      actionId: { '$first': '$actionId' },
+      typeFormId: { '$first': '$typeFormId' },
+      componentUuid: { '$first': '$componentUuid' },
+      location: { '$first': '$data.boardRejectionLocation' },
+    },
+  });
+
+  // Query the 'actions' records collection using the aggregation stages defined above
+  let records = await db.collection('actions')
+    .aggregate(aggregation_stages)
+    .toArray();
+
+  // At this point, we have a list of 'Factory Board Rejection' actions with the 'rejected' disposition
+  // But what we actually want is counts of how many geometry boards of each part number were rejected at each location
+
+  // Set up arrays of the possible board rejection locations (taken from the 'Factory Board Rejection' action type form) ...
+  // ... and the geometry board part numbers (taken from the 'Search for Geometry Boards by Location or Part Number' interface page .pug code) ...
+  // ... and an empty array of zeroes, each of which represents a single [location, part number] combination ... i.e. [0] = ['cambridge', '8760051'], [1] = ['cambridge', '8760054'], etc.
+  const rejectionLocations = ['cambridge', 'chicago', 'daresbury', 'lancaster', 'sheffield', 'sussex', 'williamAndMary'];
+  const boardPartNumbers = [
+    '8760051', '8760054', '8760062', '8760113', '8760038', '8760040', '8760042', '8760044', '8760057', '8760059',
+    '8760111', '8760024', '8760026', '8760030', '8760036', '8760107', '8760028', '8760032', '8760034', '8760109',
+    '8760119', '8760115', '8760123', '8760122', '8760121', '8760120', '8760104', '8760116', '8760108'
+  ];
+
+  let actionCounts_array = Array(rejectionLocations.length * boardPartNumbers.length).fill(0);
+
+  // For each previously found 'Factory Board Rejection' action ...
+  for (const action of records) {
+    // Retrieve the corresponding component record
+    const component = await Components.retrieve(MUUID.from(action.componentUuid).toString());
+
+    // Find which indices in their respective arrays correspond to the rejection location and the board part number ...
+    // ... and from these, determine which index of the 'actionCounts' array this action's [location, part number] combination corresponds to, and increment it by 1
+    actionCounts_array[(rejectionLocations.indexOf(action.location) * boardPartNumbers.length) + boardPartNumbers.indexOf(component.data.partNumber)] += 1;
+  }
+
+  // We need the return of this function to be an array of OBJECTS, to match the return of the 'Components.counts_byPartNumberAndLocation()' function ...
+  // ... since both function return to the same M2M script, which needs to output both sets of data in a consistent manner
+  // Set up a new empty array, and for each [location, part number] combination, create and fill a new object with the appropriate fields and values to match those from the other function
+  let actionCounts = [];
+
+  for (const [locationIndex, location] of rejectionLocations.entries()) {
+    for (const [partNumberIndex, partNumber] of boardPartNumbers.entries()) {
+      actionCounts.push({
+        'count': actionCounts_array[(locationIndex * boardPartNumbers.length) + partNumberIndex],
+        'partNumber': partNumber,
+        'location': location,
+      })
+    }
+  }
+
+  // Return the array of objects
+  return actionCounts;
+}
+
+
 /// Auto-complete an action ID string as it is being typed
 /// This function actually returns a list of action records with matching action IDs to that being typed
 async function autoCompleteId(inputString, limit = 10) {
@@ -381,5 +459,6 @@ module.exports = {
   retrieve,
   versions,
   list,
+  boardRejectionCounts_byPartNumberAndLocation,
   autoCompleteId,
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -73,10 +73,10 @@ async function save(input, req) {
   if (oldRecord === null) {
     // Get a list of the current component count per type across all existing component types, and then get the count of existing components of the same type as this one
     // If the component is a 'Geometry Board' type, offset the count, to account for an unknown number of boards that might have been manufactured before the database was up and running
-    const componentTypesAndCounts = await componentCountsByTypes();
+    const componentCounts_byType = await counts_byType();
     let numberOfExistingComponents = 0;
 
-    if (componentTypesAndCounts[input.formId].count) numberOfExistingComponents = componentTypesAndCounts[input.formId].count;
+    if (componentCounts_byType[input.formId].count) numberOfExistingComponents = componentCounts_byType[input.formId].count;
     if (input.formId === 'GeometryBoard') numberOfExistingComponents += 5000;
 
     // If the 'input.data' object does NOT contain a 'Type Record Number' field, add the component count to the new record's 'data' object under a new field
@@ -406,10 +406,12 @@ async function list(match_condition, options) {
 }
 
 
-/// Get a list of the current component count per type across all existing component types
-async function componentCountsByTypes() {
+/// Get a list of component counts per type across all existing component types
+async function counts_byType() {
   let aggregation_stages = [];
 
+  // Group the records by the type form ID and component UUID, so that each group represents all records with the same [component type, component UUID] combination
+  // This is an alternative approach to selecting only the most recent version of a single component ... since we don't need the individual versions, they can all be represented by a single group
   aggregation_stages.push({
     $group: {
       _id: {
@@ -419,6 +421,8 @@ async function componentCountsByTypes() {
     },
   });
 
+  // Re-group the records by the type form ID, so that each group now represents all of the previous 'single UUID' groups with the same component type
+  // Then determine the 'count' - i.e. how many records are in each group
   aggregation_stages.push({
     $group: {
       _id: '$_id.formId',
@@ -426,6 +430,7 @@ async function componentCountsByTypes() {
     },
   });
 
+  // Flatten the returned groups by projecting the 'formId' group ID directly (along with the 'count'), and not projecting the group ID object
   aggregation_stages.push({
     $project: {
       formId: '$_id',
@@ -456,6 +461,58 @@ async function componentCountsByTypes() {
 
   // Return the type forms object
   return typeFormsList;
+}
+
+
+/// Get a list of geometry board counts across all [board part number, board location] combinations
+/// This function is intended to be used ONLY for 'Geometry Board' type components, and therefore does not take any user-specified arguments
+async function boardCounts_byPartNumberAndLocation() {
+  let aggregation_stages = [];
+
+  // Match against the type form ID to get records of all components of the single specified component type
+  aggregation_stages.push({ $match: { formId: 'GeometryBoard' } });
+
+  // Group the records by the part number, location and component UUID, so that each group represents all records with the same [part number, location, component UUID] combination
+  // This is an alternative approach to selecting only the most recent version of a single component ... since we don't need the individual versions, they can all be represented by a single group
+  aggregation_stages.push({
+    $group: {
+      _id: {
+        partNumber: '$data.partNumber',
+        location: '$reception.location',
+        componentUuid: '$componentUuid',
+      },
+    },
+  });
+
+  // Re-group the records by the part number and the location, so that each group now represents all of the previous 'single UUID' groups with the same [part number, location] combination
+  // Then determine the 'count' - i.e. how many records are in each group
+  aggregation_stages.push({
+    $group: {
+      _id: {
+        partNumber: '$_id.partNumber',
+        location: '$_id.location',
+      },
+      count: { $sum: 1 },
+    },
+  });
+
+  // Flatten the returned groups by projecting the group IDs directly (along with the 'count'), and not projecting the group ID object
+  aggregation_stages.push({
+    $project: {
+      partNumber: '$_id.partNumber',
+      location: '$_id.location',
+      count: true,
+      _id: false,
+    },
+  });
+
+  // Query the 'components' records collection using the aggregation stages defined above
+  let records = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
+
+  // Return the list of grouped records
+  return records;
 }
 
 
@@ -526,6 +583,7 @@ module.exports = {
   retrieve,
   versions,
   list,
-  componentCountsByTypes,
+  counts_byType,
+  boardCounts_byPartNumberAndLocation,
   autoCompleteUuid,
 }

--- a/app/pug/component_edit.pug
+++ b/app/pug/component_edit.pug
@@ -9,7 +9,7 @@ block extrascripts
     const componentTypeForm = !{JSON.stringify(componentTypeForm, null, 4)};
     const subComponent_fullUuids = !{JSON.stringify(subComponent_fullUuids)};
     const subComponent_shortUuids = !{JSON.stringify(subComponent_shortUuids)};
-    const componentTypesAndCounts = !{JSON.stringify(componentTypesAndCounts)};
+    const componentCounts_byType = !{JSON.stringify(componentCounts_byType)};
     const workflowId = !{JSON.stringify(workflowId, null, 4)};
 
   block workscripts

--- a/app/pug/component_listTypes.pug
+++ b/app/pug/component_listTypes.pug
@@ -45,8 +45,8 @@ block content
             th.col-md-2
 
         tbody
-          each typeFormId in Object.keys(componentCountsByType).sort()
-            - const typeForm = componentCountsByType[typeFormId];
+          each typeFormId in Object.keys(componentCounts_byType).sort()
+            - const typeForm = componentCounts_byType[typeFormId];
 
             if typeForm.tags && !typeForm.tags.includes('Trash')
               tr
@@ -87,8 +87,8 @@ block content
               th.col-md-2
 
           tbody
-            each typeFormId in Object.keys(componentCountsByType).sort()
-              - const typeForm = componentCountsByType[typeFormId];
+            each typeFormId in Object.keys(componentCounts_byType).sort()
+              - const typeForm = componentCounts_byType[typeFormId];
 
               if typeForm.tags && typeForm.tags.includes('Trash')
                 tr

--- a/app/routes/api/actions.js
+++ b/app/routes/api/actions.js
@@ -162,6 +162,21 @@ router.get('/actions_NCRs/' + utils.uuid_regex, permissions.checkPermissionJson(
 });
 
 
+/// Retrieve a list of geometry board rejection counts across all [board part number, rejection location] combinations
+router.get('/actions/boardRejectionCounts_byPartNumberAndLocation', permissions.checkPermissionJson('actions:view'), async function (req, res, next) {
+  try {
+    // Retrieve a list of geometry board rejection counts across all [board part number, rejection location] combinations
+    const boardRejectionCounts_byPartNumberAndLocation = await Actions.boardRejectionCounts_byPartNumberAndLocation();
+
+    // Return the list of geometry board rejection counts
+    return res.json(boardRejectionCounts_byPartNumberAndLocation);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
 /// Compare wire tension measurements across locations
 router.get('/actions/tensionComparisonAcrossLocations/' + utils.uuid_regex + '/:wireLayer/:origin/:destination', async function (req, res, next) {
   try {

--- a/app/routes/api/components.js
+++ b/app/routes/api/components.js
@@ -135,4 +135,19 @@ router.get('/components/:typeFormId/list', permissions.checkPermissionJson('comp
 });
 
 
+/// Retrieve a list of geometry board counts across all [board part number, board location] combinations
+router.get('/components/boardCounts_byPartNumberAndLocation', permissions.checkPermissionJson('components:view'), async function (req, res, next) {
+  try {
+    // Retrieve a list of geometry board counts across all [board part number, board location] combinations
+    const boardCounts_byPartNumberAndLocation = await Components.boardCounts_byPartNumberAndLocation();
+
+    // Return the list of geometry board counts
+    return res.json(boardCounts_byPartNumberAndLocation);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
 module.exports = router;

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -649,7 +649,7 @@ router.get('/component/:typeFormId', permissions.checkPermission('components:edi
     }
 
     // Get a list of the current component count per type across all existing component types
-    const componentTypesAndCounts = await Components.componentCountsByTypes();
+    const componentCounts_byType = await Components.counts_byType();
 
     // Set the workflow ID if one is provided
     let workflowId = '';
@@ -665,7 +665,7 @@ router.get('/component/:typeFormId', permissions.checkPermission('components:edi
       componentTypeForm,
       subComponent_fullUuids,
       subComponent_shortUuids,
-      componentTypesAndCounts,
+      componentCounts_byType,
       workflowId,
     });
   } catch (err) {
@@ -694,7 +694,7 @@ router.get('/component/' + utils.uuid_regex + '/edit', permissions.checkPermissi
       componentTypeForm,
       subComponent_fullUuids: [],
       subComponent_shortUuids: [],
-      componentTypesAndCounts: [],
+      componentCounts_byType: [],
       workflowId: '',
     });
   } catch (err) {
@@ -749,11 +749,11 @@ router.get('/componentTypes/:typeFormId/edit', permissions.checkPermission('form
 /// List all component types
 router.get('/componentTypes/list', permissions.checkPermission('components:view'), async function (req, res, next) {
   try {
-    // Retrieve a list of component counts by type across all type forms
-    const componentCountsByType = await Components.componentCountsByTypes();
+    // Retrieve a list of component counts per type across all existing component types
+    const componentCounts_byType = await Components.counts_byType();
 
     // Render the interface page
-    res.render('component_listTypes.pug', { componentCountsByType });
+    res.render('component_listTypes.pug', { componentCounts_byType });
   } catch (err) {
     logger.error(err);
     res.status(500).send(err.toString());

--- a/app/static/pages/component_edit.js
+++ b/app/static/pages/component_edit.js
@@ -63,11 +63,11 @@ async function onPageLoad() {
       submission.data.subComponent_fullUuids = slice_fullUuids;
       submission.data.subComponent_shortUuids = slice_shortUuids;
 
-      // Get the count of existing components of the same type as the sub-components from the 'componentTypesAndCounts' object
+      // Get the count of existing components of the same type as the sub-components from the 'componentCounts_byType' object
       // If the component is a 'Geometry Board' type, offset the count, to account for an unknown number of boards that might have been manufactured before the database was up and running
       let numberOfExistingSubComponents = 0;
 
-      if (componentTypesAndCounts[submission.data.subComponent_formId].count) numberOfExistingSubComponents = componentTypesAndCounts[submission.data.subComponent_formId].count;
+      if (componentCounts_byType[submission.data.subComponent_formId].count) numberOfExistingSubComponents = componentCounts_byType[submission.data.subComponent_formId].count;
       if (submission.data.subComponent_formId === 'GeometryBoard') numberOfExistingSubComponents += 5000;
 
       // Set up an array to hold the sub-component type record numbers and submission objects (these will be populated in the sub-component loop below)


### PR DESCRIPTION
- new library function and API route for retrieving the counts of geometry boards at each [board part number, board location] combination
- new library function and API route for retrieving the counts of geometry board rejections at each [board part number, rejection location] combination
- renamed library function and related route and interface code variables for the existing counts per component type functionality, to make things clearer alongside new counting functions
- added comments to existing counts per component type library function

These changes relate to a new M2M script being written for use by Andra/Sandeep for tracking board intake and movement, and comparison to orders for payment, etc.