### PR TITLE
Moving to MongoDB version 7.0 (6.0 is reaching end of life)

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -139,7 +139,17 @@ async function save(input, req) {
       newRecord.reception.location = '';
     }
   } else {
-    newRecord.reception = input.reception;
+    // For some unknown reason, sometimes the entire 'reception' object can be set to 'null' when editing a component (seems to happen rarely, and only with 'Board Shipment' components) ...
+    // ... if this does happen, just reconstruct the 'reception' object and its fields - giving them some default values (the actual values for shipment-type components are assigned below anyway)
+    // If this is not the case, i.e. the existing 'reception' object contains some information, simply copy it over to the new record
+    if (input.reception === null) {
+      newRecord.reception = {};
+      newRecord.reception.location = '';
+      newRecord.reception.date = (new Date()).toISOString().slice(0, 10);
+      newRecord.reception.detail = '';
+    } else {
+      newRecord.reception = input.reception;
+    }
   }
 
   // Components of some (but only a few) types should have names that can change even after creation, because they are based in some way on user-editable fields in the record

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -399,12 +399,16 @@ block content
                   td #{dictionary_locations[entry.data.originOfShipment]}
 
                   if entry.typeFormName === 'Board Shipment'
-                    if entry.reception.location === 'in_transit'
-                      td #{dictionary_locations[entry.data.destinationOfShipment]}
-                      td [not yet received]
+                    if entry.reception
+                      if entry.reception.location === 'in_transit'
+                        td #{dictionary_locations[entry.data.destinationOfShipment]}
+                        td [not yet received]
+                      else
+                        td #{dictionary_locations[entry.reception.location]}
+                        td #{entry.reception.date}
                     else
-                      td #{dictionary_locations[entry.reception.location]}
-                      td #{entry.reception.date}
+                      td [reception object missing!]
+                      td [reception object missing!]
                   else 
                     td -
                     td -

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         condition: service_healthy
 
   db:
-    image: mongo:6.0
+    image: mongo:7.0
     environment:
       MONGO_INITDB_DATABASE: dunedb
     volumes:


### PR DESCRIPTION
As required by Fermilab for the Staging and Production instances.
Have tested all functionality on Development - no issues found on the software side.  Fermilab-based deployments should also be tested for any build issues.

Also added a workaround for 'null' shipment reception
- if the component 'reception' object is 'null' currently the DB will crash in two places - when attempting to set a new location (if editing the component), and when attempting to display the location (in the case of geometry boards which were part of a shipment with 'null' reception)
- have changed the component information interface page so that if a shipment has a 'null' reception object, it will now display a message indicating as such, rather than breaking completely
- have changed the component submission library function so that if a component is being edited, but has been passed a 'null' reception object, the object will now be first reconstructed and populated with fields (before attempting to assign values to the fields)
- this doesn't actually answer the underlying question of why a component's reception object can be 'nulled' in the first place, but it should at least allow users to work around it
