### PR TITLE
Recent Changes from Staging

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -165,36 +165,47 @@ async function save(input, req) {
 }
 
 
-/// Update the most recently logged reception location and date of a single component
+/// Update the most recently logged reception information of a single component
 async function updateLocation(componentUuid, location, date, detail) {
-  // Set up the DB query match condition to be that a record's component UUID must match the specified one
-  let match_condition = { componentUuid };
+  // The reception information should NOT be changed in the following situations:
+  //  - if the location is currently set to 'installed_on_APA' ... this can happen if a geometry board shipment is being retroactively received
+  // 
+  // First retrieve the component's record, then check for the current location, and only proceed to change the reception information if we are NOT in one of the situations described above
+  const component = await retrieve(componentUuid);
+  const currentLocation = component.reception.location;
 
-  if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
+  if (currentLocation !== 'installed_on_APA') {
+    // Set up the DB query match condition to be that a record's component UUID must match the specified one
+    let match_condition = { componentUuid };
 
-  match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
+    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
 
-  // Use the MongoDB '$set' operator to directly edit the values of the relevant fields in the component record, and throw an error if the edit fails
-  const result = db.collection('components')
-    .findOneAndUpdate(
-      match_condition,
-      {
-        $set: {
-          'reception.location': location,
-          'reception.date': date,
-          'reception.detail': detail,
-        }
-      },
-      {
-        sort: { 'validity.version': -1 },
-        returnNewDocument: true,
-      },
-    );
+    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
 
-  if (result.ok === 0) throw new Error(`Components::updateLocation() - failed to update the component record!`);
+    // Use the MongoDB '$set' operator to directly edit the values of the relevant fields in the component record, and throw an error if the edit fails
+    const result = db.collection('components')
+      .findOneAndUpdate(
+        match_condition,
+        {
+          $set: {
+            'reception.location': location,
+            'reception.date': date,
+            'reception.detail': detail,
+          }
+        },
+        {
+          sort: { 'validity.version': -1 },
+          returnNewDocument: true,
+        },
+      );
 
-  // If the edit is successful, return the status of the 'result.ok' property (which should be 1)
-  return result.ok;
+    if (result.ok === 0) throw new Error(`Components::updateLocation() - failed to update the component record!`);
+
+    // If the edit is successful, return the status of the 'result.ok' property (which should be 1)
+    return result.ok;
+  }
+
+  return 1;
 }
 
 

--- a/app/lib/Search_GeoBoards.js
+++ b/app/lib/Search_GeoBoards.js
@@ -620,9 +620,94 @@ async function boardsByOrderNumber(orderNumber) {
 }
 
 
+/// Retrieve a list of geometry boards that have been installed on a particular Assembled APA, specified by its UUID
+async function boardsByAPA(apaUUID) {
+  let aggregation_stages = [];
+
+  // Match against the type form ID to get records of all 'Geometry Board' components
+  aggregation_stages.push({
+    $match: {
+      'formId': 'GeometryBoard',
+    }
+  });
+
+  // Select the latest version of each record, and pass through only the fields required for later use
+  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({
+    $group: {
+      _id: { componentUuid: '$componentUuid' },
+      partNumber: { '$first': '$data.partNumber' },
+      partString: { '$first': '$data.partString' },
+      componentUuid: { '$first': '$componentUuid' },
+      ukid: { '$first': '$data.typeRecordNumber' },
+      receptionLocation: { '$first': '$reception.location' },
+      receptionDetail: { '$first': '$reception.detail' },
+    },
+  });
+
+  // Match against the reception location and detail to get only those boards that have been installed on the specified APA
+  // Note that for some reason, the APA UUID can be saved into the 'reception.detail' field as EITHER a string OR a MUUID-type object, so we have to account for both possibilities
+  aggregation_stages.push({
+    $match: {
+      'receptionLocation': 'installed_on_APA',
+      'receptionDetail': { $in: [apaUUID, MUUID.from(apaUUID)] },
+    }
+  });
+
+  aggregation_stages.push({ $sort: { 'ukid': 1 } });
+
+  // Group the records according to the board part number and corresponding string, and pass through the fields required for later use
+  aggregation_stages.push({
+    $group: {
+      _id: {
+        partNumber: '$partNumber',
+        partString: '$partString',
+      },
+      componentUuid: { $push: '$componentUuid' },
+    }
+  });
+
+  // Sort the record groups to be in numerical order of the part number
+  aggregation_stages.push({ $sort: { '_id.partNumber': 1 } });
+
+  // Query the 'components' records collection using the aggregation stages defined above
+  let results = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
+
+  // Reorganise the query results to make it easier to display them on the interface page
+  let cleanedResults = [];
+
+  for (const boardGroup of results) {
+    let cleanedBoardGroup = {};
+
+    cleanedBoardGroup.partNumber = boardGroup._id.partNumber;
+    cleanedBoardGroup.partString = boardGroup._id.partString;
+
+    cleanedBoardGroup.componentUuids = [];
+    cleanedBoardGroup.ukids = [];
+    cleanedBoardGroup.receptionDates = [];
+
+    for (const boardUuid of boardGroup.componentUuid) {
+      const board = await Components.retrieve(MUUID.from(boardUuid).toString());
+
+      cleanedBoardGroup.componentUuids.push(MUUID.from(boardUuid).toString());
+      cleanedBoardGroup.ukids.push(board.data.typeRecordNumber);
+      cleanedBoardGroup.receptionDates.push(board.reception.date);
+    }
+
+    if (cleanedBoardGroup.componentUuids.length > 0) cleanedResults.push(cleanedBoardGroup);
+  }
+
+  // Return the list of boards grouped by part numbers
+  return cleanedResults;
+}
+
+
 module.exports = {
   boardsByLocation,
   boardsByPartNumber,
   boardsByVisualInspection,
   boardsByOrderNumber,
+  boardsByAPA,
 }    

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -7,6 +7,8 @@ block extrascripts
     const componentVersions = !{JSON.stringify(componentVersions, null, 4)};
     const componentTypeForm = !{JSON.stringify(componentTypeForm, null, 4)};
     const collectionDetails = !{JSON.stringify(collectionDetails, null, 4)};
