### PR TITLE
More Miscellaneous Changes

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -379,6 +379,7 @@ async function list(match_condition, options) {
       componentUuid: true,
       workflowId: true,
       validity: true,
+      data: true,
     }
   })
 
@@ -396,6 +397,7 @@ async function list(match_condition, options) {
       componentUuid: { '$first': '$componentUuid' },
       workflowId: { '$first': '$workflowId' },
       lastEditDate: { '$first': '$validity.startDate' },
+      data: { '$first': '$data' },
     },
   });
 

--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -105,6 +105,46 @@ async function save(input, req) {
     }
   }
 
+  // NCR actions each always contain (4) arrays of damaged, misplaced, missing and shorted wires ...
+  // ... however, depending on the specific user input, any number of them may not contain any information
+  // Formio doesn't like this, and can sometimes write a partial (single) non-empty entry to any unused array ... which can lead to the APA Executive Summary not being created correctly
+  // For these types of action, check if each array contains a single partial entry, and if so replace it with a correct and complete one
+  const correctedEntry = {
+    wireLayer: '',
+    readoutChannel: null,
+    headBoardAndPad: '',
+    coldElectronicsChannel: '',
+    textField: '',
+    offlineChannel: '',
+    endPointsForMissingSegments: '',
+  };
+
+  if (newRecord.typeFormId === 'APANonConformance') {
+    if (newRecord.data.damagedWireGrid.length === 1) {
+      if (!newRecord.data.damagedWireGrid[0].hasOwnProperty('wireLayer')) {
+        newRecord.data.damagedWireGrid[0] = correctedEntry;
+      }
+    }
+
+    if (newRecord.data.misplacedGrid.length === 1) {
+      if (!newRecord.data.misplacedGrid[0].hasOwnProperty('wireLayer')) {
+        newRecord.data.misplacedGrid[0] = correctedEntry;
+      }
+    }
+
+    if (newRecord.data.dataGrid.length === 1) {
+      if (!newRecord.data.dataGrid[0].hasOwnProperty('wireLayer')) {
+        newRecord.data.dataGrid[0] = correctedEntry;
+      }
+    }
+
+    if (newRecord.data.shortedGrid.length === 1) {
+      if (!newRecord.data.shortedGrid[0].hasOwnProperty('wireLayer')) {
+        newRecord.data.shortedGrid[0] = correctedEntry;
+      }
+    }
+  }
+
   // Generate and add an 'insertion' field to the new record
   newRecord.insertion = commonSchema.insertion(req);
 

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -675,9 +675,9 @@ async function forExecSummary(componentUUID) {
       result.types = typesString.substring(0, typesString.length - 2);
 
       if (result.disposition === 'useAsIs') {
-        if ((result.missingWireData[0].wireLayer !== '') || (result.shortedWireData[0].wireLayer !== '')) {
-          let missingShortedWires = [];
+        let missingShortedWires = [];
 
+        if (result.missingWireData[0].hasOwnProperty('wireLayer')) {
           if (result.missingWireData[0].wireLayer !== '') {
             for (const missingWire of result.missingWireData) {
               missingShortedWires.push({
@@ -690,7 +690,9 @@ async function forExecSummary(componentUUID) {
               })
             }
           }
+        }
 
+        if (result.shortedWireData[0].hasOwnProperty('wireLayer')) {
           if (result.shortedWireData[0].wireLayer !== '') {
             for (const shortedWire of result.shortedWireData) {
               missingShortedWires.push({
@@ -703,7 +705,9 @@ async function forExecSummary(componentUUID) {
               })
             }
           }
+        }
 
+        if (missingShortedWires.length > 0) {
           result.missingShortedWires = missingShortedWires;
 
           delete result.nonConf_type;

--- a/app/pug/action_listOfSingleType.pug
+++ b/app/pug/action_listOfSingleType.pug
@@ -26,8 +26,13 @@ block content
         thead
           tr
             th.col-md-2 Action ID
-            th.col-md-3 Performed on Component:
-            th.col-md-1
+
+            if actionTypeForm.formId == 'APANonConformance'
+              th.col-md-2 Performed on Component:
+              th.col-md-5 NCR Title 
+            else 
+              th.col-md-4 Performed on Component:
+              th.col-md-3 
             th.col-md-2 Last Performed On:
             th.col-md-1
 
@@ -41,7 +46,9 @@ block content
                   a(href = `/action/${action.actionId}`) #{action.actionId}
                 td
                   a(href = `/component/${uuid}`) #{action.componentName}
-                td
+
+                td #{action.additionalInformation} 
+
                 td
                   +dateTimeFormat(action.lastEditDate)
                 td

--- a/app/pug/common.pug
+++ b/app/pug/common.pug
@@ -11,15 +11,17 @@ block pugscripts
   //- Return the ordinal of a given number when provided with the remainders of that number divided by 10 and 100
   - function get_ordinal(r10, r100) { if (r10 === 1 && r100 !== 100) return 'st'; if (r10 === 2 && r100 !== 12) return 'nd'; if (r10 === 3 && r100 !== 13) return 'rd'; return 'th'; }
 
+  //- Return a short-format month string (with an ending period) when provided with the number of the month
+  - const months = ['Jan.', 'Feb.', 'March', 'April', 'May', 'June', 'July', 'Aug.', 'Sept.', 'Oct.', 'Nov.', 'Dec.']
+  - function get_month(number) { return months[number]; }
+
 mixin dateTimeFormat(date)
   - const fullDate = new Date(date);
-  - const ordinal = get_ordinal(fullDate.getDate() % 10, fullDate.getDate() % 100);
-  span.date(data - date = date) #{`${fullDate.toLocaleString('default', { month: 'long' })} ${fullDate.getDate()}${ordinal} ${fullDate.getFullYear()}, ${fullDate.toLocaleTimeString()}`}
+  span.date(data - date = date) #{`${fullDate.getDate()}${get_ordinal(fullDate.getDate() % 10, fullDate.getDate() % 100)} ${get_month(fullDate.getMonth())} ${fullDate.getFullYear()}, ${fullDate.toLocaleTimeString('en-GB')}`}
 
 mixin dateFormat(date)
   - const fullDate = new Date(date);
-  - const ordinal = get_ordinal(fullDate.getDate() % 10, fullDate.getDate() % 100);
-  span.date(data - date = date) #{`${fullDate.toLocaleString('default', { month: 'long' })} ${fullDate.getDate()}${ordinal} ${fullDate.getFullYear()}`}
+  span.date(data - date = date) #{`${fullDate.getDate()}${get_ordinal(fullDate.getDate() % 10, fullDate.getDate() % 100)} ${get_month(fullDate.getMonth())} ${fullDate.getFullYear()}`}
 
 mixin arrayFormat(array)
   span #{JSON.stringify(array).replace(/["\[\]]/g, '').replace(/,/g, ', ')}

--- a/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
+++ b/app/pug/search_geoBoardsByVisInspectOrOrderNumber.pug
@@ -45,13 +45,11 @@ block content
           .vert-space-x1 
             select.form-control#dispositionSelection
               option(value = '')          
-              option(value = 'useAsIs') Use As Is 
-              option(value = 'repair') Repair 
-              option(value = 'return') Return 
-              option(value = 'scrap') Scrap 
-              option(value = 'toBeDetermined') To be determined 
               option(value = 'boardIsConformant') Board Is Conformant
-
+              option(value = 'useAsIs') Use As Is 
+              option(value = 'return') Return 
+              option(value = 'toBeDetermined') To Be Determined 
+              
           .vert-space-x2
             button.btn-primary.btn-lg#confirmButton_disposition Search by Disposition
 

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -388,6 +388,16 @@ router.get('/actions/:typeFormId/list', permissions.checkPermission('actions:vie
       }
     }
 
+    // For certain action types, it is useful to display some extra information
+    // Add whatever information is relevant to each action record (but using the same generic field name regardless of what the information actually is)
+    if (actionTypeForm.formId == 'APANonConformance') {
+      for (let ncrAction of actions) {
+        ncrAction.additionalInformation = ncrAction.data.nonConformanceTitle;
+      }
+    } else {
+      for (let action of actions) { action.additionalInformation = ''; }
+    }
+
     const workflowAction = list_workflowActions.includes(actionTypeForm.formName);
 
     // Render the interface page


### PR DESCRIPTION
Removing now unused visual inspection dispositions from search
- following on from changes made in previous commits

Adding NCR title to interface display
- when listing NCR actions (on both APAs and mesh panels), the NCR title will now be displayed
- other action types remain unchanged - with an empty column displayed
- code framework can be extended to show additional information for any other action types in the future (as with component types)
- also adjusted displayed dates and times to international standard and for better display (shortened month strings)

Fixes for bugged NCR actions
- for some reason, Formio can sometimes (but not always) write an incomplete entry to any number of the wire data grids in NCR actions
- might be related to whether the user selects and deselects the corresponding checkbox during data input, but not completely sure of the cause
- applied two changes to the code in order to mitigate the resulting crash when attempting to set up the APA Executive Summary
- when saving the NCR action, the DB will now check to see if there are any incomplete entries in the grids, and correct them if found
- when setting up the Exec. Summary, the DB will now check to see if the 'wireLayer' field exists in the wire grids, and only attempt to display them if so