### PR TITLE
Requests Relating to Component Locations

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -115,16 +115,18 @@ async function save(input, req) {
     // Components of certain types will always start at specific fixed locations, whereas the rest do not need any initial location set (only for the record field to exist)
     if ((input.formId === 'APAFrame') || (input.formId === 'GroundingMeshPanel')) {
       newRecord.reception.location = 'ukWarehouse';
-    } else if ((input.formId === 'APAShipment') || (input.formId === 'BoardShipment') || (input.formId === 'CEAdapterBoardShipment') || (input.formId === 'DWAComponentShipment') || (input.formId === 'FrameShipment') || (input.formId === 'GroundingMeshShipment')) {
+    } else if ((input.formId === 'APAShipment') || (input.formId === 'BoardShipment') || (input.formId === 'DWAComponentShipment') || (input.formId === 'FrameShipment') || (input.formId === 'GroundingMeshShipment') || (input.formId === 'PopulatedBoardShipment')) {
       newRecord.reception.location = 'in_transit';
-    } else if ((input.formId === 'AssembledAPA') || (input.formId === 'wire_bobbin')) {
-      newRecord.reception.location = 'daresbury';
-    } else if ((input.formId === 'CEAdapterBoard') || (input.formId === 'CRBoard') || (input.formId === 'CableHarness') || (input.formId === 'GBiasBoard') || (input.formId === 'SHVBoard') || (input.formId === 'PopulatedBoardShipment')) {
+    } else if (input.formId === 'AssembledAPA') {
+      newRecord.reception.location = newRecord.data.apaAssemblyLocation;
+    } else if ((input.formId === 'CEAdapterBoard') || (input.formId === 'CEAdapterBoardShipment') || (input.formId === 'CRBoard') || (input.formId === 'CRBoardShipment') || (input.formId === 'CableHarness') || (input.formId === 'CableHarnessShipment') || (input.formId === 'GBiasBoard') || (input.formId === 'GBiasBoardShipment') || (input.formId === 'SHVBoard') || (input.formId === 'SHVBoardShipment')) {
       newRecord.reception.location = 'wisconsin';
     } else if ((input.formId === 'DWA') || (input.formId === 'DWAPDB')) {
       newRecord.reception.location = newRecord.data.productionLocation;
     } else if (input.formId === 'GeometryBoard') {
       newRecord.reception.location = 'lancaster';
+    } else if (input.formId === 'wire_bobbin') {
+      newRecord.reception.location = 'daresbury';
     } else {
       newRecord.reception.location = '';
     }
@@ -143,17 +145,15 @@ async function save(input, req) {
   if (!result.acknowledged) throw new Error(`Components::save() - failed to insert a new component record into the database!`);
 
   // Once the component record has been successfully saved, deal with the reception information for any related components:
-  // - for any type of shipment except a 'Populated Board Kit', update the reception information of the various sub-components to indicate that they are in transit
+  // - for various types of shipment, update the reception information of the various sub-components to indicate that they are in transit
   // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
-  // - for a 'Populated Board Kit', update the reception information of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
+  // - for a 'Populated Board Shipment', update the reception information of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
   // - for a 'Return Geometry Board Batch', update the reception information of the individual geometry board sub-components to indicate they are at Lancaster (where the batch is put together)
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
-  if ((newRecord.formId === 'APAShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment')) {
+  if ((newRecord.formId === 'APAShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
-  } else if (newRecord.formId === 'PopulatedBoardShipment') {
-    const result = await updateLocations_inShipment(newRecord.componentUuid, 'wisconsin', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'ReturnedGeometryBoardBatch') {
     for (const board of newRecord.data.boardUuids) {
       const result = await updateLocation(board.component_uuid, 'lancaster', (new Date()).toISOString().slice(0, 10), '');
@@ -209,7 +209,7 @@ async function updateLocation(componentUuid, location, date, detail) {
 }
 
 
-/// Update the most recently logged reception locations and dates of all sub-components in a shipment-like component
+/// Update the most recently logged reception locations and dates of all sub-components in a shipment-type component
 async function updateLocations_inShipment(componentUuid, location, date) {
   // Retrieve the most recent version of the shipment-like component record corresponding to the specified component UUID
   const shipment = await retrieve(componentUuid);
@@ -221,14 +221,9 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     for (const apa of shipment.data.apaUuiDs) {
       const result = await updateLocation(apa.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'BoardShipment') {
-    // Extract the UUID and update the location information of each geometry board in a shipment of geometry boards
+  } else if ((shipment.formId === 'BoardShipment') || (shipment.formId === 'CEAdapterBoardShipment') || (shipment.formId === 'CRBoardShipment') || (shipment.formId === 'CableHarnessShipment') || (shipment.formId === 'GBiasBoardShipment') || (shipment.formId === 'SHVBoardShipment')) {
+    // Extract the UUID and update the location information of each board in a shipment of (single type) boards
     for (const board of shipment.data.boardUuiDs) {
-      const result = await updateLocation(board.component_uuid, location, date, '');
-    }
-  } else if (shipment.formId === 'CEAdapterBoardShipment') {
-    // Extract the UUID and update the location information of each CE Adapter board in a shipment of CE Adapter boards
-    for (const board of shipment.data.ceAdapterBoardUuiDs) {
       const result = await updateLocation(board.component_uuid, location, date, '');
     }
   } else if (shipment.formId === 'DWAComponentShipment') {
@@ -242,21 +237,21 @@ async function updateLocations_inShipment(componentUuid, location, date) {
       const result = await updateLocation(mesh.component_uuid, location, date, '');
     }
   } else if (shipment.formId === 'PopulatedBoardShipment') {
-    // Extract the UUID and update the location information of each component in a populated kit
-    for (const board of shipment.data.crBoardUuiDs) {
-      const result = await updateLocation(board.component_uuid, location, date, '');
+    // Extract the UUID and update the location information of each shipment in a multi-type populated board shipment
+    for (const crBoardShipment of shipment.data.crBoardKitUuiDs) {
+      const result = await updateLocations_inShipment(crBoardShipment.component_uuid, location, date);
     }
 
-    for (const board of shipment.data.gBiasBoardUuiDs) {
-      const result = await updateLocation(board.component_uuid, location, date, '');
+    for (const gBiasBoardShipment of shipment.data.gBiasBoardKitUuiDs) {
+      const result = await updateLocations_inShipment(gBiasBoardShipment.component_uuid, location, date);
     }
 
-    for (const board of shipment.data.shvBoardUuiDs) {
-      const result = await updateLocation(board.component_uuid, location, date, '');
+    for (const shvBoardShipment of shipment.data.shvBoardKitUuiDs) {
+      const result = await updateLocations_inShipment(shvBoardShipment.component_uuid, location, date);
     }
 
-    for (const board of shipment.data.cableHarnessUuiDs) {
-      const result = await updateLocation(board.component_uuid, location, date, '');
+    for (const cableHarnessShipment of shipment.data.cableHarnessKitUuiDs) {
+      const result = await updateLocations_inShipment(cableHarnessShipment.component_uuid, location, date);
     }
   }
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -41,6 +41,7 @@ module.exports = {
     surf: 'SURF',
     sussex: 'Sussex',
     ukWarehouse: 'UK Warehouse',
+    unknown: 'Unknown / Lost',
     williamAndMary: 'William and Mary',
     wisconsin: 'Wisconsin',
   },

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -187,15 +187,9 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'CEAdapterBoardShipment'
+    else if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
-        dt Origin Location 
-        dd #{dictionary_locations[component.data.originOfShipment]}
-
-        dt Destination Location
-        dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-        dt Boards in Shipment
+        dt Boards in Shipment / Kit
         dd
           table.table
             thead
@@ -288,14 +282,13 @@ block content
         dt Destination Location
         dd #{dictionary_locations[component.data.destinationOfShipment]}
 
-        dt Components in Kit
+        dt Single-Type Shipments in Multi-Type Shipment
         dd
           table.table 
             thead 
               tr 
                 th.col-md-2 UUID 
-                th.col-md-1 Type
-                th.col-md-1 UW ID 
+                th.col-md-2 Type
                 th.col-md-3 QR Code Link 
 
             tbody 
@@ -304,9 +297,8 @@ block content
                   td
                     a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
 
-                  td #{info[2]}
                   td #{info[1]}
-                  td #{`${base_url}/c/${info[3]}`}
+                  td #{`${base_url}/c/${info[2]}`}
 
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -22,7 +22,7 @@ block allbody
     .container.fluid
       - const qrCodeText = `${base_url}/c/${component.shortUuid.toString()}`;
 
-      if (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'FrameShipment') || (component.formId === 'GroundingMeshShipment') || (component.formId === 'PopulatedBoardShipment')
+      if (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'FrameShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment')
         - const qrCodeDesc = component.componentUuid
 
         .row.qr-row

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -48,7 +48,7 @@ block allbody
               else
                 dd (none)
 
-              if component.formId == 'BoardShipment'
+              if component.formId == 'BoardShipment' || component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
                 dt Number of Boards in Shipment
                 dd #{component.data.boardUuiDs.length}
 
@@ -92,15 +92,9 @@ block allbody
                     td #{info[0]}
                     td #{info[1]}
                     td #{info[2]}
-      else if component.formId === 'CEAdapterBoardShipment'
+      else if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
         .vert-space-x1.border-success.border.rounded.p-2
-          dt Origin Location 
-          dd #{dictionary_locations[component.data.originOfShipment]}
-
-          dt Destination Location
-          dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-          dt Boards in Shipment
+          dt Boards in Shipment / Kit
           dd
             table.table
               thead
@@ -169,20 +163,18 @@ block allbody
           dt Destination Location
           dd #{dictionary_locations[component.data.destinationOfShipment]}
 
-          dt Components in Kit
+          dt Single-Type Shipments in Multi-Type Shipment
           dd
             table.table 
               thead 
                 tr 
                   th.col-sm-1 UUID 
-                  th.col-sm-1 Type
-                  th.col-sm-1 UW ID 
+                  th.col-sm-2 Type
 
               tbody 
                 each info in collectionDetails
                   tr
                     td #{info[0]}
-                    td #{info[2]}
                     td #{info[1]}
       else if component.formId === 'CEAdapterBoardBatch' || component.formId === 'CRBoardBatch' || component.formId === 'GBiasBoardBatch' || component.formId === 'GeometryBoardBatch'
         if component.formId === 'GeometryBoardBatch'

--- a/app/pug/search_componentsByIdentifier.pug
+++ b/app/pug/search_componentsByIdentifier.pug
@@ -58,6 +58,7 @@ block content
               option(value = 'GeometryBoard') Geometry Board
               option(value = 'GroundingMeshPanel') Grounding Mesh Panel
               option(value = 'SHVBoard') SHV Board
+              option(value = 'Yoke') Yoke
 
           .vert-space-x2
             p Enter a type record number below.

--- a/app/pug/search_geoBoardsByLocationOrPartNumber.pug
+++ b/app/pug/search_geoBoardsByLocationOrPartNumber.pug
@@ -41,6 +41,7 @@ block content
                 option(value = 'merlin') #{dictionary_locations['merlin']} 
                 option(value = 'sheffield') #{dictionary_locations['sheffield']} 
                 option(value = 'sussex') #{dictionary_locations['sussex']} 
+                option(value = 'unknown') #{dictionary_locations['unknown']} 
                 option(value = 'williamAndMary') #{dictionary_locations['williamAndMary']} 
                 option(value = 'wisconsin') #{dictionary_locations['wisconsin']} 
 

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -157,8 +157,8 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
       }
     }
 
-    if (component.formId === 'CEAdapterBoardShipment') {
-      for (const info of component.data.ceAdapterBoardUuiDs) {
+    if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
+      for (const info of component.data.boardUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -194,43 +194,43 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
     }
 
     if (component.formId === 'PopulatedBoardShipment') {
-      for (const info of component.data.crBoardUuiDs) {
+      for (const info of component.data.crBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
 
-      for (const info of component.data.gBiasBoardUuiDs) {
+      for (const info of component.data.gBiasBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
 
-      for (const info of component.data.shvBoardUuiDs) {
+      for (const info of component.data.shvBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
 
-      for (const info of component.data.cableHarnessUuiDs) {
+      for (const info of component.data.cableHarnessKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
     }
@@ -309,20 +309,8 @@ router.get('/component/' + utils.uuid_regex + '/batchQRCodes', permissions.check
     // ... but for batch-type components, they are already saved in the batch component's own record, so the individual sub-component records are not needed
     let shortUUIDs = [];
 
-    if (component.formId === 'BoardShipment') {
+    if ((component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
-        let uuid = info.component_uuid;
-
-        if (uuid !== '') {
-          const boardRecord = await Components.retrieve(uuid);
-
-          if (boardRecord) shortUUIDs.push([boardRecord.data.typeRecordNumber, boardRecord.shortUuid, boardRecord.formName]);
-        }
-      }
-    }
-
-    if (component.formId === 'CEAdapterBoardShipment') {
-      for (const info of component.data.ceAdapterBoardUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -358,7 +346,7 @@ router.get('/component/' + utils.uuid_regex + '/batchQRCodes', permissions.check
     }
 
     if (component.formId === 'PopulatedBoardShipment') {
-      for (const info of component.data.crBoardUuiDs) {
+      for (const info of component.data.crBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -368,7 +356,7 @@ router.get('/component/' + utils.uuid_regex + '/batchQRCodes', permissions.check
         }
       }
 
-      for (const info of component.data.gBiasBoardUuiDs) {
+      for (const info of component.data.gBiasBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -378,7 +366,7 @@ router.get('/component/' + utils.uuid_regex + '/batchQRCodes', permissions.check
         }
       }
 
-      for (const info of component.data.shvBoardUuiDs) {
+      for (const info of component.data.shvBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -388,7 +376,7 @@ router.get('/component/' + utils.uuid_regex + '/batchQRCodes', permissions.check
         }
       }
 
-      for (const info of component.data.cableHarnessUuiDs) {
+      for (const info of component.data.cableHarnessKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -508,8 +496,8 @@ router.get('/component/' + utils.uuid_regex + '/summary', permissions.checkPermi
       }
     }
 
-    if (component.formId === 'CEAdapterBoardShipment') {
-      for (const info of component.data.ceAdapterBoardUuiDs) {
+    if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
+      for (const info of component.data.boardUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -545,7 +533,7 @@ router.get('/component/' + utils.uuid_regex + '/summary', permissions.checkPermi
     }
 
     if (component.formId === 'PopulatedBoardShipment') {
-      for (const info of component.data.crBoardUuiDs) {
+      for (const info of component.data.crBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -555,7 +543,7 @@ router.get('/component/' + utils.uuid_regex + '/summary', permissions.checkPermi
         }
       }
 
-      for (const info of component.data.gBiasBoardUuiDs) {
+      for (const info of component.data.gBiasBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -565,7 +553,7 @@ router.get('/component/' + utils.uuid_regex + '/summary', permissions.checkPermi
         }
       }
 
-      for (const info of component.data.shvBoardUuiDs) {
+      for (const info of component.data.shvBoardKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {
@@ -575,7 +563,7 @@ router.get('/component/' + utils.uuid_regex + '/summary', permissions.checkPermi
         }
       }
 
-      for (const info of component.data.cableHarnessUuiDs) {
+      for (const info of component.data.cableHarnessKitUuiDs) {
         let uuid = info.component_uuid;
 
         if (uuid !== '') {


### PR DESCRIPTION
Adding new 'unknown / lost' geometry board location ...
- added new key/value pair to central dictionary of all recognised locations
- added new option to menu of selectable locations in the 'Search for Geometry Boards by Location / Part Number'

Adding 'Yoke' to the searchable component types by identifier

Changes and updates to shipment location tracking ...
- added location tracking for new board shipment type components ... initial locations are all 'Wisconsin', changeable to 'In Transit' upon creation of the (new style) Populated Board Shipment and then wherever they are received
- CE Adapter Board shipments now assigned an initial location of 'Wisconsin', in line with other US board shipments
- Assembled APAs now assigned an initial location equal to their production location (was previously always Daresbury, even for US ones)
- reworked updating of shipment component locations for Populated Board Shipments ... since this type of component now contains shipments of boards (not the individual boards themselves), the field names have been changed accordingly, and the call to update shipments within shipments is recursive
- added new board shipment types to interface pages for displaying component information, component QR codes and summaries, with corresponding changes to the page routes
- removed 'typeRecordNumber' variable from being sent to interface when displaying Populated Board Shipments, since these don't matter anymore for the sub-shipments

All changes have been tested on Staging.