### PR TITLE
Requested Miscellaneous Changes

### DIFF
--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -374,12 +374,16 @@ async function componentsByTypeAndNumber(typeFormId, typeRecordNumber) {
     $group: {
       _id: { componentUuid: '$componentUuid' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$data.componentName' },
       typeRecordNumber: { '$first': '$data.typeRecordNumber' },
       formName: { '$first': '$formName' },
       shortUuid: { '$first': '$shortUuid' },
       data: { '$first': '$data' },
     },
   });
+
+  // Sort the records into alphabetical order by the component name
+  aggregation_stages.push({ $sort: { componentName: 1 } });
 
   // Query the 'components' records collection using the aggregation stages defined above
   let results = await db.collection('components')

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -183,6 +183,13 @@ block content
           | &nbsp; Print all sub-component QR codes
     else if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
+        if component.formId === 'CEAdapterBoardShipment'
+          dt Origin Location 
+          dd #{dictionary_locations[component.data.originOfShipment]}
+
+          dt Destination Location
+          dd #{dictionary_locations[component.data.destinationOfShipment]}
+
         dt Boards in Shipment / Kit
         dd
           table.table

--- a/app/pug/component_bulkQRCodeViewer.pug
+++ b/app/pug/component_bulkQRCodeViewer.pug
@@ -23,6 +23,6 @@ block allbody
     .container.fluid 
       .qr-grid
         each info in shortUUIDs
-          +qr-panel-topText(`${base_url}/c/${info[1]}`, `${info[2]} #${info[0]}`)
+          +qr-panel-topText(`${base_url}/c/${info[1]}`, `${info[0]}`)
 
   .vert-space-x2

--- a/app/pug/search.pug
+++ b/app/pug/search.pug
@@ -42,7 +42,7 @@ block content
 
       p If the specified information corresponds to a component record in the database, the user will be automatically redirected to the page for viewing the component information.  If there is no corresponding record, an error will be displayed.
         br
-        |  It should not be possible for multiple components of the same type to have the same type record number (since the numbers are assigned in sequence at component creation) or for multiple components to have the same DUNE PID.  However, in the unlikely case of this situation occurring, a message will also be displayed indicating so.
+        |  There are certain component types which allow multiple components to share the same type record number - if this is the case, all matching components will be listed (and linked to) below the input boxes.  For all other component types, it should not be possible for multiple components of the same type to have the same type record number ... and for all component types, it should not possible for multiple components to have the same DUNE PID.  In the unlikely case of this situation occurring, a message will also be displayed indicating so.
 
       hr
 

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -841,11 +841,12 @@ router.get('/components/bulkQRCodes/:typeFormId/:firstNumber/:lastNumber', permi
     let shortUUIDs = [];
 
     // For each value of the type record number in the specified range (including both the first and last ones) ...
+    // ... and each returned component with that type record number (since certain component types can have multiple components sharing the same type record number) ...
     // ... retrieve a reduced instance of the component record corresponding to the specified type form ID and type record number value, and add the information in the correct order to the  list
     for (let typeRecordNumber = parseInt(req.params.firstNumber, 10); typeRecordNumber <= parseInt(req.params.lastNumber, 10); typeRecordNumber++) {
       const componentsList = await Search_OtherComponents.componentsByTypeAndNumber(req.params.typeFormId, typeRecordNumber);
 
-      if (componentsList.length > 0) shortUUIDs.push([componentsList[0].typeRecordNumber, componentsList[0].shortUuid, componentsList[0].formName]);
+      for (const componentRecord of componentsList) { shortUUIDs.push([componentRecord.componentName, componentRecord.shortUuid]); }
     }
 
     // Render the interface page

--- a/app/static/pages/search_componentsByIdentifier.js
+++ b/app/static/pages/search_componentsByIdentifier.js
@@ -87,19 +87,33 @@ function postSuccess(result) {
   $('#messages').empty();
 
   // If there are no search results, display a message to indicate this, and then re-enable both confirmation buttons for the next search
-  // Similarly, if there is more than one search result, also display a message and re-enable both buttons
+  // Similarly, if there is more than one search result and the component type is NOT 'Cable Harness', also display a message and re-enable both buttons
+  // If there is more than one search result and the component type is 'Cable Harness', display some information about all results so that the user can choose which one to explore further
   // Otherwise (i.e. there is exactly one component in the search results), redirect the user to the page for viewing the component record
   if (result.length === 0) {
     $('#messages').append('<b>The specified search parameters do not match an existing component.</b>');
     $('#confirmButton_dunePID').prop('disabled', false);
     $('#confirmButton_typeAndNumber').prop('disabled', false);
   } else if (result.length > 1) {
-    const output = `
-      <b>The specified search parameters match <u>multiple</u> components.</b>
-      <br>This should not happen, since each component should have a unique DUNE PID, and each component of a single type should have a unique type record number.
-      <br>Please bring this to the attention of one of the database development team, indicating the search parameters that you specified above.`;
+    if (componentType === 'CableHarness') {
+      const output = `
+        <b>The specified search parameters match <u>multiple</u> components:</b><br><br>`;
 
-    $('#messages').append(output);
+      $('#messages').append(output);
+
+      for (const component of result) {
+        const componentText = `<a href = '/component/${component.componentUuid}' target = '_blank'</a>${component.componentName}<br>`;
+        $('#messages').append(componentText);
+      }
+    } else {
+      const output = `
+        <b>The specified search parameters match <u>multiple</u> components.</b>
+        <br>This should not happen, since each component should have a unique DUNE PID, and each component of the selected type should have a unique type record number.
+        <br>Please bring this to the attention of one of the database development team, indicating the search parameters that you specified above.`;
+
+      $('#messages').append(output);
+    }
+
     $('#confirmButton_dunePID').prop('disabled', false);
     $('#confirmButton_typeAndNumber').prop('disabled', false);
   } else {


### PR DESCRIPTION
Displaying CE Adapter Board Shipment locations
- for some reason, the origin and destination locations of CE Adapter Board Shipments were not being displayed on the component info pages
- this is the only shipment-type component where they weren't ... every other one had them displayed

Changes relating to non-unique Cable Harness typeRecordNumbers
- the 'display bulk QR codes' page will now account for the situation where each typeRecordNumber can correspond to multiple components
- the 'Search for Components by Type and Type Record Number' will show a list of matching component records when searching for cable harnesses with non-unique typeRecordNumbers ... for any other component type that matches multiple components, an error message will still be shown as before