### PR TITLE
Overhaul of Component Names (Part 1) ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -7,6 +7,7 @@ const { db } = require('./db');
 const dbLock = require('./dbLock');
 const Forms = require('./Forms');
 const permissions = require('./permissions');
+const utils = require('./utils');
 
 
 /// Generate a new component UUID
@@ -83,32 +84,100 @@ async function save(input, req) {
     // The field will exist only when creating new records for individual sub-components in a batch, since in this situation the sub-component type record numbers are determined on the client side
     if (!input.data.typeRecordNumber) newRecord.data.typeRecordNumber = numberOfExistingComponents + 1;
 
-    // Most component types should have a name assigned when first created (and only at this time), to make it easier for users to identify them in the interface
-    // For some types, this name is a shortened version of the DUNE PID (which should also be assigned at this point) - a fixed prefix and suffix, plus the type record number padded to 5 digits
-    // For other types, the name will still include the type record number, but within a string of a different format specific to the type
-    // Note that components of some (but only a few) types should have names that can be changed even after creation - these are dealt with separately below
-    if (input.formId === 'GeometryBoard') {
-      newRecord.data.name = `${newRecord.data.typeRecordNumber}`;
-    } else if (input.formId === 'GroundingMeshPanel') {
-      newRecord.data.name = `D00300200004-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-UK106-01-00-00`;
-    } else if (input.formId === 'CRBoard') {
-      newRecord.data.name = `D00300400001-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US200-01-00-00`;
-    } else if (input.formId === 'GBiasBoard') {
-      newRecord.data.name = `D00300400002-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US200-01-00-00`;
-    } else if (input.formId === 'CEAdapterBoard') {
-      newRecord.data.name = `D00300400003-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US200-01-00-00`;
-    } else if (input.formId === 'SHVBoard') {
-      newRecord.data.name = `D00300500001-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US200-01-00-00`;
-    } else if (input.formId === 'CableHarness') {
-      if (newRecord.data.cableHarnessSide === 'a') {
-        newRecord.data.name = `D00300500002-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US200-01-00-00`;
-      } else if (newRecord.data.cableHarnessSide === 'b') {
-        newRecord.data.name = `D00300500003-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US200-01-00-00`;
+    // Every component should have a name and DUNE PID assigned to it ... if the name is based on unchangable or rarely changed fields in the record, it can be assigned here during creation
+    // ... on the other hand, if the name is based on fields that are more likely to be changed by the user, it should be assigned and re-assigned any time the record is edited (see below)
+    // The format of the name is dependent on the component type ... some are simply a combination of the type form name and type record number, whereas others have more information included
+    const typeRecordNumber = String(newRecord.data.typeRecordNumber).padStart(5, '0');
+
+    if (newRecord.formId === 'APAFrame') {
+      const frameNumber = String(newRecord.data.frameNumber).padStart(5, '0');
+      let pidSuffix = '';
+
+      if (newRecord.data.frameProductionLocation === 'dsm') {
+        newRecord.data.componentName = `APA Frame ${frameNumber}-UK`;
+        pidSuffix = 'UK106-010000';
+      } else if (newRecord.data.frameProductionLocation === 'wisconsin') {
+        newRecord.data.componentName = `APA Frame ${frameNumber}-US`;
+        pidSuffix = 'US200-010000';
       }
-    } else if (input.formId === 'DWA') {
-      newRecord.data.name = `D00300800001-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US136-01-00-00`;
-    } else if (input.formId === 'DWAPDB') {
-      newRecord.data.name = `D00300800002-${String(newRecord.data.typeRecordNumber).padStart(5, '0')}-US136-01-00-00`;
+
+      newRecord.data.dunePid = `D00300200001-${frameNumber}-${pidSuffix}`;
+    } else if (newRecord.formId === 'AssembledAPA') {
+      const apaNumber = String(newRecord.data.apaNumberAtLocation).padStart(5, '0');
+      let pidPrefix = '';
+      let pidSuffix = '';
+
+      if (newRecord.data.apaConfiguration === 'top') {
+        pidPrefix = 'D00300100001';
+      } else {
+        pidPrefix = 'D00300100002';
+      }
+
+      if (newRecord.data.apaAssemblyLocation === 'chicago') {
+        newRecord.data.componentName = `APA ${apaNumber}-US`;
+        pidSuffix = 'US175-010000';
+      } else if (newRecord.data.apaAssemblyLocation === 'daresbury') {
+        newRecord.data.componentName = `APA ${apaNumber}-UK`;
+        pidSuffix = 'UK106-010000';
+      } else if (newRecord.data.apaAssemblyLocation === 'wisconsin') {
+        newRecord.data.componentName = `APA ${apaNumber}-US`;
+        pidSuffix = 'US200-010000';
+      }
+
+      newRecord.data.dunePid = `${pidPrefix}-${apaNumber}-${pidSuffix}`;
+    } else if (newRecord.formId === 'CEAdapterBoard') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00300400003-${typeRecordNumber}-US200-010000`;
+    } else if (newRecord.formId === 'CEAdapterBoardBatch') {
+      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (newRecord.formId === 'CRBoard') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00300400001-${typeRecordNumber}-US200-010000`;
+    } else if (newRecord.formId === 'CRBoardBatch') {
+      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (newRecord.formId === 'CableHarness') {
+      if (newRecord.data.cableHarnessSide === 'a') {
+        newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (Side A)`;
+        newRecord.data.dunePid = `D00300500002-${typeRecordNumber}-US200-010000`;
+      } else if (newRecord.data.cableHarnessSide === 'b') {
+        newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (Side B)`;
+        newRecord.data.dunePid = `D00300500003-${typeRecordNumber}-US200-010000`;
+      }
+    } else if (newRecord.formId === 'DWA') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00300800001-${typeRecordNumber}-US136-010000`;
+    } else if (newRecord.formId === 'DWAPDB') {
+      newRecord.data.componentName = `DWA PDB ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00300800002-${typeRecordNumber}-US136-010000`;
+    } else if (newRecord.formId === 'GBiasBoard') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00300400002-${typeRecordNumber}-US200-010000`;
+    } else if (newRecord.formId === 'GBiasBoardBatch') {
+      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (newRecord.formId === 'GeometryBoard') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.partString})`;
+      newRecord.data.dunePid = `D003003${utils.dictionary_geometryBoardPIDs[newRecord.data.partNumber]}-${typeRecordNumber}-UK109-010000`;
+    } else if (newRecord.formId === 'GeometryBoardBatch') {
+      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.PN${newRecord.data.subComponent_partNumber}.ON${newRecord.data.orderNumber})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (newRecord.formId === 'GroundingMeshPanel') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00300200004-${typeRecordNumber}-UK106-010000`;
+    } else if (newRecord.formId === 'ReturnedGeometryBoardBatch') {
+      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.PN${newRecord.data.subComponent_partNumber}.ON${newRecord.data.orderNumber})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (newRecord.formId === 'SHVBoard') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00300500001-${typeRecordNumber}-US200-010000`;
+    } else if (newRecord.formId === 'Yoke') {
+      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+      newRecord.data.dunePid = `D00301000001-${typeRecordNumber}-US200-010000`;
+    } else if (newRecord.formId === 'wire_bobbin') {
+      newRecord.data.componentName = `${newRecord.formName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     }
 
     // Set up a new 'Reception' object to hold the component's current location and the date at which it was received at this location ... and we can immediately set the date to be the current one
