### PR TITLE
Follow Up Fixes and Changes related to Previous Commits

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -327,11 +327,10 @@ async function list(match_condition, options) {
 async function boardRejectionCounts_byPartNumberAndLocation() {
   let aggregation_stages = [];
 
-  // Match against the type form ID and disposition to get records of all 'Factory Board Rejection' actions that result in a completely rejected board
+  // Match against the type form ID to get records of all 'Factory Board Rejection' actions (with any disposition)
   aggregation_stages.push({
     $match: {
       'typeFormId': 'FactoryBoardRejection',
-      'data.disposition': 'rejected',
     }
   });
 
@@ -346,8 +345,16 @@ async function boardRejectionCounts_byPartNumberAndLocation() {
       actionId: { '$first': '$actionId' },
       typeFormId: { '$first': '$typeFormId' },
       componentUuid: { '$first': '$componentUuid' },
+      disposition: { '$first': '$data.disposition' },
       location: { '$first': '$data.boardRejectionLocation' },
     },
+  });
+
+  // Match against the disposition to select only actions that result in a completely rejected board
+  aggregation_stages.push({
+    $match: {
+      'disposition': 'rejected',
+    }
   });
 
   // Query the 'actions' records collection using the aggregation stages defined above

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -472,25 +472,37 @@ async function boardCounts_byPartNumberAndLocation() {
   // Match against the type form ID to get records of all components of the single specified component type
   aggregation_stages.push({ $match: { formId: 'GeometryBoard' } });
 
-  // Group the records by the part number, location and component UUID, so that each group represents all records with the same [part number, location, component UUID] combination
-  // This is an alternative approach to selecting only the most recent version of a single component ... since we don't need the individual versions, they can all be represented by a single group
+  // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
+  aggregation_stages.push({
+    $project: {
+      componentUuid: true,
+      data: true,
+      reception: true,
+      validity: true,
+    }
+  })
+
+  // Select only the latest version of each record
+  // First sort the matching records by validity ... highest version first
+  // Then group the records by the component UUID (i.e. each group contains all versions of the same component), and select only the first (highest version number) entry in each group
+  // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
+  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
   aggregation_stages.push({
     $group: {
-      _id: {
-        partNumber: '$data.partNumber',
-        location: '$reception.location',
-        componentUuid: '$componentUuid',
-      },
+      _id: { componentUuid: '$componentUuid' },
+      componentUuid: { '$first': '$componentUuid' },
+      partNumber: { '$first': '$data.partNumber' },
+      location: { '$first': '$reception.location' },
     },
   });
 
-  // Re-group the records by the part number and the location, so that each group now represents all of the previous 'single UUID' groups with the same [part number, location] combination
+  // Group the records by the part number and location, so that each group represents all records with the same [part number, location] combination
   // Then determine the 'count' - i.e. how many records are in each group
   aggregation_stages.push({
     $group: {
       _id: {
-        partNumber: '$_id.partNumber',
-        location: '$_id.location',
+        partNumber: '$partNumber',
+        location: '$location',
       },
       count: { $sum: 1 },
     },

--- a/app/lib/Search_GeoBoards.js
+++ b/app/lib/Search_GeoBoards.js
@@ -9,11 +9,10 @@ const { db } = require('./db');
 async function boardsByLocation(location, acceptanceStatus, toothStripStatus) {
   let aggregation_stages = [];
 
-  // Match against the type form ID and specified location to get records of all 'Geometry Board' components currently at this location
+  // Match against the type form ID to get records of all 'Geometry Board' components
   aggregation_stages.push({
     $match: {
       'formId': 'GeometryBoard',
-      'reception.location': location,
     }
   });
 
@@ -26,7 +25,15 @@ async function boardsByLocation(location, acceptanceStatus, toothStripStatus) {
       partString: { '$first': '$data.partString' },
       componentUuid: { '$first': '$componentUuid' },
       ukid: { '$first': '$data.typeRecordNumber' },
+      receptionLocation: { '$first': '$reception.location' },
     },
+  });
+
+  // Match against the specified location
+  aggregation_stages.push({
+    $match: {
+      'receptionLocation': location,
+    }
   });
 
   aggregation_stages.push({ $sort: { 'ukid': 1 } });
@@ -143,11 +150,10 @@ async function boardsByLocation(location, acceptanceStatus, toothStripStatus) {
 async function boardsByPartNumber(partNumber, acceptanceStatus, toothStripStatus) {
   let aggregation_stages = [];
 
-  // Match against the type form ID and specified part number to get records of all 'Geometry Board' components of this part number
+  // Match against the type form ID to get records of all 'Geometry Board' components
   aggregation_stages.push({
     $match: {
       'formId': 'GeometryBoard',
-      'data.partNumber': partNumber,
     }
   });
 
@@ -159,7 +165,15 @@ async function boardsByPartNumber(partNumber, acceptanceStatus, toothStripStatus
       componentUuid: { '$first': '$componentUuid' },
       receptionLocation: { '$first': '$reception.location' },
       ukid: { '$first': '$data.typeRecordNumber' },
+      partNumber: { '$first': '$data.partNumber' },
     },
+  });
+
+  // Match against the specified part number
+  aggregation_stages.push({
+    $match: {
+      'partNumber': partNumber,
+    }
   });
 
   aggregation_stages.push({ $sort: { 'ukid': 1 } });


### PR DESCRIPTION
Bug fixes in searches for geometry boards by part number or location
- the current code for searching by part number matches to all versions of a board record, not only the most recent
- it was written as such because I wasn't aware that the part number can change between record versions (it shouldn't, but it can and does)
- fixed search such that the match to part number is now done AFTER selecting only the most recent version of each board record
- made the equivalent change in the search by location ... again, the location shouldn't change between record versions, but who knows how things might behave in the future

Additional changes to library functions associated with previous bug fix
- changed 'Count Board Rejection Actions' library function so that disposition matching is done after retrieving most recent version of each action
- changed logic of 'Count Boards' library function ... the previous code flow was not working as intended (was an attempt to do things more efficiently), so it has been changed to something more equivalent to existing functions that do similar things
