### PR TITLE
Miscellaneous Requested Changes

### DIFF
--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -377,6 +377,7 @@ async function componentsByTypeAndNumber(typeFormId, typeRecordNumber) {
       typeRecordNumber: { '$first': '$data.typeRecordNumber' },
       formName: { '$first': '$formName' },
       shortUuid: { '$first': '$shortUuid' },
+      data: { '$first': '$data' },
     },
   });
 

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -392,19 +392,31 @@ async function componentsByTypeAndNumber(typeFormId, typeRecordNumber) {
 
 
 /// Retrieve a list of components that match the specified type and that are at a specified location
-async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatus, toothStripStatus) {
+async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatus, toothStripStatus, conformanceStatus, qaChecksStatus) {
   let aggregation_stages = [];
 
   // Allow for a 'null' location to be specified, to make debugging of components with missing locations easier
   if (location == 'none') location = null;
 
-  // Match against the type form ID and specified location to get records of all components of the specified type currently at this location
-  aggregation_stages.push({
-    $match: {
+  // Depending on which parameters have been passed to this function, match to get:
+  // ... either records of all components of the specified type at the specified location with the specified conformance (for one of the 'populated board' types where a conformance was specified)
+  // ... or records of all components of the specified type at the specified location (for one of the 'populated board' types where a conformance was not specified, or all other component types)
+  let match_condition = {};
+
+  if (['CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes(typeFormId) && (conformanceStatus !== 'any')) {
+    match_condition = {
       'formId': typeFormId,
       'reception.location': location,
-    }
-  });
+      'data.boardIsConformant': conformanceStatus,
+    };
+  } else {
+    match_condition = {
+      'formId': typeFormId,
+      'reception.location': location,
+    };
+  }
+
+  aggregation_stages.push({ $match: match_condition });
 
   // Select the latest version of each record, and pass through only the fields required for later use (dependent on the specified component type)
   aggregation_stages.push({ $sort: { 'validity.version': -1 } });
@@ -475,6 +487,7 @@ async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatu
 
   // Reorganise the query results to make it easier to display them on the interface page ... the format of the reorganised results depends on the specified component type
   // Additionally for the 'Geometry Board' component type, filter the results based on the optional 'board acceptance status' and 'tooth strip attachment status' search parameters
+  // Alternatively for any of the 'populated board' or 'Cable Harness' component types, filter the results based on the optional 'QA checks status' search parameters
   let cleanedResults = [];
 
   if (typeFormId === 'GeometryBoard') {
@@ -594,6 +607,42 @@ async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatu
 
       if (cleanedMeshGroup.componentUuids.length > 0) cleanedResults.push(cleanedMeshGroup);
     }
+  } else if (['CableHarness', 'CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes(typeFormId)) {
+    for (const result of results) {
+      const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
+
+      let qaChecksPassed = false;
+
+      let match_condition = {
+        typeFormId: 'PopulatedBoardQC',
+        componentUuid: MUUID.from(result.componentUuid).toString(),
+      };
+
+      const qaChecksActions = await Actions.list(match_condition);
+
+      if (qaChecksActions.length > 0) {
+        const qaChecksAction = await Actions.retrieve(qaChecksActions[0].actionId);
+
+        if (['CableHarness', 'CEAdapterBoard', 'SHVBoard'].includes(typeFormId)) {
+          if (qaChecksAction.data.qaTestResult === 'passed') {
+            qaChecksPassed = true;
+          }
+        } else if (['CRBoard', 'GBiasBoard'].includes(typeFormId)) {
+          if ((qaChecksAction.data.preColdCycleTest === 'passed') && (qaChecksAction.data.postColdCycleTest === 'passed')) {
+            qaChecksPassed = true;
+          }
+        }
+      }
+
+      if ((qaChecksStatus === 'any') || ((qaChecksStatus === 'passed') && (qaChecksPassed == true)) || (qaChecksStatus === 'failed') && (qaChecksPassed == false)) {
+        cleanedResults.push({
+          'componentUuid': result.componentUuid,
+          'typeRecordNumber': component.data.typeRecordNumber,
+          'receptionDate': (component.reception != null) ? component.reception.date : 'unknown',
+          'qaChecksPassed': (qaChecksPassed == true) ? 'Yes' : 'No',
+        });
+      }
+    }
   } else {
     for (const result of results) {
       const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
@@ -602,7 +651,7 @@ async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatu
         'componentUuid': result.componentUuid,
         'typeRecordNumber': component.data.typeRecordNumber,
         'receptionDate': (component.reception != null) ? component.reception.date : 'unknown',
-      })
+      });
     }
   }
 

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -62,6 +62,14 @@ block content
           li <b>board acceptance status</b> - that is, whether a board has been <u>rejected</u> (by performing a <u>Factory Rejection</u> action on it, and setting the action disposition to <u>Rejected</u>) or <u>accepted</u> (by either not performing a Factory Rejection action, or performing the action and setting the disposition to either <u>Use As Is</u> or <u>Remediated</u>)
           li <b>tooth strip attachment status</b> - whether a tooth strip has been attached to the board (by performing a <u>Tooth Strip Attachment</u> action on it)
 
