### PR TITLE
Overhaul of Component Names (Part 2)

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -329,27 +329,14 @@ async function list(match_condition, options) {
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display
-  // Then add the corresponding component name to each matching record, adjusting it depending on component type for easier readability (shorten DUNE PIDs, and use UKIDs for geometry boards)
+  // Then add the corresponding component name to each matching record
   for (let record of records) {
-    record.componentUuid = MUUID.from(record.componentUuid).toString();
-
-    const component = await Components.retrieve(record.componentUuid);
+    const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
 
     if (!component) {
       record.componentName = '[UUID does not exist!]';
     } else {
-      if (component.data.name) {
-        if (['APAFrame', 'AssembledAPA', 'GroundingMeshPanel', 'CRBoard', 'GBiasBoard', 'CEAdapterBoard', 'SHVBoard', 'CableHarness'].includes(component.formId)) {
-          const name_splits = component.data.name.split('-');
-          record.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
-        } else if (component.formId === 'GeometryBoard') {
-          record.componentName = component.data.typeRecordNumber;
-        } else {
-          record.componentName = component.data.name;
-        }
-      } else {
-        record.componentName = record.componentUuid;
-      }
+      record.componentName = component.data.componentName;
     }
   }
 

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -9,6 +9,8 @@ const Forms = require('./Forms');
 const permissions = require('./permissions');
 const utils = require('./utils');
 
+const logger = require('./logger');
+
 
 /// Generate a new component UUID
 function newUuid() {
@@ -764,7 +766,7 @@ async function setComponentNames(typeFormId) {
     const typeFormName = component.formName;
     const data = component.data;
     const typeRecordNumber = String(data.typeRecordNumber).padStart(5, '0');
-    const validityStartDate = component.validity.startDate.toISOString();
+    const validityStartDate = (typeof component.validity.startDate === 'string') ? component.validity.startDate : component.validity.startDate.toISOString();
 
     let componentName = '';
     let dunePid = '';

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -247,14 +247,12 @@ async function save(input, req) {
 
     if (newRecord.data.apaUuiDs[0].component_uuid !== '') {
       const apa = await retrieve(newRecord.data.apaUuiDs[0].component_uuid);
-      const name_splits = apa.data.name.split('-');
-      name_apa1 = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+      name_apa1 = apa.data.componentName;
     }
 
     if (newRecord.data.apaUuiDs[1].component_uuid !== '') {
       const apa = await retrieve(newRecord.data.apaUuiDs[1].component_uuid);
-      const name_splits = apa.data.name.split('-');
-      name_apa2 = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+      name_apa2 = apa.data.componentName;
     }
 
     newRecord.data.componentName = `${newRecord.formName} (${name_apa1} and ${name_apa2})`;
@@ -518,7 +516,6 @@ async function list(match_condition, options) {
       formId: true,
       formName: true,
       data: true,
-      shortName: { $substr: ['$data.name', 13, 5] },
       validity: true,
     }
   })
@@ -535,15 +532,14 @@ async function list(match_condition, options) {
       typeFormId: { '$first': '$formId' },
       typeFormName: { '$first': '$formName' },
       data: { '$first': '$data' },
-      name: { '$first': '$data.name' },
-      shortName: { '$first': '$shortName' },
+      componentName: { '$first': '$data.componentName' },
       lastEditDate: { '$first': '$validity.startDate' },
     },
   });
 
   // Re-sort the records ... by (alphanumerical) component name for APA frames and assembled APAs, or by last edit date (most recent first) for other component types
   if ((match_condition) && (match_condition.formId) && ((match_condition.formId === 'APAFrame') || (match_condition.formId === 'AssembledAPA'))) {
-    aggregation_stages.push({ $sort: { shortName: -1 } });
+    aggregation_stages.push({ $sort: { componentName: -1 } });
   } else {
     aggregation_stages.push({ $sort: { lastEditDate: -1 } });
   }
