### PR TITLE
Bug Fix for Multi-Kit Shipment Component Location Tracking

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -405,19 +405,27 @@ async function updateLocations_inShipment(componentUuid, location, date) {
   } else if (shipment.formId === 'PopulatedBoardShipment') {
     // Extract the UUID and update the location information of each shipment in a multi-type populated board shipment
     for (const crBoardShipment of shipment.data.crBoardKitUuiDs) {
-      const result = await updateLocations_inShipment(crBoardShipment.component_uuid, location, date);
+      if (crBoardShipment.component_uuid !== '') {
+        const result = await updateLocations_inShipment(crBoardShipment.component_uuid, location, date);
+      }
     }
 
     for (const gBiasBoardShipment of shipment.data.gBiasBoardKitUuiDs) {
-      const result = await updateLocations_inShipment(gBiasBoardShipment.component_uuid, location, date);
+      if (gBiasBoardShipment.component_uuid !== '') {
+        const result = await updateLocations_inShipment(gBiasBoardShipment.component_uuid, location, date);
+      }
     }
 
     for (const shvBoardShipment of shipment.data.shvBoardKitUuiDs) {
-      const result = await updateLocations_inShipment(shvBoardShipment.component_uuid, location, date);
+      if (shvBoardShipment.component_uuid !== '') {
+        const result = await updateLocations_inShipment(shvBoardShipment.component_uuid, location, date);
+      }
     }
 
     for (const cableHarnessShipment of shipment.data.cableHarnessKitUuiDs) {
-      const result = await updateLocations_inShipment(cableHarnessShipment.component_uuid, location, date);
+      if (cableHarnessShipment.component_uuid !== '') {
+        const result = await updateLocations_inShipment(cableHarnessShipment.component_uuid, location, date);
+      }
     }
   }
 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -40,7 +40,7 @@ block content
                 .hori-space-x1
                   a.copybutton.btn-sm#copy_uuid(onclick = 'CopyUUID(component.componentUuid)') Copy
 
-            
+
             if component.reception && component.reception.location !== ''
               dt Current Location:
 
@@ -289,7 +289,7 @@ block content
             thead 
               tr 
                 th.col-md-2 UUID 
-                th.col-md-2 Type
+                th.col-md-2 Shipment / Kit Name
                 th.col-md-3 QR Code Link 
 
             tbody 

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -156,13 +156,13 @@ block allbody
           dt Destination Location
           dd #{dictionary_locations[component.data.destinationOfShipment]}
 
-          dt Single-Type Shipments in Multi-Type Shipment
+          dt Single-Type Shipments / Kits in Multi-Type Shipment
           dd
             table.table 
               thead 
                 tr 
-                  th.col-sm-1 UUID 
-                  th.col-sm-2 Type
+                  th.col-sm-2 UUID 
+                  th.col-sm-2 Shipment / Kit Name
 
               tbody 
                 each info in collectionDetails

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -27,11 +27,19 @@ block content
       .row 
         .col-sm-5
           dl
-            dt Workflow ID
+            dt Workflow ID:
             dd
               a(href = `/workflow/${workflow.workflowId}`) #{workflow.workflowId}
 
-            dt Completion [%]
+            dt Performed on Component:
+
+            if componentName !== ''
+              dd 
+                a(href = `/component/${workflow.path[0].result}`, target = '_blank') #{componentName}
+            else 
+              dd (component not yet created)
+
+            dt Completion [%]:
 
             if workflow.completionStatus != null
               if workflow.completionStatus < 50.0

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -150,102 +150,84 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
 
     if (component.formId === 'BoardShipment') {
       for (const info of component.data.boardUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const boardRecord = await Components.retrieve(uuid);
-
-          if (boardRecord) collectionDetails.push([uuid, boardRecord.data.typeRecordNumber, boardRecord.data.partNumber, boardRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber, componentRecord.shortUuid]);
         }
       }
     }
 
     if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const boardRecord = await Components.retrieve(uuid);
-
-          if (boardRecord) collectionDetails.push([uuid, boardRecord.data.typeRecordNumber, boardRecord.formName, boardRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
     }
 
     if (component.formId === 'DWAComponentShipment') {
       for (const info of component.data.componentUUIDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const dwaRecord = await Components.retrieve(uuid);
-
-          if (dwaRecord) collectionDetails.push([uuid, dwaRecord.data.typeRecordNumber, dwaRecord.formName, dwaRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
         }
       }
     }
 
     if (component.formId === 'GroundingMeshShipment') {
       for (const info of component.data.apaUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const meshRecord = await Components.retrieve(uuid);
-
-          if (meshRecord) collectionDetails.push([uuid, meshRecord.data.typeRecordNumber, meshRecord.data.meshPanelPartNumber, meshRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.meshPanelPartNumber, componentRecord.shortUuid]);
         }
       }
     }
 
     if (component.formId === 'PopulatedBoardShipment') {
       for (const info of component.data.crBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName, componentRecord.shortUuid]);
         }
       }
 
       for (const info of component.data.gBiasBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName, componentRecord.shortUuid]);
         }
       }
 
       for (const info of component.data.shvBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName, componentRecord.shortUuid]);
         }
       }
 
       for (const info of component.data.cableHarnessKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName, componentRecord.shortUuid]);
         }
       }
     }
 
     if (component.formId === 'ReturnedGeometryBoardBatch') {
       for (const info of component.data.boardUuids) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const boardRecord = await Components.retrieve(uuid);
-
-          if (boardRecord) collectionDetails.push([uuid, boardRecord.data.typeRecordNumber, boardRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.shortUuid]);
         }
       }
     }
