### PR TITLE
Bug fix for Geometry Boards internal server error ...

### DIFF
--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -90,7 +90,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
       actions.push({
         'typeFormName': 'Board DB Record Created',
         'componentUuid': req.params.uuid,
-        'lastEditDate': componentVersions[componentVersions.length - 1].validity.startDate,
+        'lastEditDate': new Date(componentVersions[componentVersions.length - 1].validity.startDate),
         'data': { 'originOfShipment': 'lancaster' },
       });
 


### PR DESCRIPTION
- error was being caused by the 'toISOString()' function on the component info page being applied to a non-Date type variable
- the 'lastEditDate' variable in the first (component creation) 'action' in the Geometry Board history was sometimes being passed as a string, and sometimes as a Date ... no idea why it was inconsistent
- fix is to explicitly cast it to a Date on the server side, regardless of whether it is one already or not

This has also fixed an issue where the board's 'component creation' was being shown last in the action history instead of first ... the array of actions is sorted by ascending date, but if the creation date was not a 'Date' type variable, it would not be included in the sorting and would then always appear at the end of the array.
