### PR TITLE
Small fix for missing component names ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -392,12 +392,14 @@ async function list(match_condition, options) {
     record.componentUuid = MUUID.from(record.componentUuid).toString();
 
     if (['APAFrame', 'AssembledAPA', 'GroundingMeshPanel', 'CRBoard', 'GBiasBoard', 'CEAdapterBoard', 'SHVBoard', 'CableHarness'].includes(record.typeFormId)) {
-      const name_splits = record.name.split('-');
-      record.name = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+      if (record.name !== '') {
+        const name_splits = record.name.split('-');
+        record.name = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+      } else {
+        record.name = record.componentUuid;
+      }
     } else if (record.typeFormId === 'GeometryBoard') {
       record.name = record.data.typeRecordNumber;
-    } else {
-      record.name = record.name;
     }
   }
 


### PR DESCRIPTION
- if a board record has an empty 'data.name' field (i.e. the field exists, but is an empty string rather than the DUNE PID), the component UUID will now be shown instead
- currently, if the field is empty the entire component listing page just crashes
- note that the field shouldn't ever be empty in the first place, and if so it's a sign that something went wrong during submission ... but at least now users can still carry on using the DB while admin looks into the issue