### PR TITLE
Recent Changes from Staging

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -117,8 +117,8 @@ async function save(input, req) {
     newRecord.reception.detail = '';
 
     // Components of certain types will always start at specific fixed locations, whereas the rest do not need any initial location set (only for the record field to exist)
-    if ((input.formId === 'APAFrame') || (input.formId === 'GroundingMeshPanel')) {
-      newRecord.reception.location = 'ukWarehouse';
+    if ((input.formId === 'APAFrame') || (input.formId === 'wire_bobbin')) {
+      newRecord.reception.location = 'daresbury';
     } else if (input.formId === 'APAShipment') {
       newRecord.reception.location = newRecord.data.originOfShipment;
     } else if ((input.formId === 'BoardShipment') || (input.formId === 'DWAComponentShipment') || (input.formId === 'FrameShipment') || (input.formId === 'GroundingMeshShipment') || (input.formId === 'PopulatedBoardShipment')) {
@@ -131,8 +131,8 @@ async function save(input, req) {
       newRecord.reception.location = newRecord.data.productionLocation;
     } else if (input.formId === 'GeometryBoard') {
       newRecord.reception.location = 'lancaster';
-    } else if (input.formId === 'wire_bobbin') {
-      newRecord.reception.location = 'daresbury';
+    } else if (input.formId === 'GroundingMeshPanel') {
+      newRecord.reception.location = 'ukWarehouse';
     } else {
       newRecord.reception.location = '';
     }

--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -47,7 +47,7 @@ block content
           - const collapseId = `avail_actionTypeGroup_${index}`;
           - let startingDisplay = 'show';
 
-          if actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'APA Frame'
+          if actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'APA Frame' || actionFormsGroup._id.componentType === 'APA Shipment'
             - startingDisplay = ''
 
           .panel.panel-default

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -90,7 +90,7 @@ router.get('/component/' + utils.uuid_regex, permissions.checkPermission('compon
       actions.push({
         'typeFormName': 'Board DB Record Created',
         'componentUuid': req.params.uuid,
-        'lastEditDate': componentVersions[componentVersions.length - 1].validity.startDate,
+        'lastEditDate': new Date(componentVersions[componentVersions.length - 1].validity.startDate),
         'data': { 'originOfShipment': 'lancaster' },
       });
 


### PR DESCRIPTION
Change to APA Frame starting location
- frame prep has recently been moved back to the Daresbury Factory (was previously being done at the UK Warehouse)
- changed starting location of APA Frames from 'ukWarehouse' to 'daresbury' accordingly
- list of actions performable on 'APA Shipment' type components now displays as collapsed by default, in line with other workflow-related component types

Bug fix for Geometry Boards internal server error
- error was being caused by the 'toISOString()' function on the component info page being applied to a non-Date type variable
- the 'lastEditDate' variable in the first (component creation) 'action' in the Geometry Board history was sometimes being passed as a string, and sometimes as a Date ... no idea why it was inconsistent
- fix is to explicitly cast it to a Date on the server side, regardless of whether it is one already or not

Changes have been tested on Staging.