+      p When selecting any of the 'populated board' component types (i.e. 'CE Adapter', 'CR', 'G-Bias' or 'SHV'), the search results may be optionally refined using the following parameter: 
+        ul
+          li <b>board conformance status</b> - that is, whether a board has been deemed conformant or not (this is information provided during component creation, and not tied to an explicit action that has been performed on the board in question)
+
+      p When selecting any of the 'populated board' component types or the 'Cable Harness' component type, the search results may be optionally refined using the following parameter: 
+        ul 
+          li <b>QA checks status</b> - that is, whether a component has passed or failed the relevant QA checks that have been performed on it via a <u>Populated Board/Cable Harness QA</u> action
+
       hr
 
     .vert-space-x2

--- a/app/pug/search_componentsByTypeAndLocation.pug
+++ b/app/pug/search_componentsByTypeAndLocation.pug
@@ -39,7 +39,7 @@ block content
                 option(value = 'GroundingMeshPanel') Grounding Mesh Panel
                 option(value = 'SHVBoard') SHV Board
                 option(value = 'Yoke') Yoke
-                
+
               .vert-space-x2
 
             .col-md-6
@@ -101,6 +101,36 @@ block content
                 option(value = 'any') (any)
                 option(value = 'attached') Tooth Strip Attached
                 option(value = 'notAttached') Tooth Strip Not Yet Attached
+
+          .vert-space-x2 
+            hr
+
+          .row 
+            .col-md-6
+              h4 Board Conformance Status
+
+              .vert-space-x1 
+                p Select a status below ... this is an optional parameter.
+                  br
+                  | It only applies when selecting <b>any populated board</b> above.
+
+              select.form-control#conformanceStatusSelection
+                option(value = 'any') (any)
+                option(value = 'yes') Board is Conformant 
+                option(value = 'no') Board is Not Conformant
+
+            .col-md-6
+              h4 QA Checks Status
+
+              .vert-space-x1 
+                p Select a status below ... this is an optional parameter.
+                  br
+                  | It only applies when selecting <b>any populated board</b> or <b>'Cable Harness'</b> above.
+
+              select.form-control#qaChecksStatusSelection
+                option(value = 'any') (any)
+                option(value = 'passed') QA Checks Passed
+                option(value = 'failed') QA Checks Failed
 
         .col-md-1
 

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -92,102 +92,135 @@ block content
         .col-sm-3
 
     .vert-space-x1.border-success.border.rounded.p-2
-      - let freeSection_bgn = -2;
-      - let freeSection_end = -1;
-      - let freeSection_complete = true 
-
       if workflow.typeFormId === 'APA_Assembly'
-        - freeSection_bgn = 3;
-        - freeSection_end = 10;
-      else if workflow.typeFormId === 'FrameAssembly'
-        - freeSection_bgn = 3;
-        - freeSection_end = 4;
+        - let framePrep_start = 3;
+        - let framePrep_end = 10;
+        - let framePrep_complete = true
 
