### PR TITLE
Adding ability to upload shocklogger plots images to APA Shipment Reception actions ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -182,7 +182,7 @@ async function save(input, req) {
 
 
 /// Add one or more base64-encoded strings, each one representing a single image, to a specified action record
-async function addImageStrings(actionId, imageStringsArray) {
+async function addImageStrings(actionId, imageStringsArray, imageType) {
   // Set up the DB query match condition to be that a record's action ID must match the specified one
   let match_condition = { actionId };
 
@@ -190,19 +190,37 @@ async function addImageStrings(actionId, imageStringsArray) {
 
   match_condition.actionId = new ObjectId(match_condition.actionId);
 
-  // Use the MongoDB '$push' operator to populate the images to the 'images' array in the action record, and throw an error if the edit fails
-  const result = await db.collection('actions')
-    .findOneAndUpdate(
-      match_condition,
-      {
-        $push: { 'images': { $each: imageStringsArray } }
-      },
-      {
-        sort: { 'validity.version': -1 },
-        returnNewDocument: true,
-        includeResultMetadata: true,
-      },
-    );
+  let result = null;
+
+  if (imageType === 'shocklogger') {
+    // Use the MongoDB '$set' operator to populate the 'data.shockloggerPlots' field in the action record with the new image (overwriting any existing data), and throw an error if the edit fails
+    result = await db.collection('actions')
+      .findOneAndUpdate(
+        match_condition,
+        {
+          $set: { 'data.shocklogPlotsImage': imageStringsArray[0] }
+        },
+        {
+          sort: { 'validity.version': -1 },
+          returnNewDocument: true,
+          includeResultMetadata: true,
+        },
+      );
+  } else if (imageType === 'general') {
+    // Use the MongoDB '$push' operator to append all provided images to the 'images' array in the action record, and throw an error if the edit fails
+    result = await db.collection('actions')
+      .findOneAndUpdate(
+        match_condition,
+        {
+          $push: { 'images': { $each: imageStringsArray } }
+        },
+        {
+          sort: { 'validity.version': -1 },
+          returnNewDocument: true,
+          includeResultMetadata: true,
+        },
+      );
+  }
 
   if (result.ok === 0) throw new Error(`Actions::addImageStrings() - failed to update the action record!`);
 

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -471,24 +471,57 @@ block content
               | Planarity Analysis using M6/10/20 Holes (no results found in record!) 
               i.chevron.fa.fa-fw 
 
+        .vert-space-x2
+
+      if action.typeFormId == 'APAShipmentReception'
         .vert-space-x2 
+          hr
+
+        .row 
+          .col-sm-4
+            dt Add Shocklogger Plots Image to Action Record:
+            dd 
+              p Use the 'Select Plots Image' button below to select an appropriate image from your device.
+
+              p Once you are happy with your selection, press the 'Confirm Plots Image' button to finalise the upload.
+
+            .vert-space-x1.form-inline
+              label.btn.btn-primary(for = 'plots-selector')
+                input.custom-file-input#plots-selector(type = 'file', style = 'display:none', onchange = 'DisplayFileNames(this, "shocklogger")')
+                | Select Plots Image
+
+              .hori-space-x2 
+                a.btn-danger.btn-sm#confirm-plots(onclick = 'EncodeStoreImages("shocklogger")') Confirm Plots Image
+
+            .vert-space-x1 
+              label.label-info#plots-filename
+
+
+          .col-sm-8
+            if action.data.shocklogPlotsImage
+              img.img-fluid.border-success.border.rounded.p-2(src = action.data.shocklogPlotsImage)
+            else 
+              p <b>[use the tool to the left to upload an image showing shocklogger data plots]</b>
 
       if action.typeFormId == 'APANonConformance' || action.typeFormId == 'APAShipmentReception' || action.typeFormId == 'x_tension_testing' || action.typeFormId == 'MeshQAInspection'
+        .vert-space-x2 
+          hr
+
         dt Add Images to Action Record:
-        dd Please use the 'Select Images' button below to select one or more images from your device to add to this action record.  Once you are happy with your selection, please use the 'Confirm Images' button to finalise the upload.
+        dd Use the 'Select Images' button below to select one or more images from your device to add to this action record.  Once you are happy with your selection, press the 'Confirm Images' button to finalise the upload.
           br
-          | Please make sure that your <b>images are individually no more than <u>1MB</u> in size</b>, and <b>please do not add more than <u>5 images</u> in total to any single record</b>.
+          | Please ensure that your <b>images are individually no more than <u>1MB</u> in size</b>, and <b>do not add more than <u>5 images</u> in total to any single record</b>.
 
           .vert-space-x1.form-inline
             label.btn.btn-primary(for = 'image-selector')
-              input.custom-file-input#image-selector(type = 'file', style = 'display:none', onchange = 'DisplayFileNames(this)', multiple)
+              input.custom-file-input#image-selector(type = 'file', style = 'display:none', onchange = 'DisplayFileNames(this, "general")', multiple)
               | Select Images
 
             .hori-space-x2
               label.label-info#image-filenames 
 
             .hori-space-x2
-              a.btn-danger.btn-sm#confirm-upload(onclick = 'EncodeStoreImages()') Confirm Upload
+              a.btn-danger.btn-sm#confirm-images(onclick = 'EncodeStoreImages("general")') Confirm Images
 
           if action.images
             .vert-space-x1
@@ -503,10 +536,10 @@ block content
 
               .vert-space-x2 
                 hr
-            
+
                 dt Remove Image from Action Record:</b>
                 dd Please enter the number of the image you want to remove below (i.e. '1' for the first image, '2' for the second, etc.).  Please note that only one image can be removed at a time.  Once you are happy with your entry, please use the 'Confirm Removal' button to finalise.
-                
+
                 .vert-space-x1.form-inline
                   input.form-control#image-remover
 

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -443,11 +443,11 @@ router.post(['/json/action', '/api/action'], permissions.checkPermissionJson('ac
 
 
 /// Add one or more base64-encoded strings, each one representing a single image, to an action record
-router.post(['/json/action/:actionId/addImages', '/api/action/:actionId/addImages'], permissions.checkPermissionJson('actions:perform'), async function (req, res, next) {
+router.post(['/json/action/:actionId/addImages/:imageType', '/api/action/:actionId/addImages/:imageType'], permissions.checkPermissionJson('actions:perform'), async function (req, res, next) {
   try {
     // Add the encoded strings to the action record corresponding to the specified action ID ... if successful, the function returns the action ID
     // The encoded strings are contained as an array in the 'req.body.image' parameter (it is passed as a [key, value] pair, with the key being 'images' and the value being the array)
-    const result = await Actions.addImageStrings(req.params.actionId, req.body.images);
+    const result = await Actions.addImageStrings(req.params.actionId, req.body.images, req.params.imageType);
 
     // Return the record's action ID
     return res.status(201).json(result);

--- a/app/static/pages/action.js
+++ b/app/static/pages/action.js
@@ -62,25 +62,38 @@ function DownloadChangedTensions(retensionedWires) {
 
 // When one or more images is selected, display their name(s) in the space between the selection and confirmation buttons
 // Also change the colour and text of the confirmation button to indicate that at least one image has been selected
-function DisplayFileNames(element) {
+function DisplayFileNames(element, imageType) {
   const files = Array.from(element.files);
   let fileNames = files.map(f => { return f.name }).join(' ] , [ ');
   fileNames = '[ ' + fileNames + ' ]';
 
-  $('#image-filenames').text(fileNames);
-
-  document.getElementById('confirm-upload').style.backgroundColor = 'green';
+  if (imageType === 'shocklogger') {
+    $('#plots-filename').text(fileNames);
+    document.getElementById('confirm-plots').style.backgroundColor = 'green';
+  } else if (imageType === 'general') {
+    $('#image-filenames').text(fileNames);
+    document.getElementById('confirm-images').style.backgroundColor = 'green';
+  }
 };
 
 
-// When the 'Confirm Upload' button is pressed, read in any selected images, convert them to base64-encoded strings, and store the strings in an array
+// When the 'Confirm Images' button is pressed, read in any selected images, convert them to base64-encoded strings, and store the strings in an array
 // Then perform the submission of this array to the database, so the image strings can be added to the appropriate action record
-function EncodeStoreImages() {
+function EncodeStoreImages(imageType) {
   // The 'FileReader.readAsDataURL()' function used to read each image is asynchronous, so we must set up each read as a promise
   // The encompassing 'GetAllImageData()' function returns a single promise that is fulfilled when all sub-promises are themselves fulfilled (i.e. all images have been read)
   // Each sub-promise 'resolves' to the image's base64-encoded string, i.e. that is the value associated with the sub-promise's fulfillment
   function GetAllImageData() {
-    const imageFiles = document.getElementById('image-selector').files;
+    let imageFiles = null;
+    console.log(imageType);
+    if (imageType === 'shocklogger') {
+      imageFiles = document.getElementById('plots-selector').files;
+    } else if (imageType === 'general') {
+      imageFiles = document.getElementById('image-selector').files;
+    }
+
+    console.log(imageFiles);
+
     let imagePromises = [];
 
     imageFiles.forEach(function (imageFile) {
@@ -109,7 +122,7 @@ function EncodeStoreImages() {
     $.ajax({
       contentType: 'application/json',
       method: 'post',
-      url: `/json/action/${action.actionId}/addImages`,
+      url: `/json/action/${action.actionId}/addImages/${imageType}`,
       data: JSON.stringify(submission),
       dataType: 'json',
       success: postSuccess,


### PR DESCRIPTION
- extended existing image-upload functions to allow for different 'types' of images ... 'general' (what already existed) and 'shocklogger' (new)
- only one shocklogger plots image can be present at a time (new upload will overwrite existing) ... unlike general images (new upload is added to array of images)
- shocklogger plots image is displayed separately from general images (since both can in principle be present in a single APA Shipment Reception action) ... gallery of general images remains as it is

Changes have been tested on Staging.