### PR TITLE
Bug Fixes for Recent Changes ...

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -269,9 +269,10 @@ async function updateComponentLocations_viaActions(actionTypeFormId) {
   // Project only the fields that will be needed for the later steps
   aggregation_stages.push({
     $project: {
-      'componentUuid': true,
-      'data': true,
-      'validity': true,
+      actionId: true,
+      componentUuid: true,
+      data: true,
+      validity: true,
     }
   });
 
@@ -283,6 +284,7 @@ async function updateComponentLocations_viaActions(actionTypeFormId) {
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
+      actionId: { '$first': '$actionId' },
       componentUuid: { '$first': '$componentUuid' },
       data: { '$first': '$data' },
       validity: { '$first': '$validity' },
@@ -301,7 +303,7 @@ async function updateComponentLocations_viaActions(actionTypeFormId) {
 
     if (board.reception != null) {
       // Get the latest version of the MOST RECENT 'Factory Board Rejection' action performed on the board
-      match_condition = {
+      const match_condition = {
         typeFormId: 'FactoryBoardRejection',
         componentUuid: board.componentUuid,
       }
@@ -311,21 +313,7 @@ async function updateComponentLocations_viaActions(actionTypeFormId) {
 
       // If the most recent rejection action has a disposition of 'rejected' ...
       if (mostRecentRejectionAction.data.disposition === 'rejected') {
-        // Set up a 'matching condition' object containing the component UUID (remembering that the UUID has to be of 'MUUID' type, not a string)
-        const componentUuid = board.componentUuid;
-        let match_condition = { componentUuid };
-
-        if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
-
-        match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
-
-        // Set the desired reception information for the geometry board:
-        // - location = 'rejected'
-        // - date = the date on which the Factory Board Rejection action was performed (or last edited)
-        // - detail = a string containing some additional information about why the board was rejected
-        const newBoardLocation = 'rejected';
-        const rejectionLocation = utils.dictionary_locations[mostRecentRejectionAction.data.boardRejectionLocation]
-        const rejectionDate = mostRecentRejectionAction.validity.startDate.toISOString().slice(0, 10);
+        const rejectionLocation = utils.dictionary_locations[mostRecentRejectionAction.data.boardRejectionLocation];
         let rejectionReason = '';
 
         if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.step) { rejectionReason = 'Step Failure' }
@@ -341,24 +329,7 @@ async function updateComponentLocations_viaActions(actionTypeFormId) {
         else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.removedFromApa) { rejectionReason = 'Removed from APA' }
         else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.other) { rejectionReason = 'Unspecified Reason' }
 
-        const rejectionDetail = `[${rejectionLocation} - ${rejectionReason}]`;
-
-        // Update the reception information of ALL records with the matching component UUID (i.e. all versions of the component in question)
-        const result = await db.collection('components')
-          .updateMany(
-            match_condition,
-            [
-              {
-                $set: {
-                  'reception.location': newBoardLocation,
-                  'reception.date': rejectionDate,
-                  'reception.detail': rejectionDetail,
-                }
-              },
-            ]
-          )
-
-        if (result.ok === 0) throw new Error(`Admin_Functions::updateComponentLocations_viaActions() - failed to update the component records!`);
+        const result = await Components.updateLocation(mostRecentRejectionAction.componentUuid, 'rejected', mostRecentRejectionAction.validity.startDate.toISOString().slice(0, 10), `[${rejectionLocation} - ${rejectionReason}]`);
       }
     } else {
       logger.info(action.componentUuid, 'Component reception object is null!');

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -665,6 +665,8 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
 
     if (acceptanceStatus === 'rejected') {
       matchConditions['reception.location'] = acceptanceStatus;
+    } else if (acceptanceStatus === 'accepted') {
+      matchConditions['reception.location'] = { $not: { $eq: 'rejected' } };
     }
 
     aggregation_stages.push({ $match: matchConditions });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       NODE_ENV: development
       APP_PORT: 12313
       BASE_URL: http://localhost:12313
-      DATABASE_URL: mongodb://db:27017/dunedb
+      DATABASE_URL: mongodb://db:27017/dunedb?directConnection=true
       SESSION_SECRET: abcdefghijklmnopqrstuvwxyz
       M2M_SECRET: abcdefghijklmnopqrstuvwxyz
       AUTH0_CLIENT_ID: g36o06k2gII5s7GSJ3ApRU4E1mOkk0Oz


### PR DESCRIPTION
- board acceptance status filter was not being applied correctly when set to 'accepted' in the Search for Components by Type and Part Number
- needed to project the 'actionId' field in the recently added Admin Utility ... otherwise the subsequent grouping stage wouldn't work (since it groups by actionId)
- added 'directConnection' argument to internal DB URL for Development instance ... apparently NodeJS 17+ works better with this set, to avoid localhost server timeouts (shouldn't make any difference to OKD deployments)

Also changed the new Admin Utility to use the already-existing 'updateLocations' component library function ... this is a safer option than doing it explicitly in the utility, since the function has additional safety and sanity checks built in already.