### PR TITLE
Changes for new APA Post Production Workflow

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -9,6 +9,10 @@ const Forms = require('./Forms');
 const permissions = require('./permissions');
 const utils = require('./utils');
 
+// Declare a list of the available 'shipment transport' related action type forms
+// NOTE: this must be the same as the equivalent list given in 'static/pages/action_specComponent.js'
+const transport_typeFormIDs = ['APAShipmentTransport'];
+
 // Declare a list of the available 'reception' related action type forms
 // NOTE: this must be the same as the equivalent list given in 'static/pages/action_specComponent.js'
 const reception_typeFormIDs = ['APAShipmentReception', 'BoardReception', 'CEAdapterBoardReception', 'DWAComponentShipmentReception', 'GroundingMeshShipmentReception', 'PopulatedBoardKitReception'];
@@ -109,6 +113,13 @@ async function save(input, req) {
   _lock.release();
 
   if (!result.acknowledged) throw new Error(`Actions::save() - failed to insert a new action record into the database!`);
+
+  // If the action is one of the shipment transport types, the transport location (always 'in_transit') and date will have been passed to this function in the 'req.query' object
+  // Use these to update the location information for each individual sub-component in the shipment
+  // If successful, the updating function returns 'result = 1', but we don't actually use this value anywhere
+  if (transport_typeFormIDs.includes(newRecord.typeFormId)) {
+    const result = await Components.updateLocations_inShipment(newRecord.componentUuid, req.query.location, req.query.date);
+  }
 
   // If the action is one of the shipment or batch reception types, the reception location and date will have been passed to this function in the 'req.query' object
   // Use these to update the location information for each individual sub-component in the shipment or batch

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -119,7 +119,9 @@ async function save(input, req) {
     // Components of certain types will always start at specific fixed locations, whereas the rest do not need any initial location set (only for the record field to exist)
     if ((input.formId === 'APAFrame') || (input.formId === 'GroundingMeshPanel')) {
       newRecord.reception.location = 'ukWarehouse';
-    } else if ((input.formId === 'APAShipment') || (input.formId === 'BoardShipment') || (input.formId === 'DWAComponentShipment') || (input.formId === 'FrameShipment') || (input.formId === 'GroundingMeshShipment') || (input.formId === 'PopulatedBoardShipment')) {
+    } else if (input.formId === 'APAShipment') {
+      newRecord.reception.location = newRecord.data.originOfShipment;
+    } else if ((input.formId === 'BoardShipment') || (input.formId === 'DWAComponentShipment') || (input.formId === 'FrameShipment') || (input.formId === 'GroundingMeshShipment') || (input.formId === 'PopulatedBoardShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (input.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
@@ -149,12 +151,16 @@ async function save(input, req) {
   if (!result.acknowledged) throw new Error(`Components::save() - failed to insert a new component record into the database!`);
 
   // Once the component record has been successfully saved, deal with the reception information for any related components:
-  // - for various types of shipment, update the reception information of the various sub-components to indicate that they are in transit
+  // - for an 'APA Shipment', update the reception information of the underlying 'Assembled APA' components to be the same as the shipment
+  //    (they should already be at the same location as the shipment, but this is a double-check on that)
+  // - for other types of shipment, update the reception information of the various sub-components to indicate that they are in transit
   // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
   // - for a 'Populated Board Shipment', update the reception information of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
   // - for a 'Return Geometry Board Batch', update the reception information of the individual geometry board sub-components to indicate they are at Lancaster (where the batch is put together)
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
-  if ((newRecord.formId === 'APAShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment')) {
+  if (newRecord.formId === 'APAShipment') {
+    const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
+  } else if ((newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -479,6 +479,13 @@ block content
               p <b>Existing workflow actions can be accessed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
+          else if component.formId === 'APAShipment'
+            h4 Action History (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>Existing workflow actions can be accessed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Post Production 
+                | workflow</b>
           else
             h4 Action History
 
@@ -522,8 +529,15 @@ block content
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1
-              p <b>New workflow actions must be performed through this component's Frame Assembly 
+              p <b>New workflow actions must be performed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
+                | workflow</b>
+          else if component.formId === 'APAShipment'
+            h4 Select an Action Type to Perform (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>New workflow actions must be performed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Post Production 
                 | workflow</b>
           else 
             h4 Select an Action Type to Perform

--- a/app/pug/component_listTypes.pug
+++ b/app/pug/component_listTypes.pug
@@ -59,7 +59,7 @@ block content
                   td 0
 
                 td
-                  if (typeFormId === 'AssembledAPA' || typeFormId === 'APAFrame')
+                  if (typeFormId === 'AssembledAPA' || typeFormId === 'APAFrame' || typeFormId === 'APAShipment')
                     a.btn-sm.btn-secondary.disabled(href = '')
                       img.small-icon(src = '/images/run_icon.svg')
                       | &nbsp; Create New Components of This Type via Workflows

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -35,7 +35,7 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})', permissions.checkPermission('ac
     // Set a variable to indicate if the specified action type is one that is part of a workflow
     // First set up a list of action type form names for all actions that are part of any workflow
     // Then check to see if the list of action type form names includes the type form name of the action type being specified
-    const list_workflowTypeFormIDs = ['APA_Assembly', 'FrameAssembly'];
+    const list_workflowTypeFormIDs = ['APA_Assembly', 'FrameAssembly', 'APA_PostProduction'];
     let list_workflowActions = [];
 
     for (const workflowTypeFormID of list_workflowTypeFormIDs) {
@@ -286,7 +286,7 @@ router.get('/actionTypes/list', permissions.checkPermission('actions:view'), asy
     let actionTypeForms = await Forms.listGrouped('actionForms');
 
     // Set up a list of action type form names for all actions that are part of any workflow
-    const list_workflowTypeFormIDs = ['APA_Assembly', 'FrameAssembly'];
+    const list_workflowTypeFormIDs = ['APA_Assembly', 'FrameAssembly', 'APA_PostProduction'];
     let list_workflowActions = [];
 
     for (const workflowTypeFormID of list_workflowTypeFormIDs) {
@@ -376,7 +376,7 @@ router.get('/actions/:typeFormId/list', permissions.checkPermission('actions:vie
     // Set a variable to indicate if the specified action type is one that is part of a workflow
     // First set up a list of action type form names for all actions that are part of any workflow
     // Then check to see if the list of action type form names includes the type form name of the action type being specified
-    const list_workflowTypeFormIDs = ['APA_Assembly', 'FrameAssembly'];
+    const list_workflowTypeFormIDs = ['APA_Assembly', 'FrameAssembly', 'APA_PostProduction'];
     let list_workflowActions = [];
 
     for (const workflowTypeFormID of list_workflowTypeFormIDs) {

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -100,7 +100,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only two workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
-    const list_workflowComponents = ['AssembledAPA', 'APAFrame'];
+    const list_workflowComponents = ['AssembledAPA', 'APAFrame', 'APAShipment'];
     const workflowComponent = list_workflowComponents.includes(component.formId);
 
     // If the specified component type is one that is the subject of a workflow, filter out any action types that should be performed through the workflow
@@ -117,6 +117,8 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
         workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
       } else if (component.formId === 'APAFrame') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'FrameAssembly');
+      } else if (component.formId === 'APAShipment') {
+        workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_PostProduction');
       }
 
       const list_workflowActions = [];
@@ -805,7 +807,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only two workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
-    const list_workflowComponents = ['AssembledAPA', 'APAFrame'];
+    const list_workflowComponents = ['AssembledAPA', 'APAFrame', 'APAShipment'];
     const workflowComponent = list_workflowComponents.includes(req.params.typeFormId);
 
     // Render the interface page

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -312,12 +312,12 @@ class ComponentUUID extends TextFieldComponent {
                         if (action.data.actionComplete) {
                           info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for use`);
                         } else {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s Final QA Checklist is not complete!`);
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s QA Checklist is not complete!`);
                         }
                       },
                     }).fail();
                   } else {
-                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a Final QA Checklist!`);
+                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a QA Checklist!`);
                   }
                 },
               }).fail();
@@ -376,6 +376,32 @@ class ComponentUUID extends TextFieldComponent {
                         }
                       },
                     }).fail();
+                  }
+                },
+              }).fail();
+            } else if (component.formId === 'AssembledAPA') {
+              $.ajax({
+                contentType: 'application/json',
+                method: 'GET',
+                url: `/json/actions/${'CompletedAPAQCChecklist'}/list?uuid=${value}`,
+                dataType: 'json',
+                success: function (actionIDsList) {
+                  if (actionIDsList.length > 0) {
+                    $.ajax({
+                      contentType: 'application/json',
+                      method: 'GET',
+                      url: `/json/action/${actionIDsList[0]}`,
+                      dataType: 'json',
+                      success: function (action) {
+                        if (action.data.actionComplete) {
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for shipping`);
+                        } else {
+                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s QA Checklist is not complete!`);
+                        }
+                      },
+                    }).fail();
+                  } else {
+                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a QA Checklist!`);
                   }
                 },
               }).fail();

--- a/app/static/pages/action_specComponent.js
+++ b/app/static/pages/action_specComponent.js
@@ -1,6 +1,10 @@
 // Declare a variable to hold the completed type form that will eventually be submitted to the database
 let typeForm;
 
+// Declare a list of the available 'shipment transport' related action type forms
+// NOTE: this must be the same as the equivalent list given in 'lib/Actions.js'
+const transport_typeFormIDs = ['APAShipmentTransport'];
+
 // Declare a list of the available 'reception' related action type forms
 // NOTE: this must be the same as the equivalent list given in 'lib/Actions.js'
 const reception_typeFormIDs = ['APAShipmentReception', 'BoardReception', 'CEAdapterBoardReception', 'DWAComponentShipmentReception', 'GroundingMeshShipmentReception', 'PopulatedBoardKitReception'];
@@ -64,7 +68,9 @@ async function onPageLoad() {
 function SubmitData(submission) {
   let url = '/json/action';
 
-  if (reception_typeFormIDs.includes(submission.typeFormId)) {
+  if (transport_typeFormIDs.includes(submission.typeFormId)) {
+    url += `?location=${'in_transit'}&date=${(new Date()).toISOString().slice(0, 10)}`;
+  } else if (reception_typeFormIDs.includes(submission.typeFormId)) {
     url += `?location=${submission.data.receptionLocation}&date=${(submission.data.receptionDate).toString().slice(0, 10)}`;
   } else if (installation_typeFormIDs.includes(submission.typeFormId)) {
     url += `?location=${'installed_on_APA'}&date=${(new Date()).toISOString().slice(0, 10)}`;


### PR DESCRIPTION
Changes for revised APA Shipment component type
- at component creation, APA Shipment components are now assigned the location equal to their own user-specified origin location (would previously be set to 'in transit', as with other shipment-type components)
- at component creation, the underlying Assembled APAs are also assigned to the same location as the shipment (they should already be at the same location anyway, so this is just a double-check)
- if inputting the UUID of an Assembled APA into a Formio Component UUID box, the info message will now indicate if the APA has had a QA Checklist action performed and completed (i.e. if the associated assembly workflow is complete)

Changes for new APA Shipment Transport action
- when submitting an APA Shipment Transport action, the location of the shipment and referenced Assembled APAs will be set to 'in transit' (before submission, they will all be located wherever the shipment was being put together)
- code has been written in such a way that it can be easily applied to any future 'transport' type actions (there will probably need to be one for CE Adapter Board Shipments as well)

Changes for new APA Post Production workflow
- (workflow type form and path steps to be set up through the interface)
- APA Shipment components will now only be creatable through the workflow
- ASF and APA Shipment related actions will now only be performable through the workflow
- added corresponding checks and display text to the component and action info and listing pages
