### PR TITLE
Change to APA Frame starting location ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -117,8 +117,8 @@ async function save(input, req) {
     newRecord.reception.detail = '';
 
     // Components of certain types will always start at specific fixed locations, whereas the rest do not need any initial location set (only for the record field to exist)
-    if ((input.formId === 'APAFrame') || (input.formId === 'GroundingMeshPanel')) {
-      newRecord.reception.location = 'ukWarehouse';
+    if ((input.formId === 'APAFrame') || (input.formId === 'wire_bobbin')) {
+      newRecord.reception.location = 'daresbury';
     } else if (input.formId === 'APAShipment') {
       newRecord.reception.location = newRecord.data.originOfShipment;
     } else if ((input.formId === 'BoardShipment') || (input.formId === 'DWAComponentShipment') || (input.formId === 'FrameShipment') || (input.formId === 'GroundingMeshShipment') || (input.formId === 'PopulatedBoardShipment')) {
@@ -131,8 +131,8 @@ async function save(input, req) {
       newRecord.reception.location = newRecord.data.productionLocation;
     } else if (input.formId === 'GeometryBoard') {
       newRecord.reception.location = 'lancaster';
-    } else if (input.formId === 'wire_bobbin') {
-      newRecord.reception.location = 'daresbury';
+    } else if (input.formId === 'GroundingMeshPanel') {
+      newRecord.reception.location = 'ukWarehouse';
     } else {
       newRecord.reception.location = '';
     }

--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -47,7 +47,7 @@ block content
           - const collapseId = `avail_actionTypeGroup_${index}`;
           - let startingDisplay = 'show';
 
-          if actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'APA Frame'
+          if actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'APA Frame' || actionFormsGroup._id.componentType === 'APA Shipment'
             - startingDisplay = ''
 
           .panel.panel-default


### PR DESCRIPTION
- frame prep has recently been moved back to the Daresbury Factory (was previously being done at the UK Warehouse)
- changed starting location of APA Frames from 'ukWarehouse' to 'daresbury' accordingly
- list of actions performable on 'APA Shipment' type components now displays as collapsed by default, in line with other workflow-related component types