### PR TITLE
Fix for when the 'validity.startDate' is a string ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -9,6 +9,8 @@ const Forms = require('./Forms');
 const permissions = require('./permissions');
 const utils = require('./utils');
 
+const logger = require('./logger');
+
 
 /// Generate a new component UUID
 function newUuid() {
@@ -764,7 +766,7 @@ async function setComponentNames(typeFormId) {
     const typeFormName = component.formName;
     const data = component.data;
     const typeRecordNumber = String(data.typeRecordNumber).padStart(5, '0');
-    const validityStartDate = component.validity.startDate.toISOString();
+    const validityStartDate = (typeof component.validity.startDate === 'string') ? component.validity.startDate : component.validity.startDate.toISOString();
 
     let componentName = '';
     let dunePid = '';


### PR DESCRIPTION
- for whatever reason, geometry board 19536 doesn't have a typeRecordNumber or UUID, but still exists as a 'GeometryBoard' type record ... with a string-type 'validity.startDate' (instead of being a 'Date')
- code will now check for the type ... if 'string', do not convert to ISO string before substringing (since a string cannot be converted) ... otherwise do as normal