@@ -559,20 +555,8 @@ async function list(match_condition, options) {
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display
-  // Additionally, adjust the displayed names of certain component types for easier readability (shorten DUNE PIDs, and use UKIDs for geometry boards)
   for (let record of records) {
     record.componentUuid = MUUID.from(record.componentUuid).toString();
-
-    if (['APAFrame', 'AssembledAPA', 'GroundingMeshPanel', 'CRBoard', 'GBiasBoard', 'CEAdapterBoard', 'SHVBoard', 'CableHarness'].includes(record.typeFormId)) {
-      if ((record.name !== null) && (record.name !== '')) {
-        const name_splits = record.name.split('-');
-        record.name = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
-      } else {
-        record.name = record.componentUuid;
-      }
-    } else if (record.typeFormId === 'GeometryBoard') {
-      record.name = record.data.typeRecordNumber;
-    }
   }
 
   // Return the entire list of matching records
@@ -735,7 +719,7 @@ async function autoCompleteUuid(inputString, limit = 10) {
       _id: { componentUuid: '$componentUuid' },
       componentUuid: { '$first': '$componentUuid' },
       typeFormName: { '$first': '$formName' },
-      name: { '$first': '$data.name' },
+      componentName: { '$first': '$data.componentName' },
       lastEditDate: { '$first': '$validity.startDate' },
     },
   });

