### PR TITLE
Changes relating to new Board Installation actions ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -15,12 +15,7 @@ const reception_typeFormIDs = ['APAShipmentReception', 'BoardReception', 'CEAdap
 
 // Declare a list of the available 'board installation' and 'mesh installation' action type forms
 // NOTE: this must be the same as the equivalent list given in 'static/pages/action_specComponent.js'
-const installation_typeFormIDs = [
-  'g_foot_board_install', 'g_head_board_install_sideA', 'g_head_board_install_sideB', 'x_foot_board_install', 'x_head_board_install_sideA', 'x_head_board_install_sideB',
-  'u_foot_boards_install', 'u_head_board_install_sideA', 'u_head_board_installation_sideB', 'u_side_board_install_HSB', 'u_side_board_install_LSB',
-  'v_foot_board_install', 'v_head_board_install_sideA', 'v_head_board_install_sideB', 'v_side_board_install_HSB', 'v_side_board_install_LSB',
-  'prep_mesh_panel_install',
-];
+const installation_typeFormIDs = ['x_boards', 'v_boards', 'u_boards', 'g_boards', 'prep_mesh_panel_install'];
 
 
 /// Save a new or edited action record
@@ -126,14 +121,44 @@ async function save(input, req) {
   // Use these to update the location information for each individual board or mesh referenced in this action
   // If successful, the updating function returns 'result = 1', but we don't actually use this value anywhere
   if (installation_typeFormIDs.includes(newRecord.typeFormId)) {
-    const uuid_format = new RegExp(/[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}/);
+    if (newRecord.typeFormId === 'prep_mesh_panel_install') {
+      const uuid_format = new RegExp(/[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}/);
 
-    for (const [key, value] of Object.entries(newRecord.data)) {
-      if (uuid_format.test(value)) {
-        if (req.query.location === 'installed_on_APA') {
+      for (const [key, value] of Object.entries(newRecord.data)) {
+        if (uuid_format.test(value)) {
           const result = await Components.updateLocation(value, req.query.location, req.query.date, newRecord.componentUuid);
-        } else {
-          const result = await Components.updateLocation(value, req.query.location, req.query.date, '');
+        }
+      }
+    } else {
+      for (const board of newRecord.data.headBoardsA) {
+        if (board.boardUuid !== '') {
+          const result = await Components.updateLocation(board.boardUuid, req.query.location, req.query.date, newRecord.componentUuid);
+        }
+      }
+
+      for (const board of newRecord.data.headBoardsB) {
+        if (board.boardUuid !== '') {
+          const result = await Components.updateLocation(board.boardUuid, req.query.location, req.query.date, newRecord.componentUuid);
+        }
+      }
+
+      for (const board of newRecord.data.footBoards) {
+        if (board.boardUuid !== '') {
+          const result = await Components.updateLocation(board.boardUuid, req.query.location, req.query.date, newRecord.componentUuid);
+        }
+      }
+
+      if (newRecord.data.sideBoardsHSB) {
+        for (const board of newRecord.data.sideBoardsHSB) {
+          if (board.boardUuid !== '') {
+            const result = await Components.updateLocation(board.boardUuid, req.query.location, req.query.date, newRecord.componentUuid);
+          }
+        }
+
+        for (const board of newRecord.data.sideBoardsLSB) {
+          if (board.boardUuid !== '') {
+            const result = await Components.updateLocation(board.boardUuid, req.query.location, req.query.date, newRecord.componentUuid);
+          }
         }
       }
     }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -172,8 +172,10 @@ async function save(input, req) {
 /// Update the most recently logged reception information of a single component
 async function updateLocation(componentUuid, location, date, detail) {
   // The reception information should NOT be changed in the following situations:
-  //  - if the location is currently set to 'installed_on_APA' ... this can happen if a geometry board shipment is being retroactively received
-  // 
+  //  - if the location is currently set to 'installed_on_APA' ... this can happen in the following circumstances:
+  //      * if a geometry board shipment is being retroactively received
+  //      * when a board installation action has previously been only partially completed, and is now being edited with additional board entries
+
   // First retrieve the component's record, then check for the current location, and only proceed to change the reception information if we are NOT in one of the situations described above
   const component = await retrieve(componentUuid);
   const currentLocation = component.reception.location;

--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -203,12 +203,7 @@ async function boardInstallByReferencedComponent(componentUUID) {
   aggregation_stages.push({
     $match: {
       'typeFormId': {
-        $in: [
-          'g_foot_board_install', 'g_head_board_install_sideA', 'g_head_board_install_sideB',
-          'u_foot_boards_install', 'u_head_board_install_sideA', 'u_head_board_installation_sideB', 'u_side_board_install_HSB', 'u_side_board_install_LSB',
-          'v_foot_board_install', 'v_head_board_install_sideA', 'v_head_board_install_sideB', 'v_side_board_install_HSB', 'v_side_board_install_LSB',
-          'x_foot_board_install', 'x_head_board_install_sideA', 'x_head_board_install_sideB',
-        ]
+        $in: ['x_boards', 'v_boards', 'u_boards', 'g_boards']
       },
     }
   });
@@ -232,14 +227,33 @@ async function boardInstallByReferencedComponent(componentUUID) {
 
 
   // At this point, we have a list of all 'Board Installation' action records
-  // But we want to narrow this down to only those records which contain the specified component UUID in one of the 'data.boardXUuid' key/value pairs, where X = 1 -> 10 or 21
-  // Loop over the keys in each record's 'data' object, and if the value matches the specified UUID, save the record into a list to be returned
+  // But we want to narrow this down to only those records which contain the specified component UUID in one of the arrays of board UUIDs in the 'data' object ...
+  // ... where the arrays are named: 'headBoardsA', 'headBoardsB', 'footBoards', 'sideBoardsHSB', 'sideBoardsLSB' (the latter two being present only in V and U layer board installation actions)
+  // Loop over the entries in each possible array, and if the entry's UUID matches the specified one, save the record into a list to be returned
   let boardInstalls = [];
 
   if (results.length > 0) {
     for (const action of results) {
-      for (const [key, value] of Object.entries(action.data)) {
-        if (value === componentUUID) boardInstalls.push(action);
+      for (const board of action.data.headBoardsA) {
+        if (board.boardUuid === componentUUID) boardInstalls.push(action);
+      }
+
+      for (const board of action.data.headBoardsB) {
+        if (board.boardUuid === componentUUID) boardInstalls.push(action);
+      }
+
+      for (const board of action.data.footBoards) {
+        if (board.boardUuid === componentUUID) boardInstalls.push(action);
+      }
+
+      if (action.data.sideBoardsHSB) {
+        for (const board of action.data.sideBoardsHSB) {
+          if (board.boardUuid === componentUUID) boardInstalls.push(action);
+        }
+
+        for (const board of action.data.sideBoardsLSB) {
+          if (board.boardUuid === componentUUID) boardInstalls.push(action);
+        }
       }
     }
   }

--- a/app/pug/search_actionsByIDOrReferencedUUID.pug
+++ b/app/pug/search_actionsByIDOrReferencedUUID.pug
@@ -44,7 +44,7 @@ block content
 
                 select.form-control#actionTypeSelection
                   option(value = '')          
-                  option(value = 'boardInstall') Board Installation (any layer, any side, any position) [Geometry Boards]
+                  option(value = 'boardInstall') Board Installation (any layer) [Geometry Boards]
                   option(value = 'winding') Winding (any layer) [Wire Bobbins]
 
               .vert-space-x2

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -291,10 +291,10 @@ class ComponentUUID extends TextFieldComponent {
           url: `/json/component/${value}`,
           dataType: 'json',
           success: function (component) {    // This line will sometimes throw an error in console when moving away from an interface page that contains a lot of UUID boxes
-                                             // It appears that this code sometimes can't quite keep up with loading all of the boxes' messages, and may not finish before the next page loads ...
-                                             // ... meaning that it cannot find the 'component' variable in time, and throws an error as a result
-                                             // It does eventually catch up if given enough time, but the box messages are purely for displaying information ...
-                                             // ... it won't affect any record submission if they don't load fast enough
+            // It appears that this code sometimes can't quite keep up with loading all of the boxes' messages, and may not finish before the next page loads ...
+            // ... meaning that it cannot find the 'component' variable in time, and throws an error as a result
+            // It does eventually catch up if given enough time, but the box messages are purely for displaying information ...
+            // ... it won't affect any record submission if they don't load fast enough
             if (component.formId === 'APAFrame') {
               $.ajax({
                 contentType: 'application/json',
@@ -310,14 +310,14 @@ class ComponentUUID extends TextFieldComponent {
                       dataType: 'json',
                       success: function (action) {
                         if (action.data.actionComplete) {
-                          info_target.text(`\xa0 This ${component.formName} is ready for use ... click here for this component's information page`);
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for use`);
                         } else {
-                          info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (Final QA Checklist is not complete)... click here for this component's information page`);
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s Final QA Checklist is not complete!`);
                         }
                       },
                     }).fail();
                   } else {
-                    info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (no Final QA Checklist)... click here for this component's information page`);
+                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a Final QA Checklist!`);
                   }
                 },
               }).fail();
@@ -336,22 +336,22 @@ class ComponentUUID extends TextFieldComponent {
                       dataType: 'json',
                       success: function (action) {
                         if ((action.data.disposition === 'useAsIs') || (action.data.disposition === 'conformant')) {
-                          info_target.text(`\xa0 This ${component.formName} is ready for use ... click here for this component's information page`);
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for use`);
                         } else {
-                          info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (QA Inspection disposition is not 'Use As Is' or 'Conformant')... click here for this component's information page`);
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s QA Inspection disposition is not 'Use As Is' or 'Conformant'!`);
                         }
                       },
                     }).fail();
                   } else {
-                    info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (no QA Inspection)... click here for this component's information page`);
+                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a QA Inspection!`);
                   }
                 },
               }).fail();
             } else if (component.formId === 'wire_bobbin') {
               if (component.data.meanBreakStrength >= 24.0) {
-                info_target.text(`\xa0 This ${component.formName} is ready for use ... click here for this component's information page`);
+                info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for use`);
               } else {
-                info_target.text(`\xa0 This ${component.formName} is NOT READY TO BE USED (mean break strength < 24.0 N)... click here for this component's information page`);
+                info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s mean break strength is less than 24.0 N!`);
               }
             } else if (component.formId === 'GeometryBoard') {
               $.ajax({
@@ -361,7 +361,7 @@ class ComponentUUID extends TextFieldComponent {
                 dataType: 'json',
                 success: function (actionIDsList) {
                   if (actionIDsList.length == 0) {
-                    info_target.text(`\xa0 This ${component.formName} has been accepted and is ready for use ... click here for this component's information page`);
+                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} (part number: ${component.data.partNumber}) is ready for use`);
                   } else {
                     $.ajax({
                       contentType: 'application/json',
@@ -370,9 +370,9 @@ class ComponentUUID extends TextFieldComponent {
                       dataType: 'json',
                       success: function (action) {
                         if ((action.data.disposition === 'useAsIs') || (action.data.disposition === 'remediated')) {
-                          info_target.text(`\xa0 This ${component.formName} has been accepted and is ready for use ... click here for this component's information page`);
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} (part number: ${component.data.partNumber}) is ready for use`);
                         } else {
-                          info_target.text(`\xa0 This ${component.formName} HAS BEEN REJECTED (via Factory Rejection action) ... click here for this component's information page`);
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} (part number: ${component.data.partNumber}) has been rejected!`);
                         }
                       },
                     }).fail();
@@ -380,7 +380,7 @@ class ComponentUUID extends TextFieldComponent {
                 },
               }).fail();
             } else {
-              info_target.text(`\xa0 Click here for this component's information page`);
+              info_target.text(`\xa0 [Click for Component Info]`);
             }
           },
         }).fail();

--- a/app/static/pages/action_specComponent.js
+++ b/app/static/pages/action_specComponent.js
@@ -7,12 +7,7 @@ const reception_typeFormIDs = ['APAShipmentReception', 'BoardReception', 'CEAdap
 
 // Declare a list of the available 'board installation' and 'mesh installation' action type forms
 // NOTE: this must be the same as the equivalent list given in 'lib/Actions.js'
-const installation_typeFormIDs = [
-  'g_foot_board_install', 'g_head_board_install_sideA', 'g_head_board_install_sideB', 'x_foot_board_install', 'x_head_board_install_sideA', 'x_head_board_install_sideB',
-  'u_foot_boards_install', 'u_head_board_install_sideA', 'u_head_board_installation_sideB', 'u_side_board_install_HSB', 'u_side_board_install_LSB',
-  'v_foot_board_install', 'v_head_board_install_sideA', 'v_head_board_install_sideB', 'v_side_board_install_HSB', 'v_side_board_install_LSB',
-  'prep_mesh_panel_install',
-];
+const installation_typeFormIDs = ['x_boards', 'v_boards', 'u_boards', 'g_boards', 'prep_mesh_panel_install'];
 
 
 // Run a specified function when the page is loaded


### PR DESCRIPTION
- submission of the new board installation actions will set the individual board locations to 'installed on APA' with corresponding date and APA UUID
- submission of the old board installation actions will NOT trigger update of the individual board locations any more
- searching for boards by installation action will now match against the new board installation action types ONLY, not the old ones
- reduced verbosity of text displayed under Formio Component UUID input boxes ... was unnecessarily long and messing up the formatting of certain type forms

Changes have been checked on Staging.