+    const installedGeometryBoards = !{JSON.stringify(installedGeometryBoards, null, 4)};
+    const installedGeometryBoardsCount = !{JSON.stringify(installedGeometryBoardsCount, null, 4)};
     const actions = !{JSON.stringify(actions, null, 4)};
     const mostRecentAction = !{JSON.stringify(mostRecentAction, null, 4)};
     const actionTypeForms = !{JSON.stringify(actionTypeForms, null, 4)};
@@ -419,6 +421,51 @@ block content
                     td -
                   else 
                     td #{entry.data.checksPassed}
+
+    if component.formId === 'AssembledAPA'
+      .vert-space-x2.border-success.border.rounded.p-2
+        dt Installed Geometry Boards (#{installedGeometryBoardsCount})
+        dd
+          .row 
+            .col-sm-5 
+              table.table 
+                thead 
+                  tr 
+                    th.col-md-8 Part Number / String 
+                    th.col-md-1 UKID
+                    th.col-md-3 Install. Date
+
+                tbody 
+                  each entry in installedGeometryBoards.slice(0, (installedGeometryBoards.length / 2))
+                    each uuid, index in entry.componentUuids
+                      tr 
+                        td #{entry.partNumber} (#{entry.partString})
+                        td
+                          a(href = `/component/${uuid}`) #{entry.ukids[index]}
+
+                        td #{entry.receptionDates[index]}
+
+            .col-sm-1 
+
+            .col-sm-5 
+              table.table 
+                thead 
+                  tr 
+                    th.col-md-8 Part Number / String 
+                    th.col-md-1 UKID
+                    th.col-md-3 Install. Date
+
+                tbody 
+                  each entry in installedGeometryBoards.slice((installedGeometryBoards.length / 2), installedGeometryBoards.length)
+                    each uuid, index in entry.componentUuids
+                      tr 
+                        td #{entry.partNumber} (#{entry.partString})
+                        td
+                          a(href = `/component/${uuid}`) #{entry.ukids[index]}
+
+                        td #{entry.receptionDates[index]}
+
+            .col-sm-1
 
     .vert-space-x2
       hr

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -7,6 +7,7 @@ const Components_ExecSummary = require('../lib/Components_ExecSummary');
 const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
 const permissions = require('../lib/permissions');
+const Search_GeoBoards = require('../lib/Search_GeoBoards');
 const Search_OtherComponents = require('../lib/Search_OtherComponents');
 const utils = require('../lib/utils');
 const Workflows = require('../lib/Workflows');
@@ -246,12 +247,26 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
       }
     }
 
+    // If the specified component is an 'Assembled APA' type, retrieve some more detailed information about any geometry boards that have been installed on it
+    let installedGeometryBoards = [];
+    let installedGeometryBoardsCount = 0;
+
+    if (component.formId === 'AssembledAPA') {
+      installedGeometryBoards = await Search_GeoBoards.boardsByAPA(req.params.uuid);
+
+      for (const boardGroup of installedGeometryBoards) {
+        installedGeometryBoardsCount += boardGroup.componentUuids.length;
+      }
+    }
+
     // Render the interface page
     res.render('component.pug', {
       component,
       componentVersions,
       componentTypeForm,
       collectionDetails,
+      installedGeometryBoards,
+      installedGeometryBoardsCount,
       actions: nonWorkflowActions,
       mostRecentAction,
       actionTypeForms,


### PR DESCRIPTION
Adding display of installed geometry boards to APA component info ...
- the component information pages of Assembled APAs now show a table of all installed geometry boards (UKID, part number and string, link to board info page)
- added new library function, modified existing component info retrieval route, modified existing component info page .pug file

Guarding against retroactive board shipment reception ...
- the reception information of individual geometry boards will no longer be updated if they've already been installed on an APA (reception.location = 'installed_on_APA')
- this should prevent boards from being 'reset' to their last shipment reception location if the shipment is retroactively received somewhere

Changes have been tested on Staging.

