### PR TITLE
Miscellaneous Follow-Up and Requested Changes

### DIFF
--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -639,12 +639,21 @@ async function componentsByTypeAndLocation(typeFormId, location, acceptanceStatu
       }
 
       if ((qaChecksStatus === 'any') || ((qaChecksStatus === 'passed') && (qaChecksPassed == true)) || (qaChecksStatus === 'failed') && (qaChecksPassed == false)) {
-        cleanedResults.push({
-          'componentUuid': result.componentUuid,
-          'typeRecordNumber': component.data.typeRecordNumber,
-          'receptionDate': (component.reception != null) ? component.reception.date : 'unknown',
-          'qaChecksPassed': (qaChecksPassed == true) ? 'Yes' : 'No',
-        });
+        if (['CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes(typeFormId)) {
+          cleanedResults.push({
+            'componentUuid': result.componentUuid,
+            'typeRecordNumber': component.data.typeRecordNumber,
+            'receptionDate': (component.reception != null) ? component.reception.date : 'unknown',
+            'qaChecksPassed': (qaChecksPassed == true) ? 'Yes' : 'No',
+          });
+        } else {
+          cleanedResults.push({
+            'componentUuid': result.componentUuid,
+            'typeRecordNumber': `${component.data.typeRecordNumber}${(component.data.cableHarnessSide).toUpperCase()}`,
+            'receptionDate': (component.reception != null) ? component.reception.date : 'unknown',
+            'qaChecksPassed': (qaChecksPassed == true) ? 'Yes' : 'No',
+          });
+        }
       }
     }
   } else {

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -201,6 +201,13 @@ module.exports = {
     joeMunski: 'Joe Munski',
   },
 
+  // Personnel from the CERN Compliance Office
+  dictionary_cernComplianceOffice: {
+    alexandreAcerraGil: 'Alexandre Acerra Gil',
+    olgaBeltramello: 'Olga Beltramello',
+    denisDiyakov: 'Denis Diyakov',
+  },
+
   // Lead personnel at the UK and US APA factories (also doubling for personnel who are authorised to sign-off on 'Assembled APA Quality Assurance Check' actions)
   dictionary_apaFactoryLeads: {
     edBlucher: 'Ed Blucher',

--- a/app/pug/search_actionsByIDOrReferencedUUID.pug
+++ b/app/pug/search_actionsByIDOrReferencedUUID.pug
@@ -92,6 +92,8 @@ block content
         h4 Search Results
 
         .vert-space-x1
-          table#results1
+          .row
+            .col-md-4
+              table.results-table#results1
 
     .vert-space-x2

--- a/app/pug/search_apasByProductionDetails.pug
+++ b/app/pug/search_apasByProductionDetails.pug
@@ -106,26 +106,26 @@ block content
             #summary1 
 
             .row 
-              .col-md-5
-                table#results11 
+              .col-md-4
+                table.results-table#results11 
 
               .col-md-1
-              .col-md-5
-                table#results12
+              .col-md-4
+                table.results-table#results12
 
-              .col-md-1
+              .col-md-3
 
           .col-md-6.vert-space-x1
             #summary2 
 
             .row 
-              .col-md-5
-                table#results21 
+              .col-md-4
+                table.results-table#results21 
 
               .col-md-1
-              .col-md-5
-                table#results22
+              .col-md-4
+                table.results-table#results22
 
-              .col-md-1
+              .col-md-3
 
     .vert-space-x2

--- a/app/pug/search_boardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_boardShipmentsByReceptionDetails.pug
@@ -49,7 +49,7 @@ block content
 
           .vert-space-x1 
             select.form-control#shipmentStatusSelection
-              option(value = '') (please select)
+              option(value = '')
               option(value = 'unreceived') Unreceived Shipments
               option(value = 'received') Received Shipments
 
@@ -63,7 +63,7 @@ block content
 
           .vert-space-x1 
             select.form-control#originLocationSelection
-              option(value = '') (any)
+              option(value = '') (any origin location)
               option(value = 'cambridge') #{dictionary_locations['cambridge']} 
               option(value = 'daresbury') #{dictionary_locations['daresbury']} 
               option(value = 'lancaster') #{dictionary_locations['lancaster']} 
@@ -83,7 +83,7 @@ block content
 
           .vert-space-x1 
             select.form-control#destinationLocationSelection
-              option(value = '') (any)
+              option(value = '') (any destination location)
               option(value = 'cambridge') #{dictionary_locations['cambridge']} 
               option(value = 'chicago') #{dictionary_locations['chicago']} 
               option(value = 'daresbury') #{dictionary_locations['daresbury']} 
@@ -129,21 +129,25 @@ block content
 
           .vert-space-x1
             p 
-            | Indicate whether to query the presence of reception comments.
+            | Check for any reception comments.<br>
+            | &nbsp 
 
           .vert-space-x1 
             select.form-control#receptionCommentSelection
-              option(value = '') All shipments 
+              option(value = '') (all shipments)
               option(value = 'noComment') Only shipments received with no comments 
               option(value = 'comment') Only shipments received with comments 
 
       .vert-space-x1
         hr
-        
+
       .vert-space-x1
         h4 Search Results
 
+        .vert-space-x1 
+          #summary1 
+
         .vert-space-x1
-          table#results1
+          table.results-table#results1
 
     .vert-space-x2

--- a/app/pug/search_componentsByTypeAndLocation.pug
+++ b/app/pug/search_componentsByTypeAndLocation.pug
@@ -75,7 +75,7 @@ block content
 
           .vert-space-x1 
             select.form-control#acceptanceStatusSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any board acceptance status)
               option(value = 'accepted') Board Accepted at Factory 
               option(value = 'rejected') Board Rejected at Factory
 
@@ -89,7 +89,7 @@ block content
 
           .vert-space-x1 
             select.form-control#toothStripStatusSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any tooth strip attachment status)
               option(value = 'attached') Tooth Strip Attached
               option(value = 'notAttached') Tooth Strip Not Yet Attached
 
@@ -105,15 +105,22 @@ block content
           .vert-space-x1 
             select.form-control#locationSelection
               option(value = '')
+              option(value = 'bnl') #{dictionary_locations['bnl']} 
               option(value = 'cambridge') #{dictionary_locations['cambridge']} 
               option(value = 'cern') #{dictionary_locations['cern']} 
               option(value = 'chicago') #{dictionary_locations['chicago']} 
+              option(value = 'cincinnati') #{dictionary_locations['cincinnati']} 
               option(value = 'daresbury') #{dictionary_locations['daresbury']} 
+              option(value = 'fermilab') #{dictionary_locations['fermilab']} 
+              option(value = 'harvard') #{dictionary_locations['harvard']} 
               option(value = 'in_transit') #{dictionary_locations['in_transit']} 
               option(value = 'installed_on_APA') #{dictionary_locations['installed_on_APA']} 
+              option(value = 'isu') #{dictionary_locations['isu']} 
               option(value = 'lancaster') #{dictionary_locations['lancaster']} 
+              option(value = 'lsu') #{dictionary_locations['lsu']} 
               option(value = 'manchester') #{dictionary_locations['manchester']} 
               option(value = 'merlin') #{dictionary_locations['merlin']} 
+              option(value = 'rokeby') #{dictionary_locations['rokeby']} 
               option(value = 'sheffield') #{dictionary_locations['sheffield']} 
               option(value = 'surf') #{dictionary_locations['surf']} 
               option(value = 'sussex') #{dictionary_locations['sussex']} 
@@ -135,7 +142,7 @@ block content
 
           .vert-space-x1 
             select.form-control#conformanceStatusSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any board conformance status)
               option(value = 'yes') Board is Conformant 
               option(value = 'no') Board is Not Conformant
 
@@ -149,7 +156,7 @@ block content
 
           .vert-space-x1 
             select.form-control#qaChecksStatusSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any QA checks status)
               option(value = 'passed') QA Checks Passed
               option(value = 'failed') QA Checks Failed
 
@@ -170,17 +177,18 @@ block content
             .col-md-4 
               table#summary3 
 
-          .vert-space-x2.row
+        .vert-space-x1
+          .row
             .col-md-3 
-              table#results1 
+              table.results-table#results1 
 
             .col-md-1 
             .col-md-3 
-              table#results2 
+              table.results-table#results2 
 
             .col-md-1 
             .col-md-3 
-              table#results3 
+              table.results-table#results3 
 
             .col-md-1
 

--- a/app/pug/search_componentsByTypeAndPartNumber.pug
+++ b/app/pug/search_componentsByTypeAndPartNumber.pug
@@ -105,7 +105,7 @@ block content
 
           .vert-space-x1 
             select.form-control#acceptanceStatusSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any board acceptance status)
               option(value = 'accepted') Board Accepted at Factory 
               option(value = 'rejected') Board Rejected at Factory
 
@@ -141,7 +141,7 @@ block content
 
           .vert-space-x1 
             select.form-control#toothStripStatusSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any tooth strip attachment status)
               option(value = 'attached') Tooth Strip Attached
               option(value = 'notAttached') Tooth Strip Not Yet Attached
 
@@ -162,17 +162,18 @@ block content
             .col-md-4 
               table#summary3 
 
-          .vert-space-x2.row
+        .vert-space-x1
+          .row
             .col-md-3 
-              table#results1 
+              table.results-table#results1 
 
             .col-md-1 
             .col-md-3 
-              table#results2 
+              table.results-table#results2 
 
             .col-md-1 
             .col-md-3 
-              table#results3 
+              table.results-table#results3 
 
             .col-md-1
 

--- a/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
+++ b/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
@@ -65,7 +65,7 @@ block content
 
           .vert-space-x1 
             select.form-control#issueSelection
-              option(value = 'any') (any)         
+              option(value = 'any') (any issue)         
               option(value = 'packagingDamaged') Packaging damaged 
               option(value = 'scratches') Scratches 
               option(value = 'exposedCopper') Exposed copper 
@@ -111,8 +111,7 @@ block content
             .col-md-4 
               table#summary3 
 
-          .vert-space-x2.row
-            .col-md-12 
-              table#results1  
+        .vert-space-x1
+            table.results-table#results1
 
     .vert-space-x2

--- a/app/pug/search_nonConformanceByComponentTypeOrUUID.pug
+++ b/app/pug/search_nonConformanceByComponentTypeOrUUID.pug
@@ -66,7 +66,7 @@ block content
 
           .vert-space-x1 
             select.form-control#dispositionSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any disposition)
               option(value = 'useAsIs') Use As Is (NC concession granted)
               option(value = 'repair') Repair (no modification to base design or functionality)
               option(value = 'rework') Rework (modification to base design but no impact to function)
@@ -76,7 +76,7 @@ block content
 
           .vert-space-x1 
             select.form-control#statusSelection
-              option(value = 'any') (any)
+              option(value = 'any') (any status)
               option(value = 'open') Open 
               option(value = 'closed') Closed 
 
@@ -100,7 +100,10 @@ block content
       .vert-space-x1 
         h4 Search Results
 
+        .vert-space-x1 
+          #summary1 
+
         .vert-space-x1
-          table#results1
+          table.results-table#results1
 
     .vert-space-x2

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -92,6 +92,7 @@ module.exports = routes;
   /json/uwPCBApproval.json
   /json/uwInstallationTechnicians.json
   /json/uwInstallationApproval.json
+  /json/cernComplianceOffice.json
   /json/apaFactoryLeads.json
   /administratorUtility
   /json/administratorUtility/:inputString

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -193,6 +193,17 @@ router.get(['/json/uwInstallationApproval.json', '/api/uwInstallationApproval.js
 });
 
 
+/// List personnel from the CERN Compliance Office
+router.get(['/json/cernComplianceOffice.json', '/api/cernComplianceOffice.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_cernComplianceOffice));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
 /// List lead personnel at the UK and US APA factories
 router.get(['/json/apaFactoryLeads.json', '/api/apaFactoryLeads.json'], async function (req, res, next) {
   try {

--- a/app/static/css/common.css
+++ b/app/static/css/common.css
@@ -34,6 +34,21 @@ html {
   margin-left: 2em
 }
 
+table.results-table {
+  table-layout: fixed;
+  width: 100%;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+table.results-table th, table.results-table td {
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid lightgrey;
+}
+
 .foldable-heading {
   font-weight: bold;
   cursor: pointer;

--- a/app/static/pages/search_actionsByIDOrReferencedUUID.js
+++ b/app/static/pages/search_actionsByIDOrReferencedUUID.js
@@ -90,8 +90,8 @@ function postSuccess(result) {
   } else {
     const tableStart = `
         <tr>
-          <th scope = 'col' width = '50%'>Component</th>
-          <th scope = 'col' width = '50%'>Action</th>
+          <th style = 'width: 40%'>Component</th>
+          <th style = 'width: 60%'>Action</th>
         </tr>`;
 
     $('#results1').append(tableStart);

--- a/app/static/pages/search_apasByProductionDetails.js
+++ b/app/static/pages/search_apasByProductionDetails.js
@@ -116,12 +116,6 @@ function postSuccess_locationAndAssemblyStep(result) {
   $('#results21').empty()
   $('#results22').empty()
 
-  let tableStart = `
-    <tr>
-      <th scope = 'col' width = '65%'>APA Name</th>
-      <th scope = 'col' width = '35%'>Workflow</th>
-    </tr>`;
-
   // Display the information about APAs that have had the specified assembly step completed
   let resultsStart = `
   <tr>
@@ -132,13 +126,20 @@ function postSuccess_locationAndAssemblyStep(result) {
   </tr>`;
 
   $('#summary1').append(resultsStart);
+
+  let tableStart = `
+    <tr>
+      <th style = 'width: 57%'>APA Name</th>
+      <th style = 'width: 43%'>Workflow</th>
+    </tr>`;
+
   $('#results11').append(tableStart);
 
   for (const apa of result[0].slice(0, result[0].length / 2)) {
     const apaText = `
       <tr>
         <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>${apa.componentName}</td>
-        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[link]</td>
+        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[Info Page]</td>
       </tr>`;
 
     $('#results11').append(apaText);
@@ -150,7 +151,7 @@ function postSuccess_locationAndAssemblyStep(result) {
     const apaText = `
       <tr>
         <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>${apa.componentName}</td>
-        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[link]</td>
+        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[Info Page]</td>
       </tr>`;
 
     $('#results12').append(apaText);
@@ -172,7 +173,7 @@ function postSuccess_locationAndAssemblyStep(result) {
     const apaText = `
       <tr>
         <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>${apa.componentName}</td>
-        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[link]</td>
+        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[Info Page]</td>
       </tr>`;
 
     $('#results21').append(apaText);
@@ -184,7 +185,7 @@ function postSuccess_locationAndAssemblyStep(result) {
     const apaText = `
       <tr>
         <td><a href = '/component/${apa.componentUuid}' target = '_blank'</a>${apa.componentName}</td>
-        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[link]</td>
+        <td><a href = '/workflow/${apa.workflowId}' target = '_blank'</a>[Info Page]</td>
       </tr>`;
 
     $('#results22').append(apaText);

--- a/app/static/pages/search_boardShipmentsByReceptionDetails.js
+++ b/app/static/pages/search_boardShipmentsByReceptionDetails.js
@@ -88,7 +88,8 @@ async function renderSearchForms() {
   // Additionally, disable the button while the current search is being performed
   $('#confirmButton').on('click', function () {
     $('#confirmButton').prop('disabled', true);
-    $('#results1').empty().append('<b>Working ...</b>');
+    $('#summary1').empty().append('<b>Working ...</b>');
+    $('#results1').empty();
 
     if (shipmentStatus !== '') {
       $.ajax({
@@ -105,31 +106,34 @@ async function renderSearchForms() {
 
 // Function to run for a successful search query
 function postSuccess(result) {
-  // Make sure that the page element where the results will be displayed is empty
+  // Make sure that the page elements where the results will be displayed are all empty
+  $('#summary1').empty();
   $('#results1').empty();
 
   // If there are no search results, display a message to indicate this
   // Otherwise, set up an initial message to display, and a table of the search results
   if (Object.keys(result).length === 0) {
-    $('#results1').append('<b>There are no geometry board shipments matching the specified parameters</b>');
+    $('#summary1').append('<b>There are no geometry board shipments matching the specified parameters</b>');
   } else {
     const resultsCount = `
       <tr>
-        <td colspan = "7"><b>Found ${result.length} matching geometry board shipments</b></td>
+        <td colspan = "7"><b>Found ${result.length} matching geometry board shipments</b>
+          <br>
+          <hr>
+        </td>
       </tr>`;
 
-    $('#results1').append(resultsCount);
-    $('#results1').append('<br>');
+    $('#summary1').append(resultsCount);
 
     const tableStart = `
       <tr>
-        <th scope = 'col' width = '11%'>Shipment</th>
-        <th scope = 'col' width = '14%'>Origin</th>
-        <th scope = 'col' width = '14%'>Destination</th>
-        <th scope = 'col' width = '12%'>Creation Date</th>
-        <th scope = 'col' width = '12%'>Reception Date</th>
-        <th scope = 'col' width = '25%'>Shipment Reception Comment</th>
-        <th scope = 'col' width = '11%'>Search Comment</th>
+        <th style = 'width: 8%'>Shipment</th>
+        <th style = 'width: 12%'>Origin</th>
+        <th style = 'width: 12%'>Destination</th>
+        <th style = 'width: 12%'>Creation Date</th>
+        <th style = 'width: 12%'>Reception Date</th>
+        <th style = 'width: 25%'>Shipment Reception Comment</th>
+        <th style = 'width: 19%'>Search Comment</th>
       </tr>`;
 
     $('#results1').append(tableStart);
@@ -137,7 +141,7 @@ function postSuccess(result) {
     for (const shipment of result) {
       let actionIdLinkLine = `<td>${shipment.receptionDate}</td>`;
 
-      if (shipment.receptionDate !== '(none)') actionIdLinkLine = `<td><a href = '/action/${shipment.receptionActionId}' target = '_blank'</a>${shipment.receptionDate}</td>`;
+      if (shipment.receptionDate !== '[n.a.]') actionIdLinkLine = `<td><a href = '/action/${shipment.receptionActionId}' target = '_blank'</a>${shipment.receptionDate}</td>`;
 
       const boardText = `
         <tr>

--- a/app/static/pages/search_componentsByTypeAndLocation.js
+++ b/app/static/pages/search_componentsByTypeAndLocation.js
@@ -121,9 +121,9 @@ function postSuccess(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' style = 'width: 23%'>UKID</th>
-          <th scope = 'col' style = 'width: 32%'>Date at Location</th>
-          <th scope = 'col' style = 'width: 45%'>Installed on APA</th>
+          <th style = 'width: 23%'>UKID</th>
+          <th style = 'width: 42%'>Date at Location</th>
+          <th style = 'width: 35%'>Installed on APA</th>
         </tr>`;
 
       for (const boardGroup of result.slice(0, (result.length / 3) + 1)) {
@@ -230,9 +230,9 @@ function postSuccess(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '23%'>Number</th>
-          <th scope = 'col' width = '32%'>Date at Location</th>
-          <th scope = 'col' width = '45%'>Installed on APA</th>
+          <th style = 'width: 23%'>Number</th>
+          <th style = 'width: 42%'>Date at Location</th>
+          <th style = 'width: 35%'>Installed on APA</th>
         </tr>`;
 
       for (const meshGroup of result.slice(0, (result.length / 3) + 1)) {
@@ -306,17 +306,19 @@ function postSuccess(result) {
     } else if (['CableHarness', 'CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes($('#typeSelection option:selected').val())) {
       const resultsStart = `
         <tr>
-          <td colspan = "3"><b>Type: ${$('#typeSelection option:selected').text()}</b> - ${result.length} components</td>
+          <td colspan = "3"><b>Type: ${$('#typeSelection option:selected').text()}</b> - ${result.length} components
+            <br>
+            <hr>
+          </td>
         </tr>`;
 
       $('#summary1').append(resultsStart);
-      $('#summary1').append('<br>');
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '23%'>Number</th>
-          <th scope = 'col' width = '32%'>Date at Location</th>
-          <th scope = 'col' width = '45%'>QA Checks Passed</th>
+          <th style = 'width: 23%'>Number</th>
+          <th style = 'width: 42%'>Date at Location</th>
+          <th style = 'width: 35%'>QA Checks Passed</th>
         </tr>`;
 
       $('#results1').append(tableStart);
@@ -360,17 +362,19 @@ function postSuccess(result) {
     } else {
       const resultsStart = `
         <tr>
-          <td colspan = "3"><b>Type: ${$('#typeSelection option:selected').text()}</b> - ${result.length} components</td>
+          <td colspan = "3"><b>Type: ${$('#typeSelection option:selected').text()}</b> - ${result.length} components
+            <br>
+            <hr>
+          </td>
         </tr>`;
 
       $('#summary1').append(resultsStart);
-      $('#summary1').append('<br>');
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '23%'>Number</th>
-          <th scope = 'col' width = '32%'>Date at Location</th>
-          <th scope = 'col' width = '45%'></th>
+          <th style = 'width: 23%'>Number</th>
+          <th style = 'width: 42%'>Date at Location</th>
+          <th style = 'width: 35%'></th>
         </tr>`;
 
       $('#results1').append(tableStart);

--- a/app/static/pages/search_componentsByTypeAndPartNumber.js
+++ b/app/static/pages/search_componentsByTypeAndPartNumber.js
@@ -120,9 +120,9 @@ function postSuccess(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' style = 'width: 23%'>UKID</th>
-          <th scope = 'col' style = 'width: 32%'>Date at Location</th>
-          <th scope = 'col' style = 'width: 45%'>Installed on APA</th>
+          <th style = 'width: 23%'>UKID</th>
+          <th style = 'width: 42%'>Date at Location</th>
+          <th style = 'width: 35%'>Installed on APA</th>
         </tr>`;
 
       for (const boardGroup of result.slice(0, (result.length / 3) + 1)) {
@@ -229,9 +229,9 @@ function postSuccess(result) {
 
       const tableStart = `
         <tr>
-          <th scope = 'col' width = '23%'>Number</th>
-          <th scope = 'col' width = '32%'>Date at Location</th>
-          <th scope = 'col' width = '45%'>Installed on APA</th>
+          <th style = 'width: 23%'>UKID</th>
+          <th style = 'width: 42%'>Date at Location</th>
+          <th style = 'width: 35%'>Installed on APA</th>
         </tr>`;
 
       for (const meshGroup of result.slice(0, (result.length / 3) + 1)) {

--- a/app/static/pages/search_geoBoardsByVisInspectOrOrderNumber.js
+++ b/app/static/pages/search_geoBoardsByVisInspectOrOrderNumber.js
@@ -167,22 +167,17 @@ function postSuccess_disposition(result) {
 
     $('#summary3').append('<br>');
 
-    const tableStart = `
-      <tr>
-        <th scope = 'col' width = '7%'>UKID</th>
-        <th scope = 'col' width = '8%'>Order No.</th>
-        <th scope = 'col' width = '15%'>Visual Inspection Action</th>
-        <th scope = 'col' width = '35%'>Issue(s) Identified</th>
-        <th scope = 'col' width = '34%'>Repairs Description (if applicable)</th>
-      </tr>`;
-
     for (const boardGroup of result) {
-      const groupTitle = `
+      const tableStart = `
         <tr>
-          <td colspan = "5"><b>P/N: ${boardGroup.partNumber} (${boardGroup.partString})</b></td>
+          <th style = 'width: 7%'>Order No.</th>
+          <th style = 'width: 7%'>P/N</th>
+          <th style = 'width: 7%'>UKID</th>
+          <th style = 'width: 17%'>Visual Inspection Action</th>
+          <th style = 'width: 32%'>Issue(s) Identified</th>
+          <th style = 'width: 30%'>Repairs Description (if applicable)</th>
         </tr>`;
 
-      $('#results1').append(groupTitle);
       $('#results1').append(tableStart);
 
       for (const i in boardGroup.componentUuids) {
@@ -190,8 +185,9 @@ function postSuccess_disposition(result) {
 
         const boardText = `
           <tr>
-            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
             <td><a href = '/component/${boardGroup.batchUuids[i]}' target = '_blank'</a>${boardGroup.orderNumbers[i]}</td>
+            <td>${boardGroup.partNumber}</td>
+            <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
             <td><a href = '/action/${boardGroup.actionIds[i]}' target = '_blank'</a>${boardGroup.actionIds[i]}</td>
             <td>${inspectionData.issues}</td>
             <td>${inspectionData.repairsDescription}</td>
@@ -231,7 +227,7 @@ function postSuccess_orderNumber(result) {
   // If there are no search results, display a message to indicate this
   // // Otherwise, set up an initial message to display, and a table of the search results
   if (Object.keys(result).length === 0) {
-    $('#results').append('<b>There are no geometry boards with the specified order number and at least one Visual Inspection</b>');
+    $('#summary1').append('<b>There are no geometry boards with the specified order number and at least one Visual Inspection</b>');
   } else {
     for (const boardGroup of result.slice(0, (result.length / 3) + 1)) {
       const groupCount = `
@@ -266,21 +262,17 @@ function postSuccess_orderNumber(result) {
 
     $('#summary3').append('<br>');
 
-    const tableStart = `
-      <tr>
-        <th scope = 'col' width = '15%'>UKID</th>
-        <th scope = 'col' width = '15%'>Visual Inspection Action</th>
-        <th scope = 'col' width = '35%'>Issue(s) Identified</th>
-        <th scope = 'col' width = '34%'>Repairs Description (if applicable)</th>
-      </tr>`;
 
     for (const boardGroup of result) {
-      const groupTitle = `
+      const tableStart = `
         <tr>
-          <td colspan = "5"><b>Disposition: ${dispositionsDictionary[boardGroup.disposition]}</b></td>
+          <th style = 'width: 14%'>Disposition</th>
+          <th style = 'width: 7%'>UKID</th>
+          <th style = 'width: 17%'>Visual Inspection Action</th>
+          <th style = 'width: 32%'>Issue(s) Identified</th>
+          <th style = 'width: 30%'>Repairs Description (if applicable)</th>
         </tr>`;
 
-      $('#results1').append(groupTitle);
       $('#results1').append(tableStart);
 
       for (const i in boardGroup.actionIds) {
@@ -288,6 +280,7 @@ function postSuccess_orderNumber(result) {
 
         const boardText = `
           <tr>
+            <td>${dispositionsDictionary[boardGroup.disposition]}</td>
             <td><a href = '/component/${boardGroup.componentUuids[i]}' target = '_blank'</a>${boardGroup.ukids[i]}</td>
             <td><a href = '/action/${boardGroup.actionIds[i]}' target = '_blank'</a>${boardGroup.actionIds[i]}</td>
             <td>${inspectionData.issues}</td>

--- a/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
+++ b/app/static/pages/search_nonConformanceByComponentTypeOrUUID.js
@@ -69,7 +69,8 @@ async function renderSearchForms() {
   $('#confirmButton_uuid').on('click', function () {
     $('#confirmButton_type').prop('disabled', true);
     $('#confirmButton_uuid').prop('disabled', true);
-    $('#results1').empty().append('<b>Working ...</b>');
+    $('#summary1').empty().append('<b>Working ...</b>');
+    $('#results1').empty();
 
     if (componentUuid) {
       $.ajax({
@@ -94,9 +95,9 @@ function postSuccess(result) {
   };
 
   const dispositionsDictionary = {
-    useAsIs: 'Use As Is (NC concession granted)',
-    repair: 'Repair (no modification to base design or functionality)',
-    rework: 'Rework (modification to base design but no impact to function)',
+    useAsIs: 'Use As Is',
+    repair: 'Repair',
+    rework: 'Rework',
     returnToSupplier: 'Return to Supplier',
     rejectRePurpose: 'Reject/Re-purpose',
     scrap: 'Scrap',
@@ -107,21 +108,22 @@ function postSuccess(result) {
     closed: 'Closed',
   };
 
-  // Make sure that the page element where the results will be displayed is empty
+  // Make sure that the page elements where the results will be displayed are all empty
+  $('#summary1').empty();
   $('#results1').empty();
 
   // If there are no search results, display a message to indicate this
   // Otherwise, set up an initial message to display, and a table of the search results
   if (Object.keys(result).length === 0) {
-    $('#results1').append('<b>Found no matching non-conformance actions</b>');
+    $('#summary1').append('<b>There are no non-conformance actions matching the specified parameters</b>');
   } else {
     const tableStart = `
       <tr>
-        <th scope = 'col' width = '17%'>Component</th>
-        <th scope = 'col' width = '23%'>NC Type</th>
-        <th scope = 'col' width = '25%'>NC Title</th>
-        <th scope = 'col' width = '33%'>Disposition</th>
-        <th scope = 'col' width = '5%'>Status</th>
+        <th style = 'width: 20%'>Component</th>
+        <th style = 'width: 25%'>NC Type</th>
+        <th style = 'width: 35%'>NC Title</th>
+        <th style = 'width: 12%'>Disposition</th>
+        <th style = 'width: 8%'>Status</th>
       </tr>`;
 
     $('#results1').append(tableStart);

--- a/m2m/README.md
+++ b/m2m/README.md
@@ -49,7 +49,7 @@ However, users will still need to call the various backend functions in their ow
     * `connection, headers` : objects returned by the `ConnectToAPI()` function
     * `version` (integer) : [OPTIONAL] the desired version of the record to retrieve ... if not specified or set to '0', the most recent version will be retrieved
 
-* `GetComponent_byTypeRecordNumber(componentTypeFormID, typeRecordNumber, connection, headers)` : retrieve the most recent version of an existing component record via its type form ID and type record number, returning the record as a Python dictionary
+* `GetComponents_byTypeRecordNumber(componentTypeFormID, typeRecordNumber, connection, headers)` : retrieve a list of the most recent versions of all existing component records with the specified type form ID and type record number, returning a Python list of the records
     * `componentTypeFormID` (string) : the type form ID of the component to be retrieved
     * `typeRecordNumber` (integer) : the type record number of the component to be retrieved
     * `connection, headers` : objects returned by the `ConnectToAPI()` function

--- a/m2m/common.py
+++ b/m2m/common.py
@@ -237,28 +237,28 @@ def GetComponent(componentUUID, connection, headers, version = 0):
         print(f" GetComponent() [GET /api/component/componentUuid] - SOCKET TIMEOUT: {s} \n")
 
 
-###########################################################################
-## Get an existing component via its type form ID and type record number ##
-###########################################################################
-def GetComponent_byTypeRecordNumber(componentTypeFormID, typeRecordNumber, connection, headers):
+#####################################################################################
+## Get a list of existing components via their type form ID and type record number ##
+#####################################################################################
+def GetComponents_byTypeRecordNumber(componentTypeFormID, typeRecordNumber, connection, headers):
     # Request a response from the API route that retrieves the most recent version of an existing component record via its type form ID and type record number
     # If the request is successful, continue with the function ... otherwise print any raised exceptions
     try:
-        connection.request('GET', f'/api/component/{componentTypeFormID}/{typeRecordNumber}', headers = headers)
+        connection.request('GET', f'/api/search/componentsByTypeAndNumber/{componentTypeFormID}/{typeRecordNumber}', headers = headers)
 
-        # The route returns the component record as a JSON document (which must be deserialised to get the record as a Python dictionary)
-        component = json.loads(connection.getresponse().read().decode('utf-8'))
+        # The route returns a list of component records as a JSON document (which must be deserialised to get the list as a Python dictionary)
+        components = json.loads(connection.getresponse().read().decode('utf-8'))
 
         # If the provided type form ID and type record number together don't correspond to an existing component record, print an error and exit the function immediately
-        if component == None:
-            sys.exit(f" GetComponent_byTypeRecordNumber() - ERROR: there is no component record with type form ID = {componentTypeFormID} and type record number = {typeRecordNumber} \n")
+        if len(components) == 0:
+            sys.exit(f" GetComponents_byTypeRecordNumber() - ERROR: there are no component records with type form ID = {componentTypeFormID} and type record number = {typeRecordNumber} \n")
 
-        # Return the component record
-        return component
+        # Return the list of component records
+        return components
     except http.client.HTTPException as e:
-        print(f" GetComponent_byTypeRecordNumber() [GET /api/component/typeFormId/typeRecordNumber] - HTTP EXCEPTION: {e} \n")
+        print(f" GetComponents_byTypeRecordNumber() [GET /api/search/componentsByTypeAndNumber/typeFormId/typeRecordNumber] - HTTP EXCEPTION: {e} \n")
     except socket.timeout as s:
-        print(f" GetComponent_byTypeRecordNumber() [GET /api/component/typeFormId/typeRecordNumber] - SOCKET TIMEOUT: {s} \n")
+        print(f" GetComponents_byTypeRecordNumber() [GET /api/search/componentsByTypeAndNumber/typeFormId/typeRecordNumber] - SOCKET TIMEOUT: {s} \n")
 
 
 ###################################################

--- a/m2m/template_getRecords.py
+++ b/m2m/template_getRecords.py
@@ -1,5 +1,5 @@
 # Local Python imports
-from common import ConnectToAPI, GetComponent, GetListOfComponents, GetAction, GetListOfActions, GetWorkflow, GetListOfWorkflows
+from common import ConnectToAPI, GetComponent, GetComponents_byTypeRecordNumber, GetListOfComponents, GetAction, GetListOfActions, GetWorkflow, GetListOfWorkflows
 
 
 # Main script function
@@ -13,7 +13,6 @@ if __name__ == '__main__':
     ########################################
     # User-defined script functionality goes here
 
-    # Retrieving a single existing component record requires only the UUID
     # Call the component retrieval function, which takes the UUID as its first argument
     # The second and third arguments must ALWAYS be 'connection' and 'headers' respectively
     # The optional fourth argument is the desired version of the component record ... if this is not specified or set to '0', the most recent version will be retrieved
@@ -24,7 +23,17 @@ if __name__ == '__main__':
     print(component)
     print()
 
-    # Retrieving a list of all components of a single type requires only the component type form ID (NOT THE TYPE FORM NAME!)
+    # Call the component list retrieval function, which takes the type form ID and type record number as its first and second arguments respectively
+    # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
+    # If successful, the function returns a list of component records (which can be empty, i.e. len() = 0, if there are no matching components)
+    componentTypeFormID = 'basic_component_2'
+    typeRecordNumber = 1
+
+    components = GetComponents_byTypeRecordNumber(componentTypeFormID, typeRecordNumber, connection, headers)
+    print(f" Found {len(components)} components with type form ID '{componentTypeFormID}' and type record number = {typeRecordNumber}")
+    print(components)
+    print()
+
     # Call the component listing function, which takes the type form ID as its first argument
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
     # If successful, the function returns a list of component UUIDs, with each UUID being an individual string
@@ -33,8 +42,8 @@ if __name__ == '__main__':
     componentUUIDs = GetListOfComponents(componentTypeFormID, connection, headers)
     print(f" Found {len(componentUUIDs)} components with type form ID '{componentTypeFormID}'")
     print(componentUUIDs)
+    print()
 
-    # Retrieving a single existing action record requires only the ID
     # Call the action retrieval function, which takes the ID as its first argument
     # The second and third arguments must ALWAYS be 'connection' and 'headers' respectively
     # The optional fourth argument is the desired version of the action record ... if this is not specified or set to '0', the most recent version will be retrieved
@@ -45,7 +54,6 @@ if __name__ == '__main__':
     print(action)
     print()
 
-    # Retrieving a list of all actions of a single type requires only the action type form ID (NOT THE TYPE FORM NAME!)
     # Call the action listing function, which takes the type form ID as its first argument
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
     # If successful, the function returns a list of action IDs, with each ID being an individual string
@@ -54,8 +62,8 @@ if __name__ == '__main__':
     actionIDs = GetListOfActions(actionTypeFormID, connection, headers)
     print(f" Found {len(actionIDs)} actions with type form ID: '{actionTypeFormID}'")
     print(actionIDs)
+    print()
 
-    # Retrieving a single existing workflow record requires only the ID
     # Call the workflow retrieval function, which takes the ID as its first argument
     # The second and third arguments must ALWAYS be 'connection' and 'headers' respectively
     # If successful, the function returns the latest version of the workflow record as a Python dictionary (if not, an error message is automatically displayed)
@@ -65,7 +73,6 @@ if __name__ == '__main__':
     print(workflow)
     print()
 
-    # Retrieving a list of all workflows of a single type requires only the workflow type form ID (NOT THE TYPE FORM NAME!)
     # Call the workflow listing function, which takes the type form ID as its first argument
     # The last two arguments must ALWAYS be 'connection' and 'headers' respectively
     # If successful, the function returns two lists - one of workflow IDs (with each ID being an individual string), and the other of workflow statuses
@@ -75,6 +82,7 @@ if __name__ == '__main__':
     print(f" Found {len(workflowIDs)} workflows with type form ID: '{workflowTypeFormID}'")
     print(workflowIDs)
     print(workflowStatuses)
+    print()
 
     ########################################
 


### PR DESCRIPTION
Adding new personnel list for the CERN Compliance Office

More fixes and tweaks to Search interface pages
- finally figured out how to keep table column widths fixed, regardless of the contents of individual cells
- adding new .css styles for 'results-table' (derivative of the standard Bootstrap 'table') and derived 'th' and 'td'
- any search results that show tables will now use the new 'results-table' styling ... fixed column widths, less padding
- made the default displayed texts for filter variables more consistent and indicative of what the filter is (i.e. 'any' --> 'any disposition')
- fixed some additional issues that I spotted ... split summaries from main results, fixed some incorrect links

Small fix to Search for Components by Type and Location ... when searching for cable harnesses, the side will now be displayed along with the type record number

Updates to M2M files
- updating the common function for retrieving components via type form ID and type record number to now return a list of components (since cable harnesses can have non-unique type record numbers)
- updating the same function to use the 'search for components via type record number' API route ... for some reason we have two routes that do the same thing, but I want to keep this one since it is also used for the interface search - will eventually remove the other routes once I'm sure nobody else is using it
- updated the 'GetRecords' template and README files