--- a/app/lib/Components_ExecSummary.js
+++ b/app/lib/Components_ExecSummary.js
@@ -157,7 +157,7 @@ async function collateInfo(componentUUID) {
   const frameUUID = assembledAPA.data.frameUuid;
 
   // Add relevant information from the APA's component record to the 'general' section of the collated information object
-  collatedInfo.general.dunePID = assembledAPA.data.name;
+  collatedInfo.general.dunePID = assembledAPA.data.dunePid;
   collatedInfo.general.productionSite = utils.dictionary_locations[assembledAPA.data.apaAssemblyLocation];
   collatedInfo.general.configuration = assembledAPA.data.apaConfiguration[0].toUpperCase() + assembledAPA.data.apaConfiguration.slice(1);
 

--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -104,8 +104,7 @@ async function nonConformanceByComponentType(componentType, disposition, status)
   // Additionally, get the first 'true' non-conformance type in each record, convert it to something more readable and save this new string to the record
   for (let result of results) {
     const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
-    const name_splits = component.data.name.split('-');
-    result.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+    result.componentName = component.data.componentName;
 
     if (result.componentType === 'assembledApa') {
       if (result.nonConfTypes_apas != null) {
@@ -168,8 +167,7 @@ async function nonConformanceByUUID(componentUUID) {
   // Additionally, get the first 'true' non-conformance type in each record, convert it to something more readable and save this new string to the record
   for (let result of results) {
     const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
-    const name_splits = component.data.name.split('-');
-    result.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+    result.componentName = component.data.componentName;
 
     if (result.componentType === 'assembledApa') {
       if (result.nonConfTypes_apas != null) {
@@ -258,11 +256,10 @@ async function boardInstallByReferencedComponent(componentUUID) {
     }
   }
 
-  // Add the corresponding shortened Assembled APA component name to each matching record
+  // Add the corresponding component name to each matching record
   for (let record of boardInstalls) {
     const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-    const name_splits = component.data.name.split('-');
-    record.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+    record.componentName = component.data.componentName;
   }
 
   // Return the list of matching actions
@@ -311,11 +308,10 @@ async function windingByReferencedComponent(componentUUID) {
     }
   }
 
-  // Add the corresponding shortened Assembled APA component name to each matching record
+  // Add the corresponding component name to each matching record
   for (let record of windings) {
     const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-    const name_splits = component.data.name.split('-');
-    record.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+    record.componentName = component.data.componentName;
   }
 
   // Return the list of matching actions

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -274,9 +274,7 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
     if (component.data.apaAssemblyLocation === location) {
       uuids_apasCompletedToStep_atLocation.push(action.componentUuid);
 
-      const name_splits = component.data.name.split('-');
-
-      action.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+      action.componentName = component.data.componentName;
       action.workflowId = component.workflowId;
 
       apasCompletedToStep_atLocation.push(action);
@@ -314,11 +312,10 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
     .aggregate(comp_aggregation_stages)
     .toArray();
 
-  // Add the corresponding shortened Assembled APA component name to each matching record
+  // Add the corresponding component name to each matching record
   for (let record of apasNotCompletedToStep_atLocation) {
     const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-    const name_splits = component.data.name.split('-');
-    record.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
+    record.componentName = component.data.componentName;
   }
 
   // Re-sort the records by the component name ... in reverse alphanumerical order
@@ -337,7 +334,7 @@ async function componentsByDUNEPID(dunePID) {
 
   // Match against the DUNE PID to get records of all components that have the same name as the specified one
   aggregation_stages.push({
-    $match: { 'data.name': dunePID }
+    $match: { 'data.dunePid': dunePID }
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
@@ -546,8 +543,7 @@ async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatu
             if (board.reception.detail) {
               const apa = await Components.retrieve(board.reception.detail);
 
-              const name_splits = apa.data.name.split('-');
-              cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+              cleanedBoardGroup.installedOnAPA.push(apa.data.componentName);
             } else {
               cleanedBoardGroup.installedOnAPA.push('[No APA UUID found!]');
             }
@@ -574,7 +570,7 @@ async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatu
         const mesh = await Components.retrieve(MUUID.from(meshUuid).toString());
 
         cleanedMeshGroup.componentUuids.push(MUUID.from(meshUuid).toString());
-        cleanedMeshGroup.dunePids.push(mesh.data.name);
+        cleanedMeshGroup.dunePids.push(mesh.data.dunePid);
 
         if (mesh.reception) {
           cleanedMeshGroup.receptionDates.push(mesh.reception.date);
@@ -586,8 +582,7 @@ async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatu
           if (mesh.reception.detail) {
             const apa = await Components.retrieve(mesh.reception.detail);
 
-            const name_splits = apa.data.name.split('-');
-            cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+            cleanedMeshGroup.installedOnAPA.push(apa.data.componentName);
           } else {
             cleanedMeshGroup.installedOnAPA.push('[No APA UUID found!]');
           }
@@ -735,8 +730,7 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
             if (board.reception.detail) {
               const apa = await Components.retrieve(board.reception.detail);
 
-              const name_splits = apa.data.name.split('-');
-              cleanedBoardGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+              cleanedBoardGroup.installedOnAPA.push(apa.data.componentName);
             } else {
               cleanedBoardGroup.installedOnAPA.push('[No APA UUID found!]');
             }
@@ -763,7 +757,7 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
         const mesh = await Components.retrieve(MUUID.from(meshUuid).toString());
 
         cleanedMeshGroup.componentUuids.push(MUUID.from(meshUuid).toString());
-        cleanedMeshGroup.dunePids.push(mesh.data.name);
+        cleanedMeshGroup.dunePids.push(mesh.data.dunePid);
 
         if (mesh.reception) {
           cleanedMeshGroup.receptionDates.push(mesh.reception.date);
@@ -775,8 +769,7 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
           if (mesh.reception.detail) {
             const apa = await Components.retrieve(mesh.reception.detail);
 
-            const name_splits = apa.data.name.split('-');
-            cleanedMeshGroup.installedOnAPA.push(`${name_splits[1]}-${name_splits[2]}`.slice(0, -3));
+            cleanedMeshGroup.installedOnAPA.push(apa.data.componentName);
           } else {
             cleanedMeshGroup.installedOnAPA.push('[No APA UUID found!]');
           }

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -270,27 +270,20 @@ async function list(match_condition, options) {
     .aggregate(aggregation_stages)
     .toArray();
 
-  // Add the corresponding component name to each matching record, adjusting it depending on component type for easier readability (i.e. use shortened DUNE PIDs)
-  // NOTE: all workflows must have some kind of component name in order to determine where they are being performed in the section below ...
+  // Add the corresponding component name to each matching record
+  // NOTE: all 'APA Assembly' workflows must have some kind of component name in order to determine where they are being performed in the section below ...
   // ... so any workflow that does not yet have an associated component will be given a temporary fake UK-based component name here, purely for location matching
   for (let record of records) {
     if (record.path[0].result != '') {
       const component = await Components.retrieve(record.path[0].result);
 
-      if (component) {
-        if (component.data.name) {
-          if (['APAFrame', 'AssembledAPA'].includes(component.formId)) {
-            const name_splits = component.data.name.split('-');
-            record.componentName = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
-          } else {
-            record.componentName = component.data.name;
-          }
-        } else {
-          record.componentName = record.path[0].result;
-        }
+      if (!component) {
+        record.componentName = 'APA 00000-UK';
+      } else {
+        record.componentName = component.data.componentName;
       }
     } else {
-      record.componentName = '99999-UK';
+      record.componentName = 'APA 99999-UK';
     }
   }
 
@@ -301,7 +294,7 @@ async function list(match_condition, options) {
   if (options) {
     if (options.location) {
       for (let record of records) {
-        if (record.componentName.slice(6) === options.location) filtered_records.push(record);
+        if (record.componentName.slice(10) === options.location) filtered_records.push(record);
       }
     } else {
       filtered_records = [...records];

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -27,7 +27,7 @@ block content
       .row 
         .col-sm-5
           dl
-            dt Action ID
+            dt Action ID:
             dd
               .form-inline
                 a(href = `/action/${action.actionId}`) #{action.actionId}
@@ -38,21 +38,15 @@ block content
             - const uuid = MUUID.from(action.componentUuid).toString();
 
             dt Performed on Component:
-
-            if (component.data.name)
-              dd 
-                a(href = `/component/${uuid}`) #{component.data.name}
-                |  (#{component.formName})
-            else 
-              dd 
-                a(href = `/component/${uuid}`) #{component.formName}
+            dd 
+              a(href = `/component/${uuid}`) #{component.data.componentName}
 
             if action.workflowId
               dt Part of Workflow:
               dd
                 a(href = `/workflow/${action.workflowId}`, target = '_blank') #{action.workflowId}
 
-            dt Current Version:
+            dt Current Action Version:
             dd This is version #{action.validity.version} of the action.
               br
               | It was last performed on !{' '}
@@ -65,7 +59,7 @@ block content
             .vert-space-x1
               .panel.panel-default
               .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
-                | All Versions: 
+                | All Action Versions: 
                 i.chevron.fa.fa-fw 
 
               .collapse#versionsBox
@@ -107,10 +101,7 @@ block content
           if (action.typeFormId == 'x_tension_testing')
             .vert-space-x1 
               if retensionedWires_versions[0] !== null
-                - const name_splits = component.data.name.split('-');
-                - const apa = `${name_splits[1]}-${name_splits[2]}`.slice(0, -3);
-
-                a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${apa}_${action.data.apaLayer.toUpperCase()}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
+                a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${component.data.componentName.slice(5)}_${action.data.apaLayer.toUpperCase()}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
               else 
                 a.btn.btn-secondary.disabled(href = '') Download List of Changed Tensions
 
@@ -482,7 +473,7 @@ block content
 
         .vert-space-x2 
 
-      if action.typeFormId == 'action_test' || action.typeFormId == 'APANonConformance' || action.typeFormId == 'x_tension_testing' || action.typeFormId == 'MeshQAInspection'
+      if action.typeFormId == 'APANonConformance' || action.typeFormId == 'x_tension_testing' || action.typeFormId == 'MeshQAInspection'
         dt Add Images to Action Record:
         dd Please use the 'Select Images' button below to select one or more images from your device to add to this action record.  Once you are happy with your selection, please use the 'Confirm Images' button to finalise the upload.
           br

--- a/app/pug/action_specComponent.pug
+++ b/app/pug/action_specComponent.pug
@@ -25,16 +25,12 @@ block content
         dt Action Type
         dd #{actionTypeForm.formName}
 
+        dt Component Name
+        dd #{componentName}
+        
         dt Component UUID
         dd
           a(href = `/component/${componentUuid}`) #{componentUuid}
-
-        dt Component Name
-
-        if componentName
-          dd #{componentName}
-        else
-          dd (none)
 
     .vert-space-x1
       hr

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -20,35 +20,29 @@ block extrascripts
     script(src = '/pages/component.js')
 
 block vars
-  - const page_title = `Component: ${component.formName}`;
+  - const page_title = `Component: ${component.data.componentName}`;
 
 block content
   .container-fluid
     .vert-space-x2
-      h2 #{component.formName}
+      h2 #{component.data.componentName}
 
     .vert-space-x1
       .row
         .col-sm-5
           dl
-            dt Component UUID
-            dd
+            dt Component Name and UUID:
+            dd #{component.data.componentName}
+              |  
               .form-inline
                 a(href = `/component/${component.componentUuid}`) #{component.componentUuid}
 
                 .hori-space-x1
                   a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
 
-            if component.data.name
-              dt Name or ID
-
-                if component.formId == 'GroundingMeshPanel'
-                  dd #{component.data.typeRecordNumber}
-                else
-                  dd #{component.data.name}
-
+            
             if component.reception && component.reception.location !== ''
-              dt Location
+              dt Current Location:
 
               if component.reception.detail && component.reception.detail != ''
                 dd
@@ -92,7 +86,7 @@ block content
             .vert-space-x1
               .panel.panel-default
               .foldable-heading.panel-heading.collapsed(data-toggle = 'collapse' data-target = '#versionsBox')
-                | All Versions: 
+                | All Component Versions: 
                 i.chevron.fa.fa-fw 
 
               .collapse#versionsBox
@@ -152,7 +146,7 @@ block content
 
         .col-sm-3
           #qr-code
-            +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, component.data.name)
+            +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, component.data.componentName)
 
           p.small.text-center #{base_url}/c/#{component.shortUuid.toString()}
 

--- a/app/pug/component_execSummary.pug
+++ b/app/pug/component_execSummary.pug
@@ -59,7 +59,7 @@ block allbody
 
         .col-sm-4
           #qr-code
-            +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, 'component.data.name')
+            +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, 'component.data.componentName')
 
     hr
 

--- a/app/pug/component_list.pug
+++ b/app/pug/component_list.pug
@@ -26,7 +26,7 @@ block content
         thead
           tr
             th.col-md-2 Type Name
-            th.col-md-3 Component Name / UUID 
+            th.col-md-3 Component Name
             th.col-md-1
             th.col-md-2 Last Edited On:
             th.col-md-1
@@ -40,16 +40,8 @@ block content
 
               tr          
                 td #{component.typeFormName}
-
-                if component.name
-                  td
-                    a(href = `/component/${uuid}`) #{component.name}
-                else if component.data.bobbinId
-                  td 
-                    a(href = `/component/${uuid}`) #{component.data.bobbinId}
-                else
-                  td 
-                    a(href = `/component/${uuid}`) #{uuid}
+                td
+                  a(href = `/component/${uuid}`) #{component.data.componentName}
 
                 if component.typeFormId == 'AssembledAPA'
                   td

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -1,12 +1,12 @@
 extend default
 include common.pug
 
-block vars
-  - const page_title = 'Component QR Codes';
-
 block extrascripts
   script(type = 'text/javascript').
     const base_url = '!{base_url}';
+
+block vars
+  - const page_title = `Component QR Codes: ${component.data.componentName}`;
 
 block allbody
   .vert-space-x2.hori-space-x1.noprint
@@ -47,7 +47,7 @@ block allbody
             +qr-panel-topText(qrCodeText, qrCodeDesc)
 
       else
-        - const qrCodeDesc = component.data.name
+        - const qrCodeDesc = component.data.componentName
 
         .row.qr-row
           .col-sm-6.qr-col

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -1,9 +1,6 @@
 extend default
 include common.pug
 
-block vars
-  - const page_title = 'Component Summary';
-
 block extrascripts
   script(type = 'text/javascript').
     const component = !{JSON.stringify(component, null, 4)};
@@ -16,6 +13,9 @@ block extrascripts
 
   block workscripts
     script(src = '/pages/component_summary.js')
+
+block vars
+  - const page_title = `Component Summary: ${component.data.componentName}`;
 
 block allbody
   .vert-space-x2.hori-space-x1.noprint
@@ -35,19 +35,12 @@ block allbody
 
           .vert-space-x1.hori-space-x1.h4
             dl
-              dt Type
-              dd #{component.formName}
+              dt Component Name
+              dd #{component.data.componentName}
 
               dt Component UUID
               dd #{component.componentUuid}
-
-              dt Name
-
-              if component.data.name
-                dd #{component.data.name}
-              else
-                dd (none)
-
+              
               if component.formId == 'BoardShipment' || component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
                 dt Number of Boards in Shipment
                 dd #{component.data.boardUuiDs.length}
@@ -58,7 +51,7 @@ block allbody
 
         .col-sm-5
           #qr-code
-            +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, 'component.data.name')
+            +qr-panel-noText(`${base_url}/c/${component.shortUuid.toString()}`, `${component.data.componentName}`)
 
       .vert-space-x1
         dl

--- a/app/pug/search_apasByProductionDetails.pug
+++ b/app/pug/search_apasByProductionDetails.pug
@@ -64,7 +64,6 @@ block content
               option(value = 'uLayerAssembly') U Layer QA Check
               option(value = 'gLayerAssembly') G Layer QA Check
               option(value = 'coverBoardsAndCaps') Cover Boards / Cap Installation QA Check
-              option(value = 'shippingPreparation') Shipping Preparation QA Check
               option(value = 'assemblyComplete') Completed APA QA Checklist
 
             .vert-space-x2

--- a/app/pug/search_componentsByIdentifier.pug
+++ b/app/pug/search_componentsByIdentifier.pug
@@ -34,7 +34,7 @@ block content
               h4 Search by DUNE PID 
 
               .vert-space-x1
-                p Enter a DUNE PID (in the form D00300XXXXXX-XXXXX-XXXXX-01-00-00) below.
+                p Enter a DUNE PID (in the form D00300XXXXXX-XXXXX-XXXXX-010000) below.
 
               input.form-control#dunePIDSelection
 

--- a/app/pug/workflow_listTypes.pug
+++ b/app/pug/workflow_listTypes.pug
@@ -40,7 +40,7 @@ block content
         thead
           tr
             th.col-md-2 Type Name
-            th.col-md-3 Recommended Component Types
+            th.col-md-3 Recommended Component Type
             th.col-md-2
             th.col-md-2
 
@@ -83,7 +83,7 @@ block content
           thead
             tr
               th.col-md-2 Type Name
-              th.col-md-3 Recommended Component Types
+              th.col-md-3 Recommended Component Type
               th.col-md-2
               th.col-md-2
 

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -189,7 +189,7 @@ router.get('/action/:typeFormId/' + utils.uuid_regex, permissions.checkPermissio
     res.render('action_specComponent.pug', {
       actionTypeForm,
       componentUuid: req.params.uuid,
-      componentName: component.data.name,
+      componentName: component.data.componentName,
       workflowId,
       stepIndex,
     });
@@ -226,7 +226,7 @@ router.get('/action/:actionId([A-Fa-f0-9]{24})/edit', permissions.checkPermissio
       action,
       actionTypeForm,
       componentUuid: action.componentUuid,
-      componentName: component.data.name,
+      componentName: component.data.componentName,
       workflowId,
       stepIndex: '-99',
     });

--- a/app/routes/autocomplete.js
+++ b/app/routes/autocomplete.js
@@ -16,7 +16,7 @@ router.get('/autocomplete/uuid', async function (req, res, next) {
   // For each retrieved record, construct a string consisting of the component's UUID, name and type form name
   for (let m of matches) {
     m.val = m.componentUuid;
-    m.text = `${m.componentUuid} (${m.typeFormName}) [${m.name}]`;
+    m.text = `${m.componentUuid} (${m.typeFormName}) [${m.componentName}]`;
   }
 
   // Return a JSON document containing the retrieved records, including the newly constructed strings

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -34,14 +34,7 @@ router.get('/workflow/:workflowId([A-Fa-f0-9]{24})', permissions.checkPermission
 
     if (workflow.path[0].result.length > 0) {
       const component = await Components.retrieve(workflow.path[0].result);
-
-      if (component) {
-        if (component.data.name) {
-          componentName = component.data.name;
-        } else {
-          componentName = workflow.path[0].result;
-        }
-      }
+      componentName = component.data.componentName;
     }
 
     // Retrieve and store the status of each action that has been performed (i.e. that has a result) - that is, the value (true or false) of the action's 'data.actionComplete' field

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -291,10 +291,10 @@ class ComponentUUID extends TextFieldComponent {
           url: `/json/component/${value}`,
           dataType: 'json',
           success: function (component) {    // This line will sometimes throw an error in console when moving away from an interface page that contains a lot of UUID boxes
-            // It appears that this code sometimes can't quite keep up with loading all of the boxes' messages, and may not finish before the next page loads ...
-            // ... meaning that it cannot find the 'component' variable in time, and throws an error as a result
-            // It does eventually catch up if given enough time, but the box messages are purely for displaying information ...
-            // ... it won't affect any record submission if they don't load fast enough
+                                             // It appears that this code sometimes can't quite keep up with loading all of the boxes' messages, and may not finish before the next page loads ...
+                                             // ... meaning that it cannot find the 'component' variable in time, and throws an error as a result
+                                             // It does eventually catch up if given enough time, but the box messages are purely for displaying information ...
+                                             // ... it won't affect any record submission if they don't load fast enough
             if (component.formId === 'APAFrame') {
               $.ajax({
                 contentType: 'application/json',
@@ -310,14 +310,14 @@ class ComponentUUID extends TextFieldComponent {
                       dataType: 'json',
                       success: function (action) {
                         if (action.data.actionComplete) {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for use`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
                         } else {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s QA Checklist is not complete!`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - QA Checklist action is not complete!`);
                         }
                       },
                     }).fail();
                   } else {
-                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a QA Checklist!`);
+                    info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - QA Checklist action cannot be found!`);
                   }
                 },
               }).fail();
@@ -336,22 +336,22 @@ class ComponentUUID extends TextFieldComponent {
                       dataType: 'json',
                       success: function (action) {
                         if ((action.data.disposition === 'useAsIs') || (action.data.disposition === 'conformant')) {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for use`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
                         } else {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s QA Inspection disposition is not 'Use As Is' or 'Conformant'!`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - QA Inspection action disposition is not 'Use As Is' or 'Conformant'!`);
                         }
                       },
                     }).fail();
                   } else {
-                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a QA Inspection!`);
+                    info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - QA Inspection action cannot be found!`);
                   }
                 },
               }).fail();
             } else if (component.formId === 'wire_bobbin') {
               if (component.data.meanBreakStrength >= 24.0) {
-                info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for use`);
+                info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
               } else {
-                info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s mean break strength is less than 24.0 N!`);
+                info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - mean break strength is less than 24.0 N!`);
               }
             } else if (component.formId === 'GeometryBoard') {
               $.ajax({
@@ -361,7 +361,7 @@ class ComponentUUID extends TextFieldComponent {
                 dataType: 'json',
                 success: function (actionIDsList) {
                   if (actionIDsList.length == 0) {
-                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} (part number: ${component.data.partNumber}) is ready for use`);
+                    info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
                   } else {
                     $.ajax({
                       contentType: 'application/json',
@@ -370,9 +370,9 @@ class ComponentUUID extends TextFieldComponent {
                       dataType: 'json',
                       success: function (action) {
                         if ((action.data.disposition === 'useAsIs') || (action.data.disposition === 'remediated')) {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} (part number: ${component.data.partNumber}) is ready for use`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
                         } else {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} (part number: ${component.data.partNumber}) has been rejected!`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - rejected via Factory Board Rejection action!`);
                         }
                       },
                     }).fail();
@@ -394,19 +394,19 @@ class ComponentUUID extends TextFieldComponent {
                       dataType: 'json',
                       success: function (action) {
                         if (action.data.actionComplete) {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName} is ready for shipping`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for shipping`);
                         } else {
-                          info_target.text(`\xa0 [Click for Component Info] This ${component.formName}'s QA Checklist is not complete!`);
+                          info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - QA Checklist action is not complete!`);
                         }
                       },
                     }).fail();
                   } else {
-                    info_target.text(`\xa0 [Click for Component Info] This ${component.formName} does not have a QA Checklist!`);
+                    info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - QA Checklist action cannot be found!`);
                   }
                 },
               }).fail();
             } else {
-              info_target.text(`\xa0 [Click for Component Info]`);
+              info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName}`);
             }
           },
         }).fail();

--- a/app/static/pages/component.js
+++ b/app/static/pages/component.js
@@ -37,7 +37,7 @@ async function populateTypeForm() {
                   },
                   {
                     "label": "Name",
-                    "key": "name",
+                    "key": "componentName",
                     "type": "textfield",
                     "input": false
                   }

--- a/m2m/template_createComponent.py
+++ b/m2m/template_createComponent.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     #   - the component's data (a Python dictionary, corresponding to the data to be entered into the type form)
     componentTypeFormID = 'basic_component'
     componentData = {
-        'name': 'New M2M Component',
+        'componentName': 'New M2M Component',
         'textField': 'This is a component created through the M2M application',
     }
 

--- a/m2m/template_editAction.py
+++ b/m2m/template_editAction.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     #   - the new values of any data fields to be edited
     actionID = '63340ac79708eb30e6403cb9'
     actionData_fields = [
-        'name',
+        'actionName',
         'measurement',
     ]
     actionData_values = [

--- a/m2m/template_performAction.py
+++ b/m2m/template_performAction.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     actionTypeFormID = 'my_action'
     componentUUID = '5f9ea420-3e88-11ed-9114-03f8483882ff'
     actionData = {
-        'name': 'M2M Action',
+        'actionName': 'M2M Action',
         'actionPerformedAfterFormsCleanup': True,
         'measurement': 12.04,
     }


### PR DESCRIPTION
Changes to various interface pages, so that they now make use of the new component names and DUNE PIDs.
Formio 'ComponentUUID' entity and autocomplete suggestions will now also display the names correctly and consistently.

Also includes the fix for when the 'validity.startDate' field is a string, instead of a 'Date' type object.  (Literally only relevant for one geometry board in the entire DB, but it breaks the administrator utility function, and is stopping the additions of new name fields in geometry boards, if not accounted for.)  Fix has been tested on Staging, confirmed to work.