@@ -119,21 +188,21 @@ async function save(input, req) {
     newRecord.reception.detail = '';
 
     // Components of certain types will always start at specific fixed locations, whereas the rest do not need any initial location set (only for the record field to exist)
-    if ((input.formId === 'APAFrame') || (input.formId === 'wire_bobbin')) {
+    if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'wire_bobbin')) {
       newRecord.reception.location = 'daresbury';
-    } else if (input.formId === 'APAShipment') {
+    } else if (newRecord.formId === 'APAShipment') {
       newRecord.reception.location = newRecord.data.originOfShipment;
-    } else if ((input.formId === 'BoardShipment') || (input.formId === 'DWAComponentShipment') || (input.formId === 'FrameShipment') || (input.formId === 'GroundingMeshShipment') || (input.formId === 'PopulatedBoardShipment')) {
+    } else if ((newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment')) {
       newRecord.reception.location = 'in_transit';
-    } else if (input.formId === 'AssembledAPA') {
+    } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
-    } else if ((input.formId === 'CEAdapterBoard') || (input.formId === 'CEAdapterBoardShipment') || (input.formId === 'CRBoard') || (input.formId === 'CRBoardShipment') || (input.formId === 'CableHarness') || (input.formId === 'CableHarnessShipment') || (input.formId === 'GBiasBoard') || (input.formId === 'GBiasBoardShipment') || (input.formId === 'SHVBoard') || (input.formId === 'SHVBoardShipment')) {
+    } else if ((newRecord.formId === 'CEAdapterBoard') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'CRBoard') || (newRecord.formId === 'CRBoardShipment') || (newRecord.formId === 'CableHarness') || (newRecord.formId === 'CableHarnessShipment') || (newRecord.formId === 'GBiasBoard') || (newRecord.formId === 'GBiasBoardShipment') || (newRecord.formId === 'SHVBoard') || (newRecord.formId === 'SHVBoardShipment')) {
       newRecord.reception.location = 'wisconsin';
-    } else if ((input.formId === 'DWA') || (input.formId === 'DWAPDB')) {
+    } else if ((newRecord.formId === 'DWA') || (newRecord.formId === 'DWAPDB')) {
       newRecord.reception.location = newRecord.data.productionLocation;
-    } else if (input.formId === 'GeometryBoard') {
+    } else if (newRecord.formId === 'GeometryBoard') {
       newRecord.reception.location = 'lancaster';
-    } else if (input.formId === 'GroundingMeshPanel') {
+    } else if (newRecord.formId === 'GroundingMeshPanel') {
       newRecord.reception.location = 'ukWarehouse';
     } else {
       newRecord.reception.location = '';
@@ -152,9 +221,29 @@ async function save(input, req) {
     }
   }
 
