### PR TITLE
Requested new M2M functionality for performing board QA actions ...

### DIFF
--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -623,13 +623,13 @@ async function componentsByDUNEPID(dunePID) {
 
 
 /// Retrieve a list of components that match the specified type and type record number
-async function componentsByTypeAndNumber(type, typeRecordNumber) {
+async function componentsByTypeAndNumber(typeFormId, typeRecordNumber) {
   let aggregation_stages = [];
 
   // Match against the type form ID and type record number to get records of all components that have the same type and number as the specified ones
   aggregation_stages.push({
     $match: {
-      'formId': type,
+      'formId': typeFormId,
       'data.typeRecordNumber': parseInt(typeRecordNumber, 10),
     }
   });

--- a/app/routes/api/components.js
+++ b/app/routes/api/components.js
@@ -5,10 +5,11 @@ const ShortUUID = require('short-uuid');
 const Components = require('../../lib/Components');
 const logger = require('../../lib/logger');
 const permissions = require('../../lib/permissions');
+const Search_OtherComponents = require('../../lib/Search_OtherComponents');
 const utils = require('../../lib/utils');
 
 
-/// Retrieve a single version of a component record (either the most recent, or a specified one)
+/// Retrieve a single version of a component record via its UUID (either the most recent, or a specified one)
 router.get('/component/' + utils.uuid_regex, permissions.checkPermissionJson('components:view'), async function (req, res, next) {
   try {
     // Set up a query object consisting of the specified component UUID and a version number if one is provided (if not, the most recent version is assumed)
@@ -22,6 +23,26 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermissionJson('co
 
     // Return the record in JSON format
     return res.json(component);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// Retrieve the most recent version of a component record via its type form ID and type record number
+router.get('/component/:typeFormId/:typeRecordNumber', permissions.checkPermissionJson('components:view'), async function (req, res, next) {
+  try {
+    // Retrieve a reduced instance of the component record corresponding to the specified type form ID and type record number
+    const componentsList = await Search_OtherComponents.componentsByTypeAndNumber(req.params.typeFormId, req.params.typeRecordNumber);
+
+    // If at least one record has been returned, return it in JSON format ... otherwise, return 'null' explicitly (also in JSON format)
+    if (componentsList.length > 0) {
+      return res.json(componentsList[0]);
+    } else {
+      return res.json(null);
+    }
+
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);
     res.status(500).json({ error: err.toString() });

--- a/app/routes/api/search.js
+++ b/app/routes/api/search.js
@@ -205,10 +205,10 @@ router.get('/search/componentsByDUNEPID/:dunePID', async function (req, res, nex
 
 
 /// Search for components by type and type record number
-router.get('/search/componentsByTypeAndNumber/:type/:number', async function (req, res, next) {
+router.get('/search/componentsByTypeAndNumber/:typeFormId/:typeRecordNumber', async function (req, res, next) {
   try {
     // Retrieve a list of components that match the specified record details
-    const components = await Search_OtherComponents.componentsByTypeAndNumber(req.params.type, req.params.number);
+    const components = await Search_OtherComponents.componentsByTypeAndNumber(req.params.typeFormId, req.params.typeRecordNumber);
 
     // Return the list in JSON format
     return res.json(components);

--- a/m2m/README.md
+++ b/m2m/README.md
@@ -44,10 +44,15 @@ However, users will still need to call the various backend functions in their ow
     * `componentData_values` (list of variables) : the new values of the fields specified in the `componentData_fields` list
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
-* `GetComponent(componentUUID, connection, headers [, version])` : retrieve a specific version of an existing component record, returning the record as a Python dictionary
+* `GetComponent(componentUUID, connection, headers [, version])` : retrieve a specific version of an existing component record via its UUID, returning the record as a Python dictionary
     * `componentUUID` (string) : the UUID of the component to be retrieved
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
     * `version` (integer) : [OPTIONAL] the desired version of the record to retrieve ... if not specified or set to '0', the most recent version will be retrieved
+
+* `GetComponent_byTypeRecordNumber(componentTypeFormID, typeRecordNumber, connection, headers)` : retrieve the most recent version of an existing component record via its type form ID and type record number, returning the record as a Python dictionary
+    * `componentTypeFormID` (string) : the type form ID of the component to be retrieved
+    * `typeRecordNumber` (integer) : the type record number of the component to be retrieved
+    * `connection, headers` : objects returned by the `ConnectToAPI()` function
 
 * `GetListOfComponents(componentTypeFormID, connection, headers)` : retrieve a list of all components of the specified type, returning a Python list of the component UUIDs
     * `componentTypeFormID` (string) : the type form ID of the components to be listed

--- a/m2m/common.py
+++ b/m2m/common.py
@@ -208,9 +208,9 @@ def EditComponent(componentUUID, componentData_fields, componentData_values, con
         print(f" EditComponent() [GET /api/component/componentUuid] - SOCKET TIMEOUT: {s1} \n")
 
 
-###############################
-## Get an existing component ##
-###############################
+############################################
+## Get an existing component via its UUID ##
+############################################
 def GetComponent(componentUUID, connection, headers, version = 0):
     # Request a response from the API route that retrieves a specified version of an existing component record via its UUID (if no version is specified, the most recent one is retrieved)
     # If the request is successful, continue with the function ... otherwise print any raised exceptions
@@ -235,6 +235,30 @@ def GetComponent(componentUUID, connection, headers, version = 0):
         print(f" GetComponent() [GET /api/component/componentUuid] - HTTP EXCEPTION: {e} \n")
     except socket.timeout as s:
         print(f" GetComponent() [GET /api/component/componentUuid] - SOCKET TIMEOUT: {s} \n")
+
+
+###########################################################################
+## Get an existing component via its type form ID and type record number ##
+###########################################################################
+def GetComponent_byTypeRecordNumber(componentTypeFormID, typeRecordNumber, connection, headers):
+    # Request a response from the API route that retrieves the most recent version of an existing component record via its type form ID and type record number
+    # If the request is successful, continue with the function ... otherwise print any raised exceptions
+    try:
+        connection.request('GET', f'/api/component/{componentTypeFormID}/{typeRecordNumber}', headers = headers)
+
+        # The route returns the component record as a JSON document (which must be deserialised to get the record as a Python dictionary)
+        component = json.loads(connection.getresponse().read().decode('utf-8'))
+
+        # If the provided type form ID and type record number together don't correspond to an existing component record, print an error and exit the function immediately
+        if component == None:
+            sys.exit(f" GetComponent_byTypeRecordNumber() - ERROR: there is no component record with type form ID = {componentTypeFormID} and type record number = {typeRecordNumber} \n")
+
+        # Return the component record
+        return component
+    except http.client.HTTPException as e:
+        print(f" GetComponent_byTypeRecordNumber() [GET /api/component/typeFormId/typeRecordNumber] - HTTP EXCEPTION: {e} \n")
+    except socket.timeout as s:
+        print(f" GetComponent_byTypeRecordNumber() [GET /api/component/typeFormId/typeRecordNumber] - SOCKET TIMEOUT: {s} \n")
 
 
 ###################################################


### PR DESCRIPTION
- new API route to retrieve a component record via its type form ID and type record number (the library function associated with this functionality already exists)
- small changes to variable names in existing library and search functions to make things more explicit and consistent
- new M2M backend function to retrieve a component record via its type form ID and type record number, accessing the new API route, plus small change to existing 'GetComponent' function to make the difference between that and the new one more explicit
- updated M2M README with information about the new backend function