### PR TITLE
Miscellaneous Changes

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -42,11 +42,24 @@ async function save(input, req) {
 
   if (!typeForm) throw new Error(`Actions:save() - the specified 'input.typeFormId' (${input.typeFormId}) does not match a known action type form!`);
 
-  // Check that the person performing or editing the action is permitted to do so ... this is an additional security check for specific action types, beyond a simple global 'permissions' check
-  // It is designed to make sure that these actions are not being performed by the logged-in user on behalf of someone else, without the latter's knowledge or permission 
+  // Some action types should be submitted only by the APA Factory Leads - these are typically the most important and/or highest level QA checks and signoffs
+  // Check that the submitter (i.e. the currently logged-in user) is the same as the person who's name is being used for the QA signoff ... if not, do not allow the action to be submitted
+  // Since the list of personnel for QA signoffs is always only the APA Factory Leads, this check should restrict such actions to only be submittable by leads WHEN LOGGED IN AS THEMSELVES
   if (input.typeFormId === 'AssembledAPAQACheck') {
-    if (!(utils.listIDs_apaFactoryLeads.includes(req.user.user_id))) {
-      throw new Error(`Actions:save() - you are not permitted to perform or edit this type of action ... it can only be done by one of the following personnel: ${Object.values(utils.dictionary_apaFactoryLeads).join(', ')}`);
+    if (req.user.displayName !== utils.dictionary_apaFactoryLeads[input.data.personSigningOff]) {
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off the QA Checks on behalf of someone else (${utils.dictionary_apaFactoryLeads[input.data.personSigningOff]}) - this is not permitted!`);
+    }
+  }
+
+  if (input.typeFormId === 'CompletedAPAQCChecklist') {
+    if (req.user.displayName !== utils.dictionary_apaFactoryLeads[input.data.personSigningOff]) {
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off the APA Final Assembly on behalf of someone else (${utils.dictionary_apaFactoryLeads[input.data.personSigningOff]}) - this is not permitted!`);
+    }
+  }
+
+  if (input.typeFormId === 'prep_mesh_panel_install') {
+    if ((req.user.displayName !== utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]) && (input.data.actionComplete)) {
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off the Installation QA and complete this action on behalf of someone else (${utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]}) - this is not permitted!`);
     }
   }
 

--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -6,7 +6,6 @@ const Components = require('./Components');
 const { db } = require('./db');
 const dbLock = require('./dbLock');
 const Forms = require('./Forms');
-const logger = require('./logger');
 const permissions = require('./permissions');
 const utils = require('./utils');
 

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -119,7 +119,7 @@ async function forExecSummary(componentUUID) {
       winding_numberOfReplacedWires: 0,
       winding_numberOfTensionAlarms: 0,
       soldering_actionID: '',
-      soldering_numberOfBadSolders: 0,
+      soldering_numberOfReworkedSolders: 0,
       tensions_actionID: '',
       tensions_location: '[no information found]',
       tensions_system: '[no information found]',
@@ -574,7 +574,7 @@ async function forExecSummary(componentUUID) {
       .toArray();
 
     if (results.length > 0) {
-      let numberOfBadSolders = 0;
+      let numberOfReworkedSolders = 0;
 
       for (let i = 0; i < results[0].badSolderJoints.length; i++) {
         let singleJoint_solderPads = results[0].badSolderJoints[i].solderPad;
@@ -583,11 +583,11 @@ async function forExecSummary(componentUUID) {
           singleJoint_solderPads = `${singleJoint_solderPads}`;
         }
 
-        numberOfBadSolders += singleJoint_solderPads.split(',').length;
+        numberOfReworkedSolders += singleJoint_solderPads.split(',').length;
       }
 
       collatedInfo[layers[i]].soldering_actionID = results[0].actionId;
-      collatedInfo[layers[i]].soldering_numberOfBadSolders = numberOfBadSolders;
+      collatedInfo[layers[i]].soldering_numberOfReworkedSolders = numberOfReworkedSolders;
     }
 
     aggregation_stages = [];

--- a/app/lib/Search_GeoBoards.js
+++ b/app/lib/Search_GeoBoards.js
@@ -1,6 +1,5 @@
 const MUUID = require('uuid-mongodb');
 
-const Actions = require('./Actions');
 const Components = require('./Components');
 const { db } = require('./db');
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -104,7 +104,7 @@ module.exports = {
     slawekKubecki: 'Slawek Kubecki',
     abbieLee: 'Abbie Lee',
     nigelLightbown: 'Nigel Lightbown',
-    yinruiLui: 'Yinrui Lui',
+    yinruiLui: 'Yinrui Liu',    // Key is misspelt (sorry Yinrui!), but correcting it would also require finding and changing any records where it has been used ... which is extremely difficult
     albertoMarchionni: 'Alberto Marchionni',
     grahamMitchell: 'Graham Mitchell',
     jamesMcNally: 'James McNally',
@@ -221,19 +221,4 @@ module.exports = {
     stephenSumner: 'Stephen Sumner',
     sotirisVlachos: 'Sotiris Vlachos',
   },
-
-  // A list of Auth0 user IDs (across all DB instances that they have accounts on) for the personnel in the 'dictionary_apaFactoryLeads' dictionary above
-  // Also included are the current DB admins, so they can have access for testing and debugging any issues
-  listIDs_apaFactoryLeads: [
-    'auth0|64567419151ddf91659e4f3a',                                                                     // Ed Blucher (Production)
-    'auth0|66766bf5c413c4d216ce3066',                                                                     // Dave Brown (Production)
-    'auth0|6467c2cd7446c74d64aa82f6',                                                                     // Alberto Marchionni (Production)
-    'auth0|6283d0da53955b00670866fa',                                                                     // Gwenn Mouster (Production)
-    'auth0|6543ac95a5b46c922b92fc5b',                                                                     // Radosav Pantelic (Production)
-    'auth0|62cc5cd824d68a7b806288dc',                                                                     // Daniel Salisbury (Production)
-    'auth0|660d6fdc89987529cfbb11d9',                                                                     // Stephen Sumner (Production)
-    'auth0|6419d07e67b64413cd0679f5',                                                                     // Sotiris Vlachos (Production)
-    'auth0|62c1f26dd68f53308071c91a', 'auth0|6247211d7ca173006f55b951',                                   // Brian Rebel (Staging, Production)
-    'auth0|62366229e644f4006ff1b144', 'auth0|6236627bcd1229006a1e5c54', 'auth0|623662b39e63f500683a210f', // Krish Majumdar (Staging, Production, Development)
-  ],
 }

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -883,26 +883,6 @@ router.get(['/json/component/:uuid', '/api/component/:uuid'], permissions.checkP
 });
 
 
-/// Retrieve an existing component record via its type form ID and type record number
-router.get(['/json/component/:typeFormId/:typeRecordNumber', '/api/component/:typeFormId/:typeRecordNumber'], permissions.checkPermissionJson('components:view'), async function (req, res, next) {
-  try {
-    // Retrieve a reduced instance of the component record corresponding to the specified type form ID and type record number
-    const componentsList = await Search_OtherComponents.componentsByTypeAndNumber(req.params.typeFormId, req.params.typeRecordNumber);
-
-    // If at least one record has been returned, return it in JSON format ... otherwise, return 'null' explicitly (also in JSON format)
-    if (componentsList.length > 0) {
-      return res.status(200).json(componentsList[0]);
-    } else {
-      return res.status(200).json(null);
-    }
-
-  } catch (err) {
-    logger.info({ route: req.route.path }, err.message);
-    res.status(500).json({ error: err.toString() });
-  }
-});
-
-
 /// Create a new component or edit an existing component record
 router.post(['/json/component', '/api/component'], permissions.checkPermissionJson('components:edit'), async function (req, res, next) {
   try {

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -56,7 +56,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       for (let entry of actions) {
         if (entry.typeFormId !== 'BoardShipment') {
           entry.data = {};
-          entry.data.checksPassed = 'No';
+          entry.data.checksPassed = '[n.a.]';
 
           const record = await Actions.retrieve(entry.actionId);
 
@@ -65,24 +65,48 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
 
             if ((record.data.nonConformingDisposition === 'boardIsConformant') || (record.data.nonConformingDisposition === 'useAsIs')) {
               entry.data.checksPassed = 'Yes';
+            } else if ((record.data.nonConformingDisposition === 'toBeDetermined') || (record.data.nonConformingDisposition === '')) {
+              entry.data.checksPassed = 'Unknown';
+            } else {
+              entry.data.checksPassed = 'No';
             }
           } else if (entry.typeFormId === 'BoardToothStripAttachment') {
             entry.data.originOfShipment = record.data.locationWorkPerformed;
 
-            if ((record.data.qcBoardDamage === 'no') && (record.data.qcGapWithBoard === 'no') && (record.data.qcToothStripDamage === 'no') && (record.data.qcStripFlushWithBoard === 'yes') && (record.data.qcCorrectEpoxyApplication === 'yes') && (record.data.qcSolderPadAlignment === 'yes')) {
-              entry.data.checksPassed = 'Yes';
-            }
-          } else if (entry.typeFormId === 'BoardMetrology') {
-            entry.data.originOfShipment = record.data.location;
+            let qcCheck_names = ['qcBoardDamage', 'qcGapWithBoard', 'qcToothStripDamage', 'qcStripFlushWithBoard', 'qcCorrectEpoxyApplication', 'qcSolderPadAlignment'];
+            let qcCheck_passValues = ['no', 'no', 'no', 'yes', 'yes', 'yes'];
+            let numberOfPassedChecks = 0;
+            let numberOfFailedChecks = 0;
+            let numberOfMissingChecks = 0;
 
-            if ((record.data.featurePositionChecks === 'passed') && (record.data.boardThicknessCheck === 'passed')) {
-              entry.data.checksPassed = 'Yes';
+            for (const [index, qcCheck] of qcCheck_names.entries()) {
+              if (record.data.hasOwnProperty(qcCheck)) {
+                if (record.data[qcCheck] === qcCheck_passValues[index]) {
+                  numberOfPassedChecks += 1;
+                } else {
+                  numberOfFailedChecks += 1;
+                }
+              } else {
+                numberOfMissingChecks += 1;
+              }
+            }
+
+            if (numberOfFailedChecks === 0) {
+              if (numberOfMissingChecks === 0) {
+                entry.data.checksPassed = 'Yes';
+              } else {
+                entry.data.checksPassed = 'Yes (partial)';
+              }
+            } else {
+              entry.data.checksPassed = 'No';
             }
           } else if (entry.typeFormId === 'FactoryBoardRejection') {
             entry.data.originOfShipment = record.data.boardRejectionLocation;
 
             if ((record.data.disposition === 'remediated') || (record.data.disposition === 'useAsIs')) {
               entry.data.checksPassed = 'Yes';
+            } else {
+              entry.data.checksPassed = 'No';
             }
           }
         }
@@ -99,7 +123,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     }
 
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
-    // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only two workflow types, so we can do this explicitly)
+    // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only a handful of workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
     const list_workflowComponents = ['AssembledAPA', 'APAFrame', 'APAShipment'];
     const workflowComponent = list_workflowComponents.includes(component.formId);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -34,7 +34,6 @@ module.exports = routes;
   /components/bulkQRCodes
   /components/bulkQRCodes/:typeFormId/:firstNumber/:lastNumber
   /json/component/:uuid
-  /json/component/:typeFormId/:typeRecordNumber
   /json/component
   /json/componentBatch
   /json/newComponentUUID

--- a/app/static/pages/component_execSummary.js
+++ b/app/static/pages/component_execSummary.js
@@ -1626,17 +1626,17 @@ function SetEntry_wireLayer(layer, layerInfo) {
                     {
                       "components": [
                         {
-                          "label": "# Bad Solders",
+                          "label": "# Reworked Solders",
                           "mask": false,
                           "disabled": true,
                           "tableView": false,
                           "delimiter": false,
                           "requireDecimal": false,
                           "inputFormat": "plain",
-                          "key": "badSolders",
+                          "key": "reworkedSolders",
                           "type": "number",
                           "input": true,
-                          "defaultValue": layerInfo.soldering_numberOfBadSolders
+                          "defaultValue": layerInfo.soldering_numberOfReworkedSolders
                         }
                       ],
                       "size": "sm",


### PR DESCRIPTION
Removing unused component route
- the '/json/component/{typeFormId}/{typeRecordNumber}' route is no longer used - was previously only used by the 'GetComponent_byTypeRecordNumber' common M2M function, but that now uses the '/json/search/componentsByTypeAndNumber/{typeFormId}/{typeRecordNumber}' route
- the latter is already used by both the API and interface for searching for a component by type and record number, so it should definitely be kept ... no point in having another route that does the same thing only for the M2M side

Small change to APA Executive Summaries
- changed 'bad solders' to 'reworked solders', both in the collation function and in the summary document itself
- based on email discussion with Eric on 2025-12-04

Removing unneeded imports from library files
- actually spotted these a while ago, but kept on forgetting to clean them out

Stronger security checks on certain actions
- applicable to Completed APA QA Checklist, Assembled APA QA Check and Mesh Panel Installation actions
- when submitting these action types, the DB will now compare the name of the submitter (from their Auth0 account) with the name given in the action's QA signoff field
- if they do not match, the action will NOT be submitted - and an error will be displayed (Mesh Installation actions are checked when being completed, others are always checked regardless of completion)
- this should prevent such actions from being submitted and completed on behalf of someone other than the submitter
- also fixed a small typo in one of the technicians' displayed names (cannot fix the dictionary key, since that would require finding and correcting all records where the key was used ... which we don't actually know)

Fix for older Tooth Strip Attachment actions
- the older tooth strip attachment actions are missing two QC checks - probably added relatively recently, but the records were not updated
- this causes them to be shown as 'failed' in the geometry board history table - since this checks for the simultaneous existence and passing of all 6 expected QC checks
- changed component route so that it now checks for existence and passing separately ... and will now show a partial pass if any checks are missing (but the remaining ones all pass)
- similarly, some older visual inspection actions have an empty string for the disposition - route now also accounts for this