-  // Components of some (but only a few) types should have names that can change even after creation, because they are based in some way on user-editable fields in the record
-  // In these cases, the simplest solution is to just reassign their names any and every time the record is edited (including at creation)
-  if (input.formId === 'APAShipment') {
+  // If the component name is based on fields that are more likely to be changed by the user, it should be assigned and re-assigned any time the record is edited
+  // The DUNE PID of such components should technically be fixed at creation, but it is simpler code-wise to assign and re-assign that here as well
+  const typeRecordNumber = String(newRecord.data.typeRecordNumber).padStart(5, '0');
+  
+  if (newRecord.formId === 'APADoublet') {
+    let name_topApa = '[not set]';
+    let name_bottomApa = '[not set]';
+
+    if (newRecord.data.topApa !== '') {
+      const apa = await retrieve(newRecord.data.topApa);
+      const name_splits = apa.data.name.split('-');
+      name_topApa = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+    }
+
+    if (newRecord.data.bottomApa !== '') {
+      const apa = await retrieve(newRecord.data.bottomApa);
+      const name_splits = apa.data.name.split('-');
+      name_bottomApa = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+    }
+
+    newRecord.data.componentName = `${newRecord.formName} (${name_topApa} and ${name_bottomApa})`;
+    newRecord.data.dunePid = `D00200000000-${typeRecordNumber}-US000-010000`;
+  } else if (newRecord.formId === 'APAShipment') {
     let name_apa1 = '[not set]';
     let name_apa2 = '[not set]';
 
@@ -170,8 +259,39 @@ async function save(input, req) {
       name_apa2 = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
     }
 
-    newRecord.data.name = `APA Shipment (${name_apa1} and ${name_apa2})`;
-  }
+    newRecord.data.componentName = `${newRecord.formName} (${name_apa1} and ${name_apa2})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'BoardShipment') {
+    newRecord.data.componentName = `Geometry ${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'CEAdapterBoardShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'CRBoardShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'CableHarnessShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'DWAComponentShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'FrameShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'GBiasBoardShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'GroundingMeshShipment') {
+    newRecord.data.componentName = `Grounding Mesh Panel Shipment (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'PopulatedBoardShipment') {
+    newRecord.data.componentName = `Multi-Type Populated Board Shipment (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'SHVBoardShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } 
 
   // Insert the new record into the 'components' records collection, and throw an error if the insertion fails
   let _lock = await dbLock(`saveComponent_${newRecord.componentUuid}`, 1000);
@@ -643,6 +763,177 @@ async function autoCompleteUuid(inputString, limit = 10) {
 }
 
 
+/// 
+async function setComponentNames(typeFormId) {
+  // Retrieve a list of component UUIDs corresponding to all components with 'formId' matching the specified component type form ID
+  let aggregation_stages = [];
+
+  aggregation_stages.push({ $match: { formId: typeFormId } });
+  aggregation_stages.push({ $project: { componentUuid: true } });
+
+  let uuids = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
+
+  // For each retrieved UUID ...
+  for (let uuid of uuids) {
+    // Get the full component record corresponding to the UUID, and construct the component name and DUNE PID
+    const component = await retrieve(uuid.componentUuid);
+    const typeFormName = component.formName;
+    const data = component.data;
+    const typeRecordNumber = String(data.typeRecordNumber).padStart(5, '0');
+    const validityStartDate = component.validity.startDate;
+
+    let componentName = '';
+    let dunePid = '';
+
+    if (typeFormId === 'APAFrame') {
+      const frameNumber = String(data.frameNumber).padStart(5, '0');
+      let pidSuffix = '';
+
+      if (data.frameProductionLocation === 'dsm') {
+        componentName = `APA Frame ${frameNumber}-UK`;
+        pidSuffix = 'UK106-010000';
+      } else if (data.frameProductionLocation === 'wisconsin') {
+        componentName = `APA Frame ${frameNumber}-US`;
+        pidSuffix = 'US200-010000';
+      }
+
+      dunePid = `D00300200001-${frameNumber}-${pidSuffix}`;
+    } else if (typeFormId === 'AssembledAPA') {
+      const apaNumber = String(data.apaNumberAtLocation).padStart(5, '0');
+      let pidPrefix = '';
+      let pidSuffix = '';
+
+      if (data.apaConfiguration === 'top') {
+        pidPrefix = 'D00300100001';
+      } else {
+        pidPrefix = 'D00300100002';
+      }
+
+      if (data.apaAssemblyLocation === 'chicago') {
+        componentName = `APA ${apaNumber}-US`;
+        pidSuffix = 'US175-010000';
+      } else if (data.apaAssemblyLocation === 'daresbury') {
+        componentName = `APA ${apaNumber}-UK`;
+        pidSuffix = 'UK106-010000';
+      } else if (data.apaAssemblyLocation === 'wisconsin') {
+        componentName = `APA ${apaNumber}-US`;
+        pidSuffix = 'US200-010000';
+      }
+
+      dunePid = `${pidPrefix}-${apaNumber}-${pidSuffix}`;
+    } else if (typeFormId === 'BoardShipment') {
+      componentName = `Geometry ${typeFormName} (${data.boardUuiDs.length}.${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'CEAdapterBoard') {
+      componentName = `${typeFormName} ${typeRecordNumber}`;
+      dunePid = `D00300400003-${typeRecordNumber}-US200-010000`;
+    } else if (typeFormId === 'CEAdapterBoardBatch') {
+      componentName = `${typeFormName} (${data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'CEAdapterBoardShipment') {
+      componentName = `${typeFormName} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'CRBoard') {
+      componentName = `${typeFormName} ${typeRecordNumber}`;
+      dunePid = `D00300400001-${typeRecordNumber}-US200-010000`;
+    } else if (typeFormId === 'CRBoardBatch') {
+      componentName = `${typeFormName} (${data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'CRBoardShipment') {
+      componentName = `${typeFormName} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'CableHarness') {
+      if (data.cableHarnessSide === 'a') {
+        componentName = `${typeFormName} ${typeRecordNumber} (Side A)`;
+        dunePid = `D00300500002-${typeRecordNumber}-US200-010000`;
+      } else if (data.cableHarnessSide === 'b') {
+        componentName = `${typeFormName} ${typeRecordNumber} (Side B)`;
+        dunePid = `D00300500003-${typeRecordNumber}-US200-010000`;
+      }
+    } else if (typeFormId === 'CableHarnessShipment') {
+      componentName = `${typeFormName} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'DWA') {
+      componentName = `${typeFormName} ${typeRecordNumber}`;
+      dunePid = `D00300800001-${typeRecordNumber}-US136-010000`;
+    } else if (typeFormId === 'DWAComponentShipment') {
+      componentName = `${typeFormName} (${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'DWAPDB') {
+      componentName = `DWA PDB ${typeRecordNumber}`;
+      dunePid = `D00300800002-${typeRecordNumber}-US136-010000`;
+    } else if (typeFormId === 'GBiasBoard') {
+      componentName = `${typeFormName} ${typeRecordNumber}`;
+      dunePid = `D00300400002-${typeRecordNumber}-US200-010000`;
+    } else if (typeFormId === 'GBiasBoardBatch') {
+      componentName = `${typeFormName} (${data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'GBiasBoardShipment') {
+      componentName = `${typeFormName} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'GeometryBoard') {
+      componentName = `${typeFormName} ${typeRecordNumber} (${data.partString})`;
+      dunePid = `D003003${utils.dictionary_geometryBoardPIDs[data.partNumber]}-${typeRecordNumber}-UK109-010000`;
+    } else if (typeFormId === 'GeometryBoardBatch') {
+      componentName = `${typeFormName} (${data.subComponent_count}.PN${data.subComponent_partNumber}.ON${data.orderNumber})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'GroundingMeshPanel') {
+      componentName = `${typeFormName} ${typeRecordNumber}`;
+      dunePid = `D00300200004-${typeRecordNumber}-UK106-010000`;
+    } else if (typeFormId === 'GroundingMeshShipment') {
+      componentName = `Grounding Mesh Panel Shipment (${data.apaUuiDs.length}.${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'PopulatedBoardShipment') {
+      componentName = `Multi-Type Populated Board Shipment (${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'ReturnedGeometryBoardBatch') {
+      componentName = `${typeFormName} (${data.subComponent_count}.PN${data.subComponent_partNumber}.ON${data.orderNumber})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'SHVBoard') {
+      componentName = `${typeFormName} ${typeRecordNumber}`;
+      dunePid = `D00300500001-${typeRecordNumber}-US200-010000`;
+    } else if (typeFormId === 'SHVBoardShipment') {
+      componentName = `${typeFormName} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'Yoke') {
+      componentName = `${typeFormName} ${typeRecordNumber}`;
+      dunePid = `D00301000001-${typeRecordNumber}-US200-010000`;
+    } else if (typeFormId === 'wire_bobbin') {
+      componentName = `${typeFormName} ${data.bobbinId} (Lot ${data.wireLot})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    }
+
+    // Set up a 'matching condition' object containing the component UUID (remembering that the UUID has to be of 'MUUID' type, not a string)
+    const componentUuid = component.componentUuid;
+    let match_condition = { componentUuid };
+
+    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
+
+    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
+
+    // Update the component name and DUNE PID fields of ALL records with the matching component UUID (i.e. all versions of the component in question)
+    const result = db.collection('components')
+      .updateMany(
+        match_condition,
+        [
+          {
+            $set: {
+              'data.componentName': componentName,
+              'data.dunePid': dunePid,
+            }
+          },
+        ]
+      )
+
+    if (result.ok === 0) throw new Error(`Components::setComponentNames() - failed to update the component records!`);
+  }
+
+  return typeFormId;
+}
+
+
 module.exports = {
   newUuid,
   save,
@@ -654,4 +945,5 @@ module.exports = {
   counts_byType,
   boardCounts_byPartNumberAndLocation,
   autoCompleteUuid,
+  setComponentNames,
 }

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -46,6 +46,40 @@ module.exports = {
     wisconsin: 'Wisconsin',
   },
 
+  // A dictionary of DUNE PID 'component ID' strings for Geometry Boards, related to the board part numbers
+  // Note that cover boards are not included (even though they do technically have DUNE PIDs), because they are not individually recorded in the DB ... either as components or during installation
+  dictionary_geometryBoardPIDs: {
+    '8760104': '00001',
+    '8760034': '00002',
+    '8760032': '00003',
+    '8760109': '00003',
+    '8760057': '00004',
+    '8760111': '00004',
+    '8760044': '00005',
+    '8760059': '00006',
+    '8760040': '00007',
+    '8760042': '00008',
+    '8760038': '00009',
+    '8760115': '00010',
+    '8760119': '00011',
+    '8760123': '00012',
+    '8760108': '00013',
+    '8760116': '00014',
+    '8760030': '00015',
+    '8760107': '00015',
+    '8760036': '00016',
+    '8760026': '00017',
+    '8760028': '00018',
+    '8760024': '00019',
+    '8760054': '00020',
+    '8760113': '00020',
+    '8760051': '00021',
+    '8760062': '00022',
+    '8760121': '00023',
+    '8760122': '00024',
+    '8760120': '00025',
+  },
+
   // The dictionaries below list various groups of UK and US personnel, whose names should be entered as appropriate in various component and action type forms
   // Using these centralised dictionaries allows names to be consistently displayed in the DB interface, and also for them to be selected via drop-down menu when filling out the type forms
 

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -1,0 +1,61 @@
+extend default
+
+block vars
+  - const page_title = 'Administrator Utility';
+
+block extrascripts
+  block workscripts
+    script(src = '/pages/administratorUtility.js')
+
+block content
+  .container-fluid
+    .vert-space-x2
+      h2 Administrator Utility
+
+    .vert-space-x2 
+      hr
+
+      .row 
+        .col-md-5
+          p Select an input string for the current utility
+
+          select.form-control#inputStringSelection
+            option(value = '')
+            option(value = 'APAFrame') APA Frame 
+            option(value = 'AssembledAPA') Assembled APA 
+            option(value = 'BoardShipment') Board Shipment 
+            option(value = 'CEAdapterBoard') CE Adapter Board
+            option(value = 'CEAdapterBoardBatch') CE Adapter Board Batch 
+            option(value = 'CEAdapterBoardShipment') CE Adapter Board Shipment 
+            option(value = 'CRBoard') CR Board
+            option(value = 'CRBoardBatch') CR Board Batch 
+            option(value = 'CRBoardShipment') CR Board Kit 
+            option(value = 'CableHarness') Cable Harness
+            option(value = 'CableHarnessShipment') Cable Harness Kit 
+            option(value = 'DWA') DWA
+            option(value = 'DWAComponentShipment') DWA Component Shipment
+            option(value = 'DWAPDB') DWA PDB 
+            option(value = 'GBiasBoard') G-Bias Board
+            option(value = 'GBiasBoardBatch') G-Bias Board Batch
+            option(value = 'GBiasBoardShipment') G-Bias Board Kit
+            option(value = 'GeometryBoard') Geometry Board
+            option(value = 'GeometryBoardBatch') Geometry Board Batch
+            option(value = 'GroundingMeshPanel') Grounding Mesh Panel
+            option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
+            option(value = 'PopulatedBoardShipment') Multi-Type Populated Board Shipment
+            option(value = 'ReturnedGeometryBoardBatch') Returned Geometry Board Batch
+            option(value = 'SHVBoard') SHV Board
+            option(value = 'SHVBoardShipment') SHV Board Kit
+            option(value = 'Yoke') Yoke
+            option(value = 'wire_bobbin') Wire Bobbin
+
+          .vert-space-x2 
+            button.btn-primary.btn-lg#confirmButton Confirm
+
+      .vert-space-x2 
+        hr
+
+      .vert-space-x1
+        #messages
+
+    .vert-space-x2

--- a/app/routes/api/users.js
+++ b/app/routes/api/users.js
@@ -2,6 +2,7 @@ const ManagementClient = require('auth0').ManagementClient;
 const router = require('express').Router();
 
 const { AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET } = require('../../lib/constants');
+const Components = require('../../lib/Components');
 const logger = require('../../lib/logger');
 const permissions = require('../../lib/permissions');
 const utils = require('../../lib/utils');
@@ -276,5 +277,21 @@ router.get('/apaFactoryLeads.json', async function (req, res, next) {
     res.status(500).json({ error: err.toString() });
   }
 });
+
+
+/// ADMINISTRATOR UTILITY ... run a specific server-side library function appropriate for the currently required utility, with user input supplied from the Administrator Utility interface page 
+router.get('/administratorUtility/:inputString', async function (req, res, next) {
+  try {
+    logger.info(req.body, 'Submission to /administratorUtility');
+
+    const result = await Components.setComponentNames(req.params.inputString);    // Change as appropriate for the required utility
+
+    return res.json(result);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
 
 module.exports = router;

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -56,4 +56,10 @@ router.get('/users/list', permissions.checkPermission('users:view'), async funct
 });
 
 
+/// ADMINISTRATOR UTILITY ... run a specific server-side library function appropriate for the currently required utility, with user input supplied from the Administrator Utility interface page 
+router.get('/administratorUtility', async function (req, res, next) {
+  res.render('administratorUtility.pug');
+});
+
+
 module.exports = router;

--- a/app/static/pages/administratorUtility.js
+++ b/app/static/pages/administratorUtility.js
@@ -1,0 +1,40 @@
+let inputString = null;
+
+window.addEventListener('load', renderInputForm);
+
+
+async function renderInputForm() {
+  $('#inputStringSelection').on('change', async function () {
+    inputString = $('#inputStringSelection').val();
+  });
+
+  $('#confirmButton').on('click', function () {
+    $('#confirmButton').prop('disabled', true);
+    $('#messages').empty();
+    $('#messages').append('<b>Working ... once complete, you will be automatically redirected to an appropriate interface page</b>');
+
+    if (inputString) {
+      $.ajax({
+        contentType: 'application/json',
+        method: 'GET',
+        url: `/json/administratorUtility/${inputString}`,
+        dataType: 'json',
+        success: postSuccess,
+      }).fail(postFail);
+    }
+  })
+}
+
+
+function postSuccess(result) {
+  window.location.href = `/components/${result}/list`;    // Change as appropriate for the required utility
+}
+
+
+function postFail(result, statusCode, statusMsg) {
+  if (result.responseText) {
+    console.log('POSTFAIL: ', result.responseText);
+  } else {
+    console.log('POSTFAIL: ', `${statusMsg} (${statusCode})`);
+  }
+};


### PR DESCRIPTION
- component names and DUNE PIDs are now always assigned for ALL component types, with the name format being dependent on the type
- some component names are assigned once at component creation, while others are (re)assigned any time the component is edited (and at creation) - this is to account for any changes to user-definable fields that the name uses
- added new Utilities dictionary for mapping geometry board part numbers to their corresponding DUNE PID 'component ID's
- added new 'Administrator Utility' flow ... interface page and JS, interface and API routes - this is intended to be a generic flow that can be used for whatever admin-level utility is required ... code is written in such a way that it only needs a specific library function and interface redirection to be changed for a different utility
- new function for setting the component names and DUNE PIDs of all versions of all records for a specific component type (using essentially the same code as would be used to assign them in the first place)