### PR TITLE
Adding exception to Admin Utility for US APA 1 boards ...

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -333,7 +333,12 @@ async function updateComponentLocations_viaActions(actionTypeFormId) {
         //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.removedFromApa) { rejectionReason = 'Removed from APA' }
         else if ((mostRecentRejectionAction.data.reasonForRejectionFromInventory.other) || (mostRecentRejectionAction.data.reasonForRejectionFromInventory.otherProvideDetailsInTheCommentsBoxOnTheRight)) {
           rejectionReason = 'Unspecified Reason';
-          boardNeedsUpdating = true;
+
+          if (board.reception.detail !== '[Chicago - Removed from APA]') {
+            boardNeedsUpdating = true;
+          } else {
+            boardNeedsUpdating = false;
+          }
         }
 
         if (boardNeedsUpdating) {


### PR DESCRIPTION
- these boards were previously rejected in 2024 via rejection actions with a reason of 'other' - and so they would be caught by the utility and have their reception details set to 'Unspecified Reason'
- however, Brian recently changed all such boards to have reception detail of 'Chicago - Removed from APA', which is the correct one ... don't want the utility to overwrite that