-        - for (let i = freeSection_bgn - 1; i < freeSection_end; i++) {
+        - for (let i = framePrep_start - 1; i < framePrep_end; i++) {
           - if (!actionsDictionary[i])
-            - freeSection_complete = false
+            - framePrep_complete = false
         - }
 
-      table.table
-        thead
-          tr 
-            th.col-md-1 Step
-            th.col-md-3 Type Form Name
-            th.col-md-3 Result (Component Name or Action ID)
-            th.col-md-3 Action Status
+        - let shippingPrep_start = 50;
+        - let shippingPrep_end = 51;
+        - let shippingPrep_complete = true
 
-        tbody
-          each step, index in workflow.path 
+        - for (let i = shippingPrep_start - 1; i < shippingPrep_end; i++) {
+          - if (!actionsDictionary[i])
+            - shippingPrep_complete = false
+        - }
+
+        table.table
+          thead
             tr 
-              td #{index + 1}
-              td #{step.formName}
+              th.col-md-1 Step
+              th.col-md-3 Type Form Name
+              th.col-md-3 Result (Component Name or Action ID)
+              th.col-md-3 Action Status
 
-              - const componentUuid = workflow.path[0].result;
-              - let stepFormId = '';
+          tbody
+            each step, index in workflow.path 
+              tr 
+                td #{index + 1}
+                td #{step.formName}
 
-              if index === 0
-                each typeFormId in Object.keys(componentTypeForms).sort()
-                  if componentTypeForms[typeFormId].formName == step.formName
-                    - stepFormId = componentTypeForms[typeFormId].formId
+                - const componentUuid = workflow.path[0].result;
+                - let stepFormId = '';
 
-                if componentUuid.length === 0
-                  td
-                    .form-inline 
-                      | (step not yet performed)
-
-                      .hori-space-x2
-                        a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
-                          img.small-icon(src = '/images/run_icon.svg')
-                          | &nbsp; Create Component 
+                if index === 0
+                  each typeFormId in Object.keys(componentTypeForms).sort()
+                    if componentTypeForms[typeFormId].formName == step.formName
+                      - stepFormId = componentTypeForms[typeFormId].formId
                 else 
-                  td
-                    a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
+                  each typeFormId in Object.keys(actionTypeForms).sort()
+                    if actionTypeForms[typeFormId].formName == step.formName
+                      - stepFormId = actionTypeForms[typeFormId].formId
 
-                td [n.a.]
-              else if index === 1
-                each typeFormId in Object.keys(actionTypeForms).sort()
-                  if actionTypeForms[typeFormId].formName == step.formName
-                    - stepFormId = actionTypeForms[typeFormId].formId
+                if index === 0
+                  if componentUuid.length === 0
+                    td
+                      .form-inline 
+                        | (step not yet performed)
 
-                if step.result.length === 0
-                  td 
-                    .form-inline 
-                      | (step not yet performed)
-
-                      .hori-space-x2
-                        if componentUuid.length === 0
-                          a.btn-sm.btn-danger
-                            | Create Component First
-                        else 
-                          a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                        .hori-space-x2
+                          a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
                             img.small-icon(src = '/images/run_icon.svg')
-                            | &nbsp; Perform Action
+                            | &nbsp; Create Component 
+                  else 
+                    td
+                      a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
 
-                  td.text-danger.font-weight-bold Not Complete
-                else 
-                  td 
-                    a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+                  td [n.a.]
+                else if index === 1
+                  if step.result.length === 0
+                    td 
+                      .form-inline 
+                        | (step not yet performed)
 
-                  if !actionsDictionary[index]
+                        .hori-space-x2
+                          if componentUuid.length === 0
+                            a.btn-sm.btn-danger
+                              | Create Component First
+                          else 
+                            a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                              img.small-icon(src = '/images/run_icon.svg')
+                              | &nbsp; Perform Action
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if !actionsDictionary[index]
+                      td.text-danger.font-weight-bold Not Complete
+                    else
+                      td.text-success.font-weight-bold Complete
+                else if index >= framePrep_start - 1 && index < framePrep_end
+                  if step.result.length === 0
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          if !actionsDictionary[framePrep_start - 2]
+                            a.btn-sm.btn-danger
+                              | Complete Step #{framePrep_start - 1} First
+                          else 
+                            a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                              img.small-icon(src = '/images/run_icon.svg')
+                              | &nbsp; Perform Action
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if !actionsDictionary[index]
+                      td.text-danger.font-weight-bold Not Complete
+                    else
+                      td.text-success.font-weight-bold Complete
+                else if index >= framePrep_end - 1 && index < shippingPrep_start
+                  if !framePrep_complete
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          a.btn-sm.btn-danger
+                            | Complete Steps #{framePrep_start} to #{framePrep_end} First
+
                     td.text-danger.font-weight-bold Not Complete
                   else
-                    td.text-success.font-weight-bold Complete
-              else 
-                each typeFormId in Object.keys(actionTypeForms).sort()
-                  if actionTypeForms[typeFormId].formName == step.formName
-                    - stepFormId = actionTypeForms[typeFormId].formId
-
-                if (workflow.typeFormId === 'APA_Assembly') || (workflow.typeFormId === 'FrameAssembly')
-                  if index >= freeSection_bgn - 1 && index < freeSection_end
                     if step.result.length === 0
-                      td
+                      td 
                         .form-inline 
                           | (step not yet performed)
 
                           .hori-space-x2
-                            if !actionsDictionary[freeSection_bgn - 2]
+                            if !actionsDictionary[index - 1]
                               a.btn-sm.btn-danger
-                                | Complete Step #{freeSection_bgn - 1} First
+                                | Complete Previous Action First
                             else 
                               a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
                                 img.small-icon(src = '/images/run_icon.svg')
@@ -202,41 +235,265 @@ block content
                         td.text-danger.font-weight-bold Not Complete
                       else
                         td.text-success.font-weight-bold Complete
+                else if index >= shippingPrep_start - 1 && index < shippingPrep_end
+                  if step.result.length === 0
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          if !actionsDictionary[shippingPrep_start - 2]
+                            a.btn-sm.btn-danger
+                              | Complete Step #{shippingPrep_start - 1} First
+                          else 
+                            a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                              img.small-icon(src = '/images/run_icon.svg')
+                              | &nbsp; Perform Action
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if !actionsDictionary[index]
+                      td.text-danger.font-weight-bold Not Complete
+                    else
+                      td.text-success.font-weight-bold Complete
+                else
+                  if !shippingPrep_complete
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          a.btn-sm.btn-danger
+                            | Complete Steps #{shippingPrep_start} and #{shippingPrep_end} First
+
+                    td.text-danger.font-weight-bold Not Complete
                   else
-                    if !freeSection_complete
-                      td
+                    if step.result.length === 0
+                      td 
                         .form-inline 
                           | (step not yet performed)
 
                           .hori-space-x2
-                            a.btn-sm.btn-danger
-                              | Complete Steps #{freeSection_bgn} to #{freeSection_end} First
+                            if !actionsDictionary[index - 1]
+                              a.btn-sm.btn-danger
+                                | Complete Previous Action First
+                            else 
+                              a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                                img.small-icon(src = '/images/run_icon.svg')
+                                | &nbsp; Perform Action
 
                       td.text-danger.font-weight-bold Not Complete
                     else 
-                      if step.result.length === 0
-                        td 
-                          .form-inline 
-                            | (step not yet performed)
+                      td 
+                        a(href = `/action/${step.result}`, target = '_blank') #{step.result}
 
-                            .hori-space-x2
-                              if !actionsDictionary[index - 1]
-                                a.btn-sm.btn-danger
-                                  | Complete Previous Action First
-                              else 
-                                a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
-                                  img.small-icon(src = '/images/run_icon.svg')
-                                  | &nbsp; Perform Action
-
+                      if !actionsDictionary[index]
                         td.text-danger.font-weight-bold Not Complete
-                      else 
-                        td 
-                          a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+                      else
+                        td.text-success.font-weight-bold Complete
+      else if workflow.typeFormId === 'FrameAssembly'
+        - let surveys_start = 3;
+        - let surveys_end = 4;
+        - let surveys_complete = true
 
-                        if !actionsDictionary[index]
-                          td.text-danger.font-weight-bold Not Complete
-                        else
-                          td.text-success.font-weight-bold Complete
+        - for (let i = surveys_start - 1; i < surveys_end; i++) {
+          - if (!actionsDictionary[i])
+            - surveys_complete = false
+        - }
+
+        table.table
+          thead
+            tr 
+              th.col-md-1 Step
+              th.col-md-3 Type Form Name
+              th.col-md-3 Result (Component Name or Action ID)
+              th.col-md-3 Action Status
+
+          tbody
+            each step, index in workflow.path 
+              tr 
+                td #{index + 1}
+                td #{step.formName}
+
+                - const componentUuid = workflow.path[0].result;
+                - let stepFormId = '';
+
+                if index === 0
+                  each typeFormId in Object.keys(componentTypeForms).sort()
+                    if componentTypeForms[typeFormId].formName == step.formName
+                      - stepFormId = componentTypeForms[typeFormId].formId
+                else 
+                  each typeFormId in Object.keys(actionTypeForms).sort()
+                    if actionTypeForms[typeFormId].formName == step.formName
+                      - stepFormId = actionTypeForms[typeFormId].formId
+
+                if index === 0
+                  if componentUuid.length === 0
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
+                            img.small-icon(src = '/images/run_icon.svg')
+                            | &nbsp; Create Component 
+                  else 
+                    td
+                      a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
+
+                  td [n.a.]
+                else if index === 1
+                  if step.result.length === 0
+                    td 
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          if componentUuid.length === 0
+                            a.btn-sm.btn-danger
+                              | Create Component First
+                          else 
+                            a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                              img.small-icon(src = '/images/run_icon.svg')
+                              | &nbsp; Perform Action
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if !actionsDictionary[index]
+                      td.text-danger.font-weight-bold Not Complete
+                    else
+                      td.text-success.font-weight-bold Complete
+                else if index >= surveys_start - 1 && index < surveys_end
+                  if step.result.length === 0
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          if !actionsDictionary[surveys_start - 2]
+                            a.btn-sm.btn-danger
+                              | Complete Step #{surveys_start - 1} First
+                          else 
+                            a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                              img.small-icon(src = '/images/run_icon.svg')
+                              | &nbsp; Perform Action
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if !actionsDictionary[index]
+                      td.text-danger.font-weight-bold Not Complete
+                    else
+                      td.text-success.font-weight-bold Complete
+                else
+                  if !surveys_complete
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          a.btn-sm.btn-danger
+                            | Complete Steps #{surveys_start} and #{surveys_end} First
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    if step.result.length === 0
+                      td 
+                        .form-inline 
+                          | (step not yet performed)
+
+                          .hori-space-x2
+                            if !actionsDictionary[index - 1]
+                              a.btn-sm.btn-danger
+                                | Complete Previous Action First
+                            else 
+                              a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                                img.small-icon(src = '/images/run_icon.svg')
+                                | &nbsp; Perform Action
+
+                      td.text-danger.font-weight-bold Not Complete
+                    else 
+                      td 
+                        a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                      if !actionsDictionary[index]
+                        td.text-danger.font-weight-bold Not Complete
+                      else
+                        td.text-success.font-weight-bold Complete
+      else
+        table.table
+          thead
+            tr 
+              th.col-md-1 Step
+              th.col-md-3 Type Form Name
+              th.col-md-3 Result (Component Name or Action ID)
+              th.col-md-3 Action Status
+
+          tbody
+            each step, index in workflow.path 
+              tr 
+                td #{index + 1}
+                td #{step.formName}
+
+                - const componentUuid = workflow.path[0].result;
+                - let stepFormId = '';
+
+                if index === 0
+                  each typeFormId in Object.keys(componentTypeForms).sort()
+                    if componentTypeForms[typeFormId].formName == step.formName
+                      - stepFormId = componentTypeForms[typeFormId].formId
+                else 
+                  each typeFormId in Object.keys(actionTypeForms).sort()
+                    if actionTypeForms[typeFormId].formName == step.formName
+                      - stepFormId = actionTypeForms[typeFormId].formId
+
+                if index === 0
+                  if componentUuid.length === 0
+                    td
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          a.btn-sm.btn-primary(href = `/component/${stepFormId}?workflowId=${workflow.workflowId}`)
+                            img.small-icon(src = '/images/run_icon.svg')
+                            | &nbsp; Create Component 
+                  else 
+                    td
+                      a(href = `/component/${componentUuid}`, target = '_blank') #{componentName}
+
+                  td [n.a.]
+                else if index === 1
+                  if step.result.length === 0
+                    td 
+                      .form-inline 
+                        | (step not yet performed)
+
+                        .hori-space-x2
+                          if componentUuid.length === 0
+                            a.btn-sm.btn-danger
+                              | Create Component First
+                          else 
+                            a.btn-sm.btn-primary(href = `/action/${stepFormId}/spec/${componentUuid}?workflowId=${workflow.workflowId}&stepIndex=${index}`)
+                              img.small-icon(src = '/images/run_icon.svg')
+                              | &nbsp; Perform Action
+
+                    td.text-danger.font-weight-bold Not Complete
+                  else 
+                    td 
+                      a(href = `/action/${step.result}`, target = '_blank') #{step.result}
+
+                    if !actionsDictionary[index]
+                      td.text-danger.font-weight-bold Not Complete
+                    else
+                      td.text-success.font-weight-bold Complete
                 else
                   if step.result.length === 0
                     td 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -100,7 +100,7 @@ module.exports = routes;
   /json/search/componentsByDUNEPID/:dunePID
   /json/search/componentsByTypeAndNumber/:typeFormId/:typeRecordNumber
   /search/componentsByTypeAndLocation
-  /json/search/componentsByTypeAndLocation/:typeFormId/:location/:acceptanceStatus/:toothStripStatus
+  /json/search/componentsByTypeAndLocation/:typeFormId/:location/:acceptanceStatus/:toothStripStatus/:conformanceStatus/:qaChecksStatus
   /search/componentsByTypeAndPartNumber
   /json/search/componentsByTypeAndPartNumber/:typeFormId/:partNumber/:acceptanceStatus/:toothStripStatus
   /search/geoBoardsByVisInspectOrOrderNumber

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -59,11 +59,11 @@ router.get('/search/componentsByTypeAndLocation', async function (req, res, next
 
 
 /// Search for components by type and current location (query to server-side)
-router.get(['/json/search/componentsByTypeAndLocation/:typeFormId/:location/:acceptanceStatus/:toothStripStatus', '/api/search/componentsByTypeAndLocation/:typeFormId/:location/:acceptanceStatus/:toothStripStatus'], async function (req, res, next) {
+router.get(['/json/search/componentsByTypeAndLocation/:typeFormId/:location/:acceptanceStatus/:toothStripStatus/:conformanceStatus/:qaChecksStatus', '/api/search/componentsByTypeAndLocation/:typeFormId/:location/:acceptanceStatus/:toothStripStatus/:conformanceStatus/:qaChecksStatus'], async function (req, res, next) {
   try {
     // Retrieve a list of components that match the specified record details
     // Geometry boards and grounding mesh panels are grouped by part number, other component types are ungrouped
-    const components = await Search_OtherComponents.componentsByTypeAndLocation(req.params.typeFormId, req.params.location, req.params.acceptanceStatus, req.params.toothStripStatus);
+    const components = await Search_OtherComponents.componentsByTypeAndLocation(req.params.typeFormId, req.params.location, req.params.acceptanceStatus, req.params.toothStripStatus, req.params.conformanceStatus, req.params.qaChecksStatus);
 
     // Return the list in JSON format
     return res.status(200).json(components);

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -254,7 +254,7 @@ class ComponentUUID extends TextFieldComponent {
   }
 
   // Set the input field to a provided string, and if it is a valid UUID string, do the appropriate action based on the current page URL
-  //   - if on the 'Search for Components by UUID or Type and Number' page, redirect to the component information page
+  //   - if on the 'Search for Components by Identifier' page, redirect to the component information page
   //   - if on the 'Search for Workflows by ID or UUID' page, retrieve the relevant workflow information and redirect to the workflow information page
   //     (note that the 'ajax' query in this scenario uses the 'postSuccess' and 'postFail' functions already defined on the 'Search for Workflows by ID or UUID' page)
   //   - if on any 'Perform Action on Unspecified Component' page, redirect to the page for performing the action on the specified component
@@ -268,7 +268,7 @@ class ComponentUUID extends TextFieldComponent {
 
       const currentURL = window.location.pathname;
 
-      if (currentURL === '/search/componentsByUUIDOrTypeAndNumber') {
+      if (currentURL === '/search/componentsByIdentifier') {
         window.location.href = `/component/${value}`;
       } else if (currentURL === '/search/workflowsByIDOrUUID') {
         $.ajax({
@@ -280,7 +280,7 @@ class ComponentUUID extends TextFieldComponent {
         }).fail(postFail);
       } else if ((currentURL.substring(0, 8) === '/action/') && (currentURL.substring(currentURL.length - 7) === '/unspec')) {
         const baseURL = currentURL.substring(0, currentURL.length - 7);
-        window.location.href = `${baseURL}/${value}`;
+        window.location.href = `${baseURL}/spec/${value}`;
       } else {
         let info_target = $(this.refs.compUuidInfo[index]);
         info_target.prop('href', `/component/${value}`).text('link');

--- a/app/static/pages/component_edit.js
+++ b/app/static/pages/component_edit.js
@@ -93,6 +93,11 @@ async function onPageLoad() {
         sub_submission.data.typeRecordNumber = numberOfExistingSubComponents + s + 1;
         subComponent_typeRecordNumbers.push(numberOfExistingSubComponents + s + 1);
 
+        // Add any other information to the sub-component's 'data' field that might be specific to certain component types
+        if (['CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes(submission.data.subComponent_formId)) {
+          sub_submission.data.boardIsConformant = 'yes';
+        }
+
         // Since there is nothing more to be added to the sub-component submission object, add it to the array of sub-component submission objects
         subComponent_objects.push(sub_submission);
       }

--- a/app/static/pages/search_componentsByTypeAndLocation.js
+++ b/app/static/pages/search_componentsByTypeAndLocation.js
@@ -3,6 +3,8 @@ let componentType = null;
 let componentLocation = null;
 let acceptanceStatus = 'any';
 let toothStripStatus = 'any';
+let conformanceStatus = 'any';
+let qaChecksStatus = 'any';
 
 // Run a specific function when the page is loaded
 window.addEventListener('load', renderSearchForms);
@@ -27,6 +29,14 @@ async function renderSearchForms() {
     toothStripStatus = $('#toothStripStatusSelection').val();
   });
 
+  $('#conformanceStatusSelection').on('change', async function () {
+    conformanceStatus = $('#conformanceStatusSelection').val();
+  });
+
+  $('#qaChecksStatusSelection').on('change', async function () {
+    qaChecksStatus = $('#qaChecksStatusSelection').val();
+  });
+
   // When the confirmation button is pressed, perform the search using the appropriate jQuery 'ajax' call and the current values of the search parameters
   // Additionally, disable the button while the current search is being performed
   $('#confirmButton').on('click', function () {
@@ -36,7 +46,7 @@ async function renderSearchForms() {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/componentsByTypeAndLocation/${componentType}/${componentLocation}/${acceptanceStatus}/${toothStripStatus}`,
+        url: `/json/search/componentsByTypeAndLocation/${componentType}/${componentLocation}/${acceptanceStatus}/${toothStripStatus}/${conformanceStatus}/${qaChecksStatus}`,
         dataType: 'json',
         success: postSuccess,
       }).fail(postFail);
@@ -161,6 +171,34 @@ function postSuccess(result) {
         }
 
         $('#results').append('<br>');
+      }
+    } else if (['CableHarness', 'CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes($('#typeSelection option:selected').val())) {
+      const resultsStart = `
+        <tr>
+          <td colspan = "3">Found ${result.length} components with matching criteria</td>
+        </tr>`;
+
+      $('#results').append(resultsStart);
+      $('#results').append('<br>');
+
+      const tableStart = `
+        <tr>
+          <th scope = 'col' width = '25%'>Type Record Number</th>
+          <th scope = 'col' width = '25%'>Date at Location</th>
+          <th scope = 'col' width = '50%'>QA Checks Passed</th>
+        </tr>`;
+
+      $('#results').append(tableStart);
+
+      for (const component of result) {
+        const componentText = `
+        <tr>
+          <td><a href = '/component/${component.componentUuid}' target = '_blank'</a>${component.typeRecordNumber}</td>
+          <td>${component.receptionDate}</td>
+          <td>${component.qaChecksPassed}</td>
+        </tr>`;
+
+        $('#results').append(componentText);
       }
     } else {
       const tableStart = `


### PR DESCRIPTION
Adding new freeform section to APA Assembly workflow
- the 'Cable Conduit Insertion' and 'Installation into ASF' actions can now be done in either order, since the tasks within can (and apparently do) overlap
- had to rewrite the entire .pug file to accommodate multiple freeform sections in a single workflow ... the old code was already too complicated to handle any further changes
- each workflow type now has its own section of code ... some extra code duplication now, but far easier to maintain and change in the future

Changes relating to performing bulk QA actions via M2M
- the M2M script (NOT KEPT IN THIS REPOSITORY) will now first check if each board (CE Adapter, CR, G-Bias or SHV) is conformant, and only perform the QA action if so
- changed the library function to pass the component's 'data' object (containing the 'boardIsConformant' field in the case of these component types) back to the script
- fixed a bug where the 'boardIsConformant' field was not being saved if these components were created via a batch

Expanding search for components by type and location
- added new search filters for board conformance (only used for populated boards) and QA check status (only used for populated boards and cable harnesses)
- changed API route and library function accordingly, and updated the index of routes
- added bespoke results layout for populated boards and cable harnesses, so that the QA check status can be displayed only for these component types
- updated search descriptions page

Bug fix for incorrect redirection when performing action on an unspecified component
- forgot to change the URL to the new route in the Formio ComponentUUID component (made the change in the .pug file previously)