@@ -360,78 +342,64 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
 
     if ((component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const boardRecord = await Components.retrieve(uuid);
-
-          if (boardRecord) shortUUIDs.push([boardRecord.data.typeRecordNumber, boardRecord.shortUuid, boardRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
     }
 
     if (component.formId === 'DWAComponentShipment') {
       for (const info of component.data.componentUUIDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const dwaRecord = await Components.retrieve(uuid);
-
-          if (dwaRecord) shortUUIDs.push([dwaRecord.data.typeRecordNumber, dwaRecord.shortUuid, dwaRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
     }
 
     if (component.formId === 'GroundingMeshShipment') {
       for (const info of component.data.apaUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const meshRecord = await Components.retrieve(uuid);
-
-          if (meshRecord) shortUUIDs.push([meshRecord.data.typeRecordNumber, meshRecord.shortUuid, meshRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
     }
 
     if (component.formId === 'PopulatedBoardShipment') {
       for (const info of component.data.crBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) shortUUIDs.push([componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
 
       for (const info of component.data.gBiasBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) shortUUIDs.push([componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
 
       for (const info of component.data.shvBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) shortUUIDs.push([componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
 
       for (const info of component.data.cableHarnessKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) shortUUIDs.push([componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
     }
@@ -441,7 +409,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
 
-          if (componentRecord) shortUUIDs.push([componentRecord.data.typeRecordNumber, componentRecord.shortUuid, componentRecord.formName]);
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
       }
     }
@@ -518,90 +486,74 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
 
     if (component.formId === 'BoardShipment') {
       for (const info of component.data.boardUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const boardRecord = await Components.retrieve(uuid);
-
-          if (boardRecord) collectionDetails.push([uuid, boardRecord.data.typeRecordNumber, boardRecord.data.partNumber]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber]);
         }
       }
     }
 
     if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const boardRecord = await Components.retrieve(uuid);
-
-          if (boardRecord) collectionDetails.push([uuid, boardRecord.data.typeRecordNumber, boardRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
         }
       }
     }
 
     if (component.formId === 'DWAComponentShipment') {
       for (const info of component.data.componentUUIDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const dwaRecord = await Components.retrieve(uuid);
-
-          if (dwaRecord) collectionDetails.push([uuid, dwaRecord.data.typeRecordNumber, dwaRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
         }
       }
     }
 
     if (component.formId === 'GroundingMeshShipment') {
       for (const info of component.data.apaUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const meshRecord = await Components.retrieve(uuid);
-
-          if (meshRecord) collectionDetails.push([uuid, meshRecord.data.typeRecordNumber, meshRecord.data.meshPanelPartNumber]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.meshPanelPartNumber]);
         }
       }
     }
 
     if (component.formId === 'PopulatedBoardShipment') {
       for (const info of component.data.crBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName]);
         }
       }
 
       for (const info of component.data.gBiasBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName]);
         }
       }
 
       for (const info of component.data.shvBoardKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName]);
         }
       }
 
       for (const info of component.data.cableHarnessKitUuiDs) {
-        let uuid = info.component_uuid;
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
 
-        if (uuid !== '') {
-          const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) collectionDetails.push([uuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName]);
         }
       }
     }


### PR DESCRIPTION
- the component type form for multi-kit shipments was recently changed to allow any number of kits of each type, including ZERO
- previously, there always had to be at least one kit of each type ... the code was written around that assumption
- changed the code so that it now first checks if a kit exists (for each type), and only attempts to retrieve it and set its location if so
- also applies when retrieving the sub-kits for component summary and bulk-QR code interface pages

While making the above changes, also found and fixed some incorrect summary and QR code displays for other component types (previously missed with the recent changes to component names and QR code displays)

Adding component name to workflow information page
- the name of the component on which a workflow is being performed will now be shown in the top section of the workflow information page
- technicians have mentioned that it's easier to expect it there, in line with actions, and easy to overlook that it's also currently displayed at the top of the path table
- also corrected some small typos on workflow information page as well