### PR TITLE
More Miscellaneous Changes from Staging

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -8,6 +8,7 @@ const dbLock = require('./dbLock');
 const Forms = require('./Forms');
 const permissions = require('./permissions');
 const utils = require('./utils');
+const logger = require('./logger');
 
 // Declare a list of the available 'shipment transport' related action type forms
 // NOTE: this must be the same as the equivalent list given in 'static/pages/action_specComponent.js'
@@ -353,10 +354,8 @@ async function list(match_condition, options) {
   // Re-sort the records by last edit date ... most recent first
   aggregation_stages.push({ $sort: { lastEditDate: -1 } });
 
-  // Add aggregation stages for any additionally specified options
-  if (options) {
-    if (options.limit) aggregation_stages.push({ $limit: options.limit });
-  }
+  // Limit the number of returned records to something reasonable ... this will be further reduced later on, but only after the optional filter on component type form ID has been applied if needed
+  aggregation_stages.push({ $limit: 1000 });
 
   // Query the 'actions' records collection using the aggregation stages defined above
   let records = await db.collection('actions')
@@ -365,6 +364,10 @@ async function list(match_condition, options) {
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display
   // Then add the corresponding component name to each matching record
+  // Finally, apply the optional filter on the component type form ID if it is needed - if the action passes the filter, save it into a new list of matching and filtered records ...
+  // ... or if the optional filter is not needed, simply save all matching records into the list of matching and filtered records
+  let filteredRecords = [];
+
   for (let record of records) {
     const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
 
@@ -373,10 +376,22 @@ async function list(match_condition, options) {
     } else {
       record.componentName = component.data.componentName;
     }
+
+    if (options) {
+      if (options.componentTypeFormId) {
+        if (component.formId === options.componentTypeFormId) {
+          filteredRecords.push(record);
+        }
+      } else {
+        filteredRecords.push(record);
+      }
+    } else {
+      filteredRecords.push(record);
+    }
   }
 
-  // Return the entire list of matching records
-  return records;
+  // Return a limited slice of the matching (and possibly filtered) records
+  return filteredRecords.slice(0, 200);
 }
 
 

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -70,7 +70,7 @@ async function save(input, req) {
   newRecord.validity.ancestor_id = input._id;
 
   // If saving a new component record, certain objects and fields need to be set up and populated
-  // If editing an existing component records, this same information will either already exist (from being included when the 'input.data' object was copied over above) or can be directly copied
+  // If editing an existing component record, this same information will either already exist (from being included when the 'input.data' object was copied over above) or can be directly copied
   if (oldRecord === null) {
     // Get a list of the current component count per type across all existing component types, and then get the count of existing components of the same type as this one
     // If the component is a 'Geometry Board' type, offset the count, to account for an unknown number of boards that might have been manufactured before the database was up and running
@@ -221,17 +221,7 @@ async function save(input, req) {
       newRecord.reception.location = '';
     }
   } else {
-    // For some unknown reason, sometimes the entire 'reception' object can be set to 'null' when editing a component (seems to happen rarely, and only with 'Board Shipment' components) ...
-    // ... if this does happen, just reconstruct the 'reception' object and its fields - giving them some default values (the actual values for shipment-type components are assigned below anyway)
-    // If this is not the case, i.e. the existing 'reception' object contains some information, simply copy it over to the new record
-    if (input.reception === null) {
-      newRecord.reception = {};
-      newRecord.reception.location = '';
-      newRecord.reception.date = (new Date()).toISOString().slice(0, 10);
-      newRecord.reception.detail = '';
-    } else {
-      newRecord.reception = input.reception;
-    }
+    newRecord.reception = input.reception;
   }
 
   // If the component name is based on fields that are more likely to be changed by the user, it should be assigned and re-assigned any time the record is edited
@@ -346,7 +336,11 @@ async function updateLocation(componentUuid, location, date, detail) {
 
   // First retrieve the component's record, then check for the current location, and only proceed to change the reception information if we are NOT in one of the situations described above
   const component = await retrieve(componentUuid);
-  const currentLocation = component.reception.location;
+  let currentLocation = 'null object';
+
+  if (component.reception != null) {
+    currentLocation = component.reception.location;
+  }
 
   if (currentLocation !== 'installed_on_APA') {
     // Set up the DB query match condition to be that a record's component UUID must match the specified one

--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -65,8 +65,29 @@ block content
 
                   if typeFormTags && !typeFormTags.includes('Trash')
                     tr
-                      td.col-md-4
-                        a(href = `/actions/${typeFormId}/list`) #{typeFormName}
+                      if typeFormId === 'APANonConformance' || typeFormId === 'PopulatedBoardQC'
+                        - let componentTypeFormId = null;
+
+                        if actionFormsGroup._id.componentType === 'Assembled APA'
+                          - componentTypeFormId = 'AssembledAPA';
+                        else if actionFormsGroup._id.componentType === 'CE Adapter Board'
+                          - componentTypeFormId = 'CEAdapterBoard'
+                        else if actionFormsGroup._id.componentType === 'CR Board'
+                          - componentTypeFormId = 'CRBoard'
+                        else if actionFormsGroup._id.componentType === 'Cable Harness'
+                          - componentTypeFormId = 'CableHarness'
+                        else if actionFormsGroup._id.componentType === 'G-Bias Board'
+                          - componentTypeFormId = 'GBiasBoard'
+                        else if actionFormsGroup._id.componentType === 'Grounding Mesh Panel'
+                          - componentTypeFormId = 'GroundingMeshPanel';
+                        else if actionFormsGroup._id.componentType === 'SHV Board'
+                          - componentTypeFormId = 'SHVBoard'
+
+                        td.col-md-4
+                          a(href = `/actions/${typeFormId}/list?componentTypeFormId=${componentTypeFormId}`) #{typeFormName}
+                      else
+                        td.col-md-4
+                          a(href = `/actions/${typeFormId}/list`) #{typeFormName}
                       td.col-md-2
                         if workflowAction
                           a.btn-sm.btn-secondary.disabled(href = '')

--- a/app/pug/component_execSummary.pug
+++ b/app/pug/component_execSummary.pug
@@ -96,7 +96,7 @@ block allbody
 
   .vert-space-x2
     .header_ncr 
-      .form_header_ncr(data-record = 'Use As Is (Missing or Shorted Wires)')
+      .form_header_ncr(data-record = ['Use As Is (Missing or Shorted Wires)', collatedInfo.ncrs_useAsIs_withWires.length])
 
     if collatedInfo.ncrs_useAsIs_withWires.length > 0
       each ncrInfo, ncrIndex in collatedInfo.ncrs_useAsIs_withWires
@@ -107,53 +107,45 @@ block allbody
             each wireInfo, wireIndex in ncrInfo.missingShortedWires
               .entry_ncrWire
                 .form_entry_ncrWire(data-record = wireInfo)
-    else 
-      p [no non-conformances found with this disposition and NCR type(s)]
 
     .vert-space-x2
       hr
 
   .vert-space-x2
     .header_ncr 
-      .form_header_ncr(data-record = 'Use As Is (Other NCR Types)')
+      .form_header_ncr(data-record = ['Use As Is (Other NCR Types)', collatedInfo.ncrs_useAsIs_noWires.length])
 
     if collatedInfo.ncrs_useAsIs_noWires.length > 0
       each ncrInfo, ncrIndex in collatedInfo.ncrs_useAsIs_noWires
         .vert-space-x1 
           .entry_ncr
             .form_entry_ncr(data-record = ncrInfo)
-    else 
-      p [no non-conformances found with this disposition and NCR type(s)]
 
     .vert-space-x2
       hr
 
   .vert-space-x2
     .header_ncr 
-      .form_header_ncr(data-record = 'Rework')
+      .form_header_ncr(data-record = ['Rework', collatedInfo.ncrs_rework.length])
 
     if collatedInfo.ncrs_rework.length > 0
       each ncrInfo, ncrIndex in collatedInfo.ncrs_rework
         .vert-space-x1 
           .entry_ncr
             .form_entry_ncr(data-record = ncrInfo)
-    else 
-      p [no non-conformances found with this disposition]
 
     .vert-space-x2
       hr
 
   .vert-space-x2
     .header_ncr 
-      .form_header_ncr(data-record = 'Repair')
+      .form_header_ncr(data-record = ['Repair', collatedInfo.ncrs_repair.length])
 
     if collatedInfo.ncrs_repair.length > 0
       each ncrInfo, ncrIndex in collatedInfo.ncrs_repair
         .vert-space-x1 
           .entry_ncr
             .form_entry_ncr(data-record = ncrInfo)
-    else 
-      p [no non-conformances found with this disposition]
 
     .vert-space-x2
       hr

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -342,7 +342,7 @@ router.get('/actions/list', permissions.checkPermission('actions:view'), async f
   try {
     // Retrieve records of all actions across all action types
     // The first argument should be 'null' in order to match to any type form ID
-    const actions = await Actions.list(null, { limit: 200 });
+    const actions = await Actions.list(null);
 
     // Retrieve a list of all action type forms that currently exist in the 'actionForms' collection
     const allActionTypeForms = await Forms.list('actionForms');
@@ -364,7 +364,7 @@ router.get('/actions/:typeFormId/list', permissions.checkPermission('actions:vie
   try {
     // Retrieve records of all actions with the specified action type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const actions = await Actions.list({ typeFormId: req.params.typeFormId }, { limit: 200 });
+    const actions = await Actions.list({ typeFormId: req.params.typeFormId }, { componentTypeFormId: req.query.componentTypeFormId });
 
     // Retrieve the action type form corresponding to the specified type form ID
     const actionTypeForm = await Forms.retrieve('actionForms', req.params.typeFormId);
@@ -484,7 +484,7 @@ router.get(['/json/actions/:typeFormId/list', '/api/actions/:typeFormId/list'], 
 
     // Retrieve records of all actions with the specified action type, and optionally further match to those that were performed on the specified component
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const actions = await Actions.list(match_condition, { limit: 200 });
+    const actions = await Actions.list(match_condition);
 
     // Extract only the ID field (in string format) from each action record, and save it into a list to be returned
     let actionIDs = [];

--- a/app/static/pages/component_execSummary.js
+++ b/app/static/pages/component_execSummary.js
@@ -6,21 +6,21 @@ function SetEntry_qcSignoffs(frameConstruction, framePreparation, x, v, u, g, co
   const meshInstall_link = (framePreparation.meshInstall_actionID !== '' ? `<a href = '/action/${framePreparation.meshInstall_actionID}' > Mesh Panel Installation </a>` : `[Mesh Panel Installation not found]`);
   const rtdInstall_link = (framePreparation.rtdInstall_actionID !== '' ? `<a href = '/action/${framePreparation.rtdInstall_actionID}' > PD & RTD Installation </a>` : `[PD & RTD Installation not found]`);
 
-  const xWinding_link = (x.winding_actionID !== '' ? `<a href = '/action/${x.winding_actionID}' > Winding </a>` : `[Winding not found]`);
-  const xSoldering_link = (x.soldering_actionID !== '' ? `<a href = '/action/${x.soldering_actionID}' > Soldering </a>` : `[Soldering not found]`);
-  const xTensions_link = (x.tensions_actionID !== '' ? `<a href = '/action/${x.tensions_actionID}' > Tension Measurements </a>` : `[Tension Measurements not found]`);
+  const xWinding_link = (x.winding_actionID !== '' ? `<a href = '/action/${x.winding_actionID}' > X Winding </a>` : `[Winding not found]`);
+  const xSoldering_link = (x.soldering_actionID !== '' ? `<a href = '/action/${x.soldering_actionID}' > X Soldering </a>` : `[Soldering not found]`);
+  const xTensions_link = (x.tensions_actionID !== '' ? `<a href = '/action/${x.tensions_actionID}' > X Tension Measurements </a>` : `[Tension Measurements not found]`);
 
-  const vWinding_link = (v.winding_actionID !== '' ? `<a href = '/action/${v.winding_actionID}' > Winding </a>` : `[Winding not found]`);
-  const vSoldering_link = (v.soldering_actionID !== '' ? `<a href = '/action/${v.soldering_actionID}' > Soldering </a>` : `[Soldering not found]`);
-  const vTensions_link = (v.tensions_actionID !== '' ? `<a href = '/action/${v.tensions_actionID}' > Tension Measurements </a>` : `[Tension Measurements not found]`);
+  const vWinding_link = (v.winding_actionID !== '' ? `<a href = '/action/${v.winding_actionID}' > V Winding </a>` : `[Winding not found]`);
+  const vSoldering_link = (v.soldering_actionID !== '' ? `<a href = '/action/${v.soldering_actionID}' > V Soldering </a>` : `[Soldering not found]`);
+  const vTensions_link = (v.tensions_actionID !== '' ? `<a href = '/action/${v.tensions_actionID}' > V Tension Measurements </a>` : `[Tension Measurements not found]`);
 
-  const uWinding_link = (u.winding_actionID !== '' ? `<a href = '/action/${u.winding_actionID}' > Winding </a>` : `[Winding not found]`);
-  const uSoldering_link = (u.soldering_actionID !== '' ? `<a href = '/action/${u.soldering_actionID}' > Soldering </a>` : `[Soldering not found]`);
-  const uTensions_link = (u.tensions_actionID !== '' ? `<a href = '/action/${u.tensions_actionID}' > Tension Measurements </a>` : `[Tension Measurements not found]`);
+  const uWinding_link = (u.winding_actionID !== '' ? `<a href = '/action/${u.winding_actionID}' > U Winding </a>` : `[Winding not found]`);
+  const uSoldering_link = (u.soldering_actionID !== '' ? `<a href = '/action/${u.soldering_actionID}' > U Soldering </a>` : `[Soldering not found]`);
+  const uTensions_link = (u.tensions_actionID !== '' ? `<a href = '/action/${u.tensions_actionID}' > U Tension Measurements </a>` : `[Tension Measurements not found]`);
 
-  const gWinding_link = (g.winding_actionID !== '' ? `<a href = '/action/${g.winding_actionID}' > Winding </a>` : `[Winding not found]`);
-  const gSoldering_link = (g.soldering_actionID !== '' ? `<a href = '/action/${g.soldering_actionID}' > Soldering </a>` : `[Soldering not found]`);
-  const gTensions_link = (g.tensions_actionID !== '' ? `<a href = '/action/${g.tensions_actionID}' > Tension Measurements </a>` : `[Tension Measurements not found]`);
+  const gWinding_link = (g.winding_actionID !== '' ? `<a href = '/action/${g.winding_actionID}' > G Winding </a>` : `[Winding not found]`);
+  const gSoldering_link = (g.soldering_actionID !== '' ? `<a href = '/action/${g.soldering_actionID}' > G Soldering </a>` : `[Soldering not found]`);
+  const gTensions_link = (g.tensions_actionID !== '' ? `<a href = '/action/${g.tensions_actionID}' > G Tension Measurements </a>` : `[Tension Measurements not found]`);
 
   const panelInstall_link = (postProduction.panelInstall_actionID !== '' ? `<a href = '/action/${postProduction.panelInstall_actionID}' > Protection Panels </a>` : `[Protection Panels not found]`);
   const conduitInstall_link = (postProduction.conduitInstall_actionID !== '' ? `<a href = '/action/${postProduction.conduitInstall_actionID}' > Cable Conduits </a>` : `[Cable Conduits not found]`);
@@ -1730,11 +1730,13 @@ function SetEntry_wireLayer(layer, layerInfo) {
 }
 
 // Set up the schema for a single NCR section header
-function SetHeader_ncrsWithDisposition(disposition) {
+function SetHeader_ncrsWithDisposition(disposition, count) {
+  const plural = (count === 1) ? '' : 's';
+
   const schema_ncrs_header = {
     "components": [
       {
-        "html": `<h4><strong>Non-Conformances with Disposition: ${disposition}</strong></h4>`,
+        "html": `<h4><strong>${count} Non-Conformance${plural} with Disposition: ${disposition}</strong></h4>`,
         "label": "Content",
         "refreshOnChange": false,
         "key": "content",
@@ -2037,7 +2039,7 @@ async function populateExecutiveSummary() {
   $('div.header_ncr').each(function () {
     const form_header_ncr = $('.form_header_ncr', this);
     const disposition = form_header_ncr.data('record');
-    const schema_header_ncr = SetHeader_ncrsWithDisposition(disposition);
+    const schema_header_ncr = SetHeader_ncrsWithDisposition(disposition[0], disposition[1]);
 
     Formio.createForm(form_header_ncr[0], schema_header_ncr, { readOnly: true, });
   })


### PR DESCRIPTION
Small final tweaks to APA Executive Summaries
- QC signoff links now identify explicitly which layer is being referred to for winding, soldering and tension measurements
- each NCR group header now shows the count of NCRs in that group, and no message is displayed if there are none (no longer needed)

Fix for listing multi-component-type actions
- some action types can be performed on multiple component types - i.e. populated board QA actions can be performed on all types of populated boards, non-conformance actions can be performed on APAs and meshes
- currently, all listing pages of these action types will show the actions across ALL component types - even though the user gets to those listing pages by clicking on one of the component types ... the expected behaviour would be to list only those actions that have been performed on that component type
- these code changes implement that expected behaviour

Another attempt at fixing the 'null' reception object issue
- removed code from the previous attempt ... clearly didn't work
- finally identified the specific line of code which throws the red-banner error in the interface - when the reception object is 'null', the 'updateLocation' function cannot get the current location
- changed so that the function will now first check if the object is 'null', and only attempt to get the current location if not
- if the object is 'null', the current location will be set to some default string ... it gets changed to the actual value later in the same function anyway
- note that none of this actually fixed why the object could be 'null' in the first place ... still haven't figured that out

Changes have been tested on Staging ... unable to completely replicate the 'null' reception object error, but testing showed that it shouldn't throw a red-banner error on the interface anymore - if encountered, the 'null' is now immediately dealt with and fixed on the server-side.