### PR TITLE
Adding framework for HWDB APA data output ...

### DIFF
--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -69,8 +69,8 @@ const dictionary_ncrTypes = {
 };
 
 
-/// Retrieve collated information about a single assembled APA (and associated components and actions) that will be displayed in its executive summary
-async function collateInfo(componentUUID) {
+/// Retrieve collated information about a single assembled APA (and associated components and actions), for use in its executive summary
+async function forExecSummary(componentUUID) {
   let aggregation_stages = [];
   let results = [];
 
@@ -729,6 +729,66 @@ async function collateInfo(componentUUID) {
 }
 
 
+/// Retrieve collated information about two specified APAs comprising a single doublet, for use in the DUNE HWDB
+async function forHWDB(apa1UUID, apa2UUID) {
+  // Set up an object to store the collated information, and then set up the various sections of the collated information object
+  // Information will be saved as [key, value] pairs for easier access on the interface page, and we know what keys are required ahead of time, so they can be hardcoded
+  let collatedInfo = {};
+
+  collatedInfo.apa1 = {
+    componentName: '',
+    componentUUID: '',
+    shortUUID: '',
+    dunePID: '',
+    productionSite: '',
+    configuration: '',
+  };
+
+  collatedInfo.apa2 = {
+    componentName: '',
+    componentUUID: '',
+    shortUUID: '',
+    dunePID: '',
+    productionSite: '',
+    configuration: '',
+  };
+
+  ///////////////////////
+  // APA 1 INFORMATION //
+  ///////////////////////
+  // Get the component record of the first Assembled APA
+  const apa1 = await Components.retrieve(apa1UUID);
+
+  // Add relevant information from this Assembled APA component record to the 'apa1' section of the collated information object
+  collatedInfo.apa1.componentName = apa1.data.componentName;
+  collatedInfo.apa1.componentUUID = apa1.componentUuid;
+  collatedInfo.apa1.shortUUID = apa1.shortUuid.toString();
+  collatedInfo.apa1.dunePID = apa1.data.dunePid;
+  collatedInfo.apa1.productionSite = utils.dictionary_locations[apa1.data.apaAssemblyLocation];
+  collatedInfo.apa1.configuration = apa1.data.apaConfiguration[0].toUpperCase() + apa1.data.apaConfiguration.slice(1);
+
+  ///////////////////////
+  // APA 2 INFORMATION //
+  ///////////////////////
+  // Get the component record of the second Assembled APA
+  const apa2 = await Components.retrieve(apa2UUID);
+
+  // Add relevant information from this Assembled APA component record to the 'apa2' section of the collated information object
+  collatedInfo.apa2.componentName = apa2.data.componentName;
+  collatedInfo.apa2.componentUUID = apa2.componentUuid;
+  collatedInfo.apa2.shortUUID = apa2.shortUuid.toString();
+  collatedInfo.apa2.dunePID = apa2.data.dunePid;
+  collatedInfo.apa2.productionSite = utils.dictionary_locations[apa2.data.apaAssemblyLocation];
+  collatedInfo.apa2.configuration = apa2.data.apaConfiguration[0].toUpperCase() + apa2.data.apaConfiguration.slice(1);
+
+  ///////////////////////
+
+  // Return the completed collated information object
+  return collatedInfo;
+}
+
+
 module.exports = {
-  collateInfo,
+  forExecSummary,
+  forHWDB,
 }

--- a/app/pug/component_hwdbInformation.pug
+++ b/app/pug/component_hwdbInformation.pug
@@ -1,0 +1,78 @@
+extend default
+
+block vars 
+  - const page_title = 'View APA HWDB Information';
+
+block extrascripts
+  block workscripts
+    script(src = '/pages/component_hwdbInformation.js')
+
+block content
+  .container-fluid
+    .vert-space-x2
+      h2 View APA HWDB Information
+
+    .vert-space-x2 
+      hr
+
+      .row 
+        .col-md-5 
+          h4 Select APA 1
+
+          .vert-space-x1 
+            p
+            | Enter the UUID of the doublet's first APA below.<br>
+            | Alternatively, take a picture of the APA's QR code 
+
+          .vert-space-x1 
+            #apa1uuidform
+
+        .col-md-5 
+          h4 Select APA 2
+
+          .vert-space-x1 
+            p
+            | Enter the UUID of the doublet's second APA below.<br>
+            | Alternatively, take a picture of the APA's QR code 
+
+          .vert-space-x1 
+            #apa2uuidform
+
+        .col-md-2
+          .vert-space-x2
+            input.form-control.spacer
+
+          .vert-space-x2
+            button.btn-primary.btn-lg#confirmButton Retrieve HWDB Information 
+
+    .vert-space-x2 
+      hr
+
+    .vert-space-x1 
+      .row 
+        .col-md-5
+          | <b>APA 1:</b>
+          textarea.form-control#apa1info(rows = 10)
+
+        .col-md-5
+          | <b>APA 2:</b>
+          textarea.form-control#apa2info(rows = 10)
+
+        .col-md-2
+
+      .row.vert-space-x1
+        .col-md-5
+          a#download_apa1info(onclick = 'DownloadInfo(1)', download = `APA1.json`, href = '') Download APA 1 Info
+
+          .vert-space-x1
+            a.button.btn.btn-primary(onclick = 'CopyInfoToClipboard(1)') Copy APA 1 Info to Clipboard
+
+        .col-md-5
+          a#download_apa2info(onclick = 'DownloadInfo(2)', download = `APA2.json`, href = '') Download APA 2 Info
+
+          .vert-space-x1
+            a.button.btn.btn-primary(onclick = 'CopyInfoToClipboard(2)') Copy APA 2 Info to Clipboard
+
+        .col-md-2
+
+    .vert-space-x2

--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -86,6 +86,9 @@ body(class = `deployment-${NODE_ENV}`)
                   +navlink(href = '/components/bulkQRCodes')
                     |      View Bulk QR Codes
 
+                li.nav-item
+                  +navlink(href = '/components/hwdbInformation')
+                    |      View HWDB Information
 
             li.nav-item
               +navlink(href = '/actions/list')

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -4,7 +4,7 @@ const ShortUUID = require('short-uuid');
 
 const Actions = require('../lib/Actions');
 const Components = require('../lib/Components');
-const Components_ExecSummary = require('../lib/Components_ExecSummary');
+const Components_CollateInfo = require('../lib/Components_CollateInfo');
 const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
 const permissions = require('../lib/permissions');
@@ -586,7 +586,7 @@ router.get('/component/:uuid/execSummary', permissions.checkPermission('componen
 
     // Retrieve the collated information about the APA - since this requires extracting specific field values from a number of DB records related to the APA ...
     // ... it is easier to collate this information through a single library function, rather than performing multiple library function calls from this route
-    let collatedInfo = await Components_ExecSummary.collateInfo(req.params.uuid);
+    let collatedInfo = await Components_CollateInfo.forExecSummary(req.params.uuid);
 
     // Render the interface page
     res.render('component_execSummary.pug', { collatedInfo });
@@ -828,6 +828,29 @@ router.get('/components/bulkQRCodes/:typeFormId/:firstNumber/:lastNumber', permi
   } catch (err) {
     logger.error(err);
     res.status(500).send(err.toString());
+  }
+});
+
+
+/// View information about two specified APAs comprising a single doublet, for use in the DUNE HWDB (client-side interface)
+router.get('/components/hwdbInformation', async function (req, res, next) {
+  // Render the interface page
+  res.render('component_hwdbInformation.pug');
+});
+
+
+/// View information about two  specified APAs comprising a single doublet, for use in the DUNE HWDB (query to server-side)
+router.get(['/json/components/hwdbInformation/:apa1uuid/:apa2uuid', '/api/components/hwdbInformation/:apa1uuid/:apa2uuid'], async function (req, res, next) {
+  try {
+    // Retrieve the collated information about the APAs - since this requires extracting specific field values from a number of DB records related to the APAs ...
+    // ... it is easier to collate this information through a single library function, rather than performing multiple library function calls from this route
+    let collatedInfo = await Components_CollateInfo.forHWDB(req.params.apa1uuid, req.params.apa2uuid);
+
+    // Return the information in JSON format
+    return res.status(200).json(collatedInfo);
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
   }
 });
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -41,6 +41,8 @@ module.exports = routes;
   /json/confirmShortUUID/:shortuuid
   /json/components/:typeFormId/list
   /json/components/boardCounts_byPartNumberAndLocation
+  /components/hwdbInformation
+  /json/components/hwdbInformation/:apa1uuid/:apa2uuid
 
   /action/:actionId
   /action/:actionId/edit
@@ -53,7 +55,7 @@ module.exports = routes;
   /actions/:typeFormId/list
   /json/action/:actionId
   /json/action
-  /json/action/:actionId/addImages
+  /json/action/:actionId/addImages/:imageType
   /json/action/:actionId/removeImage/:imageNumber
   /json/actions/:typeFormId/list
   /json/actions/allFromWorkflow/:workflowId

--- a/app/static/pages/component_hwdbInformation.js
+++ b/app/static/pages/component_hwdbInformation.js
@@ -1,0 +1,123 @@
+// Declare variables to hold the user-specified APA UUIDs
+let apa1Uuid = null;
+let apa2Uuid = null;
+
+// Run a specific function when the page is loaded
+window.addEventListener('load', renderSearchForms);
+
+
+// Function to run when the page is loaded
+async function renderSearchForms() {
+  // Create a Formio form consisting of a component UUID input box, and render it in the page elements called 'apa1uuidform' and 'apa2uuidform'
+  const componentUuidSchema = {
+    components: [{
+      type: 'ComponentUUID',
+      label: 'Component UUID',
+      key: 'componentUuid',
+      input: true,
+      hideLabel: true,
+    }],
+  }
+
+  const apa1UuidForm = await Formio.createForm(document.getElementById('apa1uuidform'), componentUuidSchema);
+  const apa2UuidForm = await Formio.createForm(document.getElementById('apa2uuidform'), componentUuidSchema);
+
+  // When the content of either component UUID input box is changed, get the text string from the box
+  // If the string is consistent with a valid UUID, set the value of the corresponding parameter
+  apa1UuidForm.on('change', function () {
+    if (apa1UuidForm.isValid()) {
+      const apa1UuidInput = apa1UuidForm.submission.data.componentUuid;
+
+      if (apa1UuidInput && apa1UuidInput.length === 36) apa1Uuid = apa1UuidInput;
+    }
+  });
+
+  apa2UuidForm.on('change', function () {
+    if (apa2UuidForm.isValid()) {
+      const apa2UuidInput = apa2UuidForm.submission.data.componentUuid;
+
+      if (apa2UuidInput && apa2UuidInput.length === 36) apa2Uuid = apa2UuidInput;
+    }
+  });
+
+  // When the confirmation button is pressed, perform the information retrieval using the appropriate jQuery 'ajax' call and the current values of the parameters
+  // Additionally, disable the confirmation button while the current retrieval is being performed
+  $('#confirmButton').on('click', function () {
+    $('#confirmButton').prop('disabled', true);
+
+    if (apa1Uuid && apa2Uuid) {
+      $.ajax({
+        contentType: 'application/json',
+        method: 'GET',
+        url: `/json/components/hwdbInformation/${apa1Uuid}/${apa2Uuid}`,
+        dataType: 'json',
+        success: postSuccess,
+      }).fail(postFail);
+    }
+  });
+}
+
+
+// Function to run for a successful retrieval query
+function postSuccess(result) {
+  // Make sure that the page elements where the information will be displayed are all empty
+  $('#apa1info').empty();
+  $('#apa2info').empty();
+
+  // Show the APA and doublet information in their corresponding page elements
+  $('#apa1info').val(JSON.stringify(result.apa1, null, 2));
+  $('#apa2info').val(JSON.stringify(result.apa2, null, 2));
+
+  // Re-enable the confirmation button for the next retrieval
+  $('#confirmButton').prop('disabled', false);
+};
+
+
+// Function to run for a failed retrieval query
+function postFail(result, statusCode, statusMsg) {
+  // If the query result contains a response message, display it, and if not, display any status message and error code instead
+  if (result.responseText) {
+    console.log('POSTFAIL: ', result.responseText);
+  } else {
+    console.log('POSTFAIL: ', `${statusMsg} (${statusCode})`);
+  }
+
+  // Re-enable the confirmation button for the next retrieval
+  $('#confirmButton').prop('disabled', false);
+};
+
+
+// When any of the 'Download Info' links are clicked, write the contents of the corresponding JSON schema box to a file and then download the file
+function DownloadInfo(selector) {
+  let info = null;
+  let info_obj = null;
+
+  if (selector === 1) {
+    info = $('#apa1info').val();
+    info_obj = window.URL.createObjectURL(new Blob([info], { type: 'application/JSON' }));
+
+    $('#download_apa1info').attr('href', info_obj);
+  } else if (selector === 2) {
+    info = $('#apa2info').val();
+    info_obj = window.URL.createObjectURL(new Blob([info], { type: 'application/JSON' }));
+
+    $('#download_apa2info').attr('href', info_obj);
+  }
+}
+
+
+// When any of the 'Copy Info to Clipboard' buttons are pressed, copy the contents of the corresponding JSON schema box to the device's clipboard
+function CopyInfoToClipboard(selector) {
+  if (selector === 1) {
+    navigator.clipboard.writeText($('#apa1info').val()).then({
+    }, function (err) {
+      console.error('Error - could not copy APA 1 info', err);
+    })
+  } else if (selector === 2) {
+    navigator.clipboard.writeText($('#apa2info').val()).then({
+    }, function (err) {
+      console.error('Error - could not copy APA 2 info', err);
+    })
+  }
+};
+


### PR DESCRIPTION
- the DUNE HWDB will eventually require data from the APA DB relating to the pairs of Assembled APAs that form each doublet in the detector
- added new library function to collate data about two specified APAs and return it in a preset JSON format (still to be determined)
- added new interface and API routes, and updated routes index
- new interface page, linked in the sidebar - the user will specify the UUIDs of two APAs, and the DB will return the preset JSON formatted information
- users may also copy each APA's returned information to their device's clipboard, or download the information directly as a JSON file