### PR TITLE
Requested reorganisation of personnel lists

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -77,8 +77,9 @@ module.exports = {
 
   // The dictionaries below list various groups of UK and US personnel, whose names should be entered as appropriate in various component and action type forms
   // Using these centralised dictionaries allows names to be consistently displayed in the DB interface, and also for them to be selected via drop-down menu when filling out the type forms
+  // Note that for all dictionaries, past personnel must still be included - otherwise their names in older records will not display correctly
 
-  // General technicians at the UK and US APA factories
+  // All technicians and other personnel at the UK and US APA factories
   dictionary_technicians: {
     vincentBaker: 'Vincent Baker',
     davidBanner: 'David Banner',
@@ -124,15 +125,7 @@ module.exports = {
     sotirisVlachos: 'Sotiris Vlachos',
   },
 
-  // Personnel who are authorised to sign-off on Grounding Mesh Panel intake
-  dictionary_meshPanelIntakeSignoff: {
-    nicholasHays: 'Nicholas Hays',
-    grahamMitchell: 'Graham Mitchell',
-    danielSalisbury: 'Daniel Salisbury',
-    kimWilliams: 'Kim Williams',
-  },
-
-  // Personnel who are authorised to sign-off on APA frame intake (including both types of frame survey results)
+  // Personnel who are authorised to signoff on APA frames (all Frame Assembly workflow actions)
   dictionary_frameIntakeSignoff: {
     gedBell: 'Ged Bell',
     callumHolt: 'Callum Holt',
@@ -142,31 +135,23 @@ module.exports = {
     kyleZeug: 'Kyle Zeug',
   },
 
-  // Personnel who are authorised to sign-off on APA frame NCR concessions
+  // Personnel who are authorised to signoff on APA frame NCR concessions ('Final Frame QA Checklist' Frame Assembly workflow actions)
   dictionary_frameNCRSignoff: {
     olgaBeltramello: 'Olga Beltramello',
     ericJames: 'Eric James',
     radosavPantelic: 'Radosav Pantelic',
   },
 
-  // Geometry board metrology technicians at Manchester
-  dictionary_manchesterTechnicians: {
-    hamzaNaseer: 'Hamza Naseer',
-    taabishAhmed: 'Taabish Ahmed',
-    jakeDeMaine: 'Jake De Maine',
-  },
-
-  // Personnel who are authorised to sign-off on tension controls
-  dictionary_tensionControlSignoff: {
-    vincentBaker: 'Vincent Baker',
-    carlosChavezBarajas: 'Carlos Chavez Barajas',
-    edBlucher: 'Ed Blucher',
-    albertoMarchionni: 'Alberto Marchionni',
-    benjaminOye: 'Benjamin Oye',
+  // Frame Prep D-band personnel (prep-related APA Assembly workflow actions and 'Final Inspection' Grounding Mesh Panel actions)
+  dictionary_dBandFramePrep: {
+    wayneGreen: 'Wayne Green',
+    nicholasHays: 'Nicholas Hays',
+    grahamMitchell: 'Graham Mitchell',
     danielSalisbury: 'Daniel Salisbury',
+    kimWilliams: 'Kim Williams',
   },
 
-  // Personnel who are authorised to sign-off on winder maintenance
+  // Personnel who are authorised to signoff on tension control and winder maintenance verifications ('? Layer - Winding' APA Assembly workflow actions)
   dictionary_winderMaintenanceSignoff: {
     vincentBaker: 'Vincent Baker',
     carlosChavezBarajas: 'Carlos Chavez Barajas',
@@ -177,7 +162,31 @@ module.exports = {
     daveSim: 'Dave Sim',
   },
 
-  // PCB technicians at UW
+  // Winding D-band personnel (winding-related APA Assembly workflow actions)
+  dictionary_dBandWinding: {
+    daveBrown: 'Dave Brown',
+    lewisGannon: 'Lewis Gannon',
+    darrenKaye: 'Darren Kaye',
+    andrewKelly: 'Andrew Kelly',
+    danielSalisbury: 'Daniel Salisbury',
+    stephenSumner: 'Stephen Sumner',
+  },
+
+  // Post-Production D-band personnel (post-winding APA Assembly workflow actions and all APA Post Production workflow actions)
+  dictionary_dBandPostProduction: {
+    danielSalisbury: 'Daniel Salisbury',
+    jasonThornhill: 'Jason Thornhill',
+  },
+
+
+  // Geometry board metrology technicians at Manchester ('Geometry Board Metrology' Geometry Board actions)
+  dictionary_manchesterTechnicians: {
+    hamzaNaseer: 'Hamza Naseer',
+    taabishAhmed: 'Taabish Ahmed',
+    jakeDeMaine: 'Jake De Maine',
+  },
+
+  // PCB technicians at UW [TODO: WHERE IS THIS USED?]
   dictionary_uwPCBTechnicians: {
     andyArbuckle: 'Andy Arbuckle',
     krishnaLakkaraju: 'Krishna Lakkaraju',
@@ -185,30 +194,30 @@ module.exports = {
     christineVerdico: 'Christine Verdico',
   },
 
-  // Personnel who are authorised to approve PCBs at UW
+  // Personnel who are authorised to approve PCBs at UW [TODO: WHERE IS THIS USED?]
   dictionary_uwPCBApproval: {
     andyArbuckle: 'Andy Arbuckle',
     pamMarrLaundrie: 'Pam Marr-Laundrie',
   },
 
-  // Hardware installation technicians at UW
+  // Hardware installation technicians at UW [TODO: WHERE IS THIS USED?]
   dictionary_uwInstallationTechnicians: {
 
   },
 
-  // Personnel who are authorised to approve hardware installation at UW
+  // Personnel who are authorised to approve hardware installation at UW [TODO: WHERE IS THIS USED?]
   dictionary_uwInstallationApproval: {
     joeMunski: 'Joe Munski',
   },
 
-  // Personnel from the CERN Compliance Office
+  // Personnel from the CERN Compliance Office [TODO: WHERE IS THIS USED?]
   dictionary_cernComplianceOffice: {
     alexandreAcerraGil: 'Alexandre Acerra Gil',
     olgaBeltramello: 'Olga Beltramello',
     denisDiyakov: 'Denis Diyakov',
   },
 
-  // Lead personnel at the UK and US APA factories (also doubling for personnel who are authorised to sign-off on 'Assembled APA Quality Assurance Check' actions)
+  // Lead personnel at the UK and US APA factories (top-level signoffs in various APA Assembly and APA Post Production workflow actions)
   dictionary_apaFactoryLeads: {
     edBlucher: 'Ed Blucher',
     daveBrown: 'Dave Brown',

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -72,7 +72,7 @@ router.get('/user', async function (req, res, next) {
 });
 
 
-/// List all technicians at the UK and US APA factories
+/// List all technicians and other personnel at the UK and US APA factories
 router.get(['/json/technicians.json', '/api/technicians.json'], async function (req, res, next) {
   try {
     return res.status(200).json(ConvertDictionaryToList(utils.dictionary_technicians));
@@ -83,18 +83,7 @@ router.get(['/json/technicians.json', '/api/technicians.json'], async function (
 });
 
 
-/// List personnel who are authorised to sign-off on Grounding Mesh Panel intake
-router.get(['/json/meshPanelIntakeSignoff.json', '/api/meshPanelIntakeSignoff.json'], async function (req, res, next) {
-  try {
-    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_meshPanelIntakeSignoff));
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-/// List personnel who are authorised to sign-off on APA frame intake (including both types of frame survey results)
+/// List personnel who are authorised to signoff on APA frames
 router.get(['/json/frameIntakeSignoff.json', '/api/frameIntakeSignoff.json'], async function (req, res, next) {
   try {
     return res.status(200).json(ConvertDictionaryToList(utils.dictionary_frameIntakeSignoff));
@@ -105,10 +94,54 @@ router.get(['/json/frameIntakeSignoff.json', '/api/frameIntakeSignoff.json'], as
 });
 
 
-/// List personnel who are authorised to sign-off on APA frame NCR concessions
+/// List personnel who are authorised to signoff on APA frame NCR concessions
 router.get(['/json/frameNCRSignoff.json', '/api/frameNCRSignoff.json'], async function (req, res, next) {
   try {
     return res.status(200).json(ConvertDictionaryToList(utils.dictionary_frameNCRSignoff));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List Frame Prep D-band personnel
+router.get(['/json/dBandFramePrep.json', '/api/dBandFramePrep.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_dBandFramePrep));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List personnel who are authorised to signoff on tension control and winder maintenance verifications
+router.get(['/json/winderMaintenanceSignoff.json', '/api/winderMaintenanceSignoff.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_winderMaintenanceSignoff));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List Winding D-band personnel
+router.get(['/json/dBandWinding.json', '/api/dBandWinding.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_dBandWinding));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List Post-Production D-band personnel
+router.get(['/json/dBandPostProduction.json', '/api/dBandPostProduction.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_dBandPostProduction));
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);
     res.status(500).json({ error: err.toString() });
@@ -120,28 +153,6 @@ router.get(['/json/frameNCRSignoff.json', '/api/frameNCRSignoff.json'], async fu
 router.get(['/json/manchesterTechnicians.json', '/api/manchesterTechnicians.json'], async function (req, res, next) {
   try {
     return res.status(200).json(ConvertDictionaryToList(utils.dictionary_manchesterTechnicians));
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-/// List personnel who are authorised to sign-off on tension controls
-router.get(['/json/tensionControlSignoff.json', '/api/tensionControlSignoff.json'], async function (req, res, next) {
-  try {
-    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_tensionControlSignoff));
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
-/// List personnel who are authorised to sign-off on winder maintenance
-router.get(['/json/winderMaintenanceSignoff.json', '/api/winderMaintenanceSignoff.json'], async function (req, res, next) {
-  try {
-    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_winderMaintenanceSignoff));
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);
     res.status(500).json({ error: err.toString() });


### PR DESCRIPTION
- added new lists of D-band personnel for frame prep, winding and post-production ... these will be used specifically for signoffs and QA checks during APA Assembly
- removed tension control and grounding mesh panel intake lists ... these are identical to the winder maintenance and (new) Frame Prep D-band lists respectively
- added some comments in the code to clarify exactly where each list is used (still need to figure this out for the UW-related lists)
- updated API routes accordingly ... will update the action type forms once these changes are on Production

Changes have been tested on Staging.