### PR TITLE
More bug fixes ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -142,18 +142,21 @@ async function save(input, req) {
 
   if (!result.acknowledged) throw new Error(`Components::save() - failed to insert a new component record into the database!`);
 
-  // If the component is of a certain type, a location and date will have been passed to this function in the 'req.query' object
-  // Use these to update the reception information, either for the component itself or for both the component and any sub-components
-  // If successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
-  if (newRecord.formId === 'AssembledAPA') {
-    // Update the location information of the APA frame that is referenced by an Assembled APA component, to show that the frame is now being used
-    const result = await updateLocation(newRecord.data.frameUuid, req.query.location, req.query.date, newRecord.componentUuid);
-  } else if ((newRecord.formId === 'APAShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment')) {
-    const result = await updateLocations_inShipment(newRecord.componentUuid, req.query.location, req.query.date);
+  // Once the component record has been successfully saved, deal with the reception information for any related components:
+  // - for any type of shipment except a 'Populated Board Kit', update the reception information of the various sub-components to indicate that they are in transit
+  // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
+  // - for a 'Populated Board Kit', update the reception information of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
+  // - for a 'Return Geometry Board Batch', update the reception information of the individual geometry board sub-components to indicate they are at Lancaster (where the batch is put together)
+  // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
+  if ((newRecord.formId === 'APAShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment')) {
+    const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
+  } else if (newRecord.formId === 'AssembledAPA') {
+    const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
+  } else if (newRecord.formId === 'PopulatedBoardShipment') {
+    const result = await updateLocations_inShipment(newRecord.componentUuid, 'wisconsin', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'ReturnedGeometryBoardBatch') {
-    // Extract the UUID and update the location information of each board in a batch of returned geometry boards to match that from the batch's submission
     for (const board of newRecord.data.boardUuids) {
-      const result = await updateLocation(board.component_uuid, req.query.location, req.query.date, '');
+      const result = await updateLocation(board.component_uuid, 'lancaster', (new Date()).toISOString().slice(0, 10), '');
     }
   }
 
@@ -392,7 +395,7 @@ async function list(match_condition, options) {
     record.componentUuid = MUUID.from(record.componentUuid).toString();
 
     if (['APAFrame', 'AssembledAPA', 'GroundingMeshPanel', 'CRBoard', 'GBiasBoard', 'CEAdapterBoard', 'SHVBoard', 'CableHarness'].includes(record.typeFormId)) {
-      if (record.name !== '') {
+      if ((record.name !== null) && (record.name !== '')) {
         const name_splits = record.name.split('-');
         record.name = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
       } else {

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -231,7 +231,7 @@ class ComponentUUID extends TextFieldComponent {
 
     if (matchedURL) {
       console.log(`static/formio/ComponentUUID.js:233 - found 'matchedURL' (= ${matchedURL})`)
-      
+
       const shortuuid = matchedURL[1].match('[^\-]*')[0];
       let that = this;
 
@@ -290,7 +290,11 @@ class ComponentUUID extends TextFieldComponent {
           method: 'GET',
           url: `/json/component/${value}`,
           dataType: 'json',
-          success: function (component) {
+          success: function (component) {    // This line will sometimes throw an error in console when moving away from an interface page that contains a lot of UUID boxes
+                                             // It appears that this code sometimes can't quite keep up with loading all of the boxes' messages, and may not finish before the next page loads ...
+                                             // ... meaning that it cannot find the 'component' variable in time, and throws an error as a result
+                                             // It does eventually catch up if given enough time, but the box messages are purely for displaying information ...
+                                             // ... it won't affect any record submission if they don't load fast enough
             if (component.formId === 'APAFrame') {
               $.ajax({
                 contentType: 'application/json',

--- a/app/static/pages/component_edit.js
+++ b/app/static/pages/component_edit.js
@@ -155,22 +155,10 @@ function SubmitBatchData(submission) {
 
 // Function to submit either a non-batch component or the batch's overall component record to the database
 function SubmitData(submission) {
-  let url = '/json/component';
-
-  if (submission.formId === 'AssembledAPA') {
-    url += `?location=${'installed_on_APA'}&date=${(new Date()).toISOString().slice(0, 10)}`;
-  } else if ((submission.formId === 'APAShipment') || (submission.formId === 'BoardShipment') || (submission.formId === 'CEAdapterBoardShipment') || (submission.formId === 'DWAComponentShipment') || (submission.formId === 'GroundingMeshShipment')) {
-    url += `?location=${'in_transit'}&date=${(new Date()).toISOString().slice(0, 10)}`;
-  } else if (submission.formId === 'PopulatedBoardShipment') {
-    url += `?location=${'wisconsin'}&date=${(new Date()).toISOString().slice(0, 10)}`;
-  } else if (submission.formId === 'ReturnedGeometryBoardBatch') {
-    url += `?location=${'lancaster'}&date=${(new Date()).toISOString().slice(0, 10)}`;
-  }
-
   $.ajax({
     contentType: 'application/json',
     method: 'post',
-    url: url,
+    url: '/json/component',
     data: JSON.stringify(submission),
     dataType: 'json',
     success: postSuccess,


### PR DESCRIPTION
- additional fix for missing component names ... now accounting for if the 'data.name' field is completely missing
- attempting fix for missing reception information when submitting components via the M2M system ... when doing so, the client-side URL that is supposed to assign sub-component location and date parameters is bypassed, and so these fields end up being 'null' - this change moves that assignment to the server-side library function, so it should be done regardless of whether the component is submitted via the interface or via M2M
- added some comments in the Formio ComponentUUID entity code to explain a certain console error that can sometimes show up ... no actual fix needed, just an explanation for future reference