### PR TITLE
New Admin Utility for Cleaning Up Component Records

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -1,4 +1,3 @@
-const Binary = require('mongodb').Binary;
 const MUUID = require('uuid-mongodb');
 
 const Actions = require('./Actions');
@@ -8,354 +7,64 @@ const logger = require('../lib/logger');
 const utils = require('./utils');
 
 
-async function setComponentNames(typeFormId) {
-  // Retrieve a list of component UUIDs corresponding to all components with 'formId' matching the specified component type form ID
-  let aggregation_stages = [];
+async function cleanComponentRecords(typeFormId) {
+  let deleteCondition = null;
 
-  aggregation_stages.push({ $match: { formId: typeFormId } });
-  aggregation_stages.push({ $project: { componentUuid: true } });
+  if (typeFormId === 'ALL_COMPONENTS') {
+    deleteCondition = { $unset: { 'data.name': "" } };
+  } else if (typeFormId === 'APAFrame') {
+    deleteCondition = { $unset: { 'data.frameNumber': "" } };
+  } else if (typeFormId === 'AssembledAPA') {
+    deleteCondition = { $unset: { 'data.apaNumberAtLocation': "" } };
+  } else if (typeFormId === 'DWA') {
+    deleteCondition = { $unset: { 'data.dwaNumber': "" } };
+  } else if (typeFormId === 'DWAPDB') {
+    deleteCondition = { $unset: { 'data.pdbNumber': "" } };
+  }
 
-  let uuids = await db.collection('components')
-    .aggregate(aggregation_stages)
-    .toArray();
+  const matchCondition = (typeFormId === 'ALL') ? {} : { formId: typeFormId };
 
-  // For each retrieved UUID ...
-  for (let uuid of uuids) {
-    // Get the full component record corresponding to the UUID, and construct the component name and DUNE PID
-    const component = await Components.retrieve(uuid.componentUuid);
-    const typeFormName = component.formName;
-    const data = component.data;
-    const typeRecordNumber = String(data.typeRecordNumber).padStart(5, '0');
-    const validityStartDate = (typeof component.validity.startDate === 'string') ? component.validity.startDate : component.validity.startDate.toISOString();
+  const result = await db.collection('components')
+    .updateMany(
+      matchCondition,
+      deleteCondition,
+    )
 
-    let componentName = '';
-    let dunePid = '';
+  if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentRecords() - failed to delete fields from the component records!`);
 
-    if (typeFormId === 'APAFrame') {
-      let pidSuffix = '';
+  return typeFormId;
+}
 
-      if (data.frameProductionLocation === 'dsm') {
-        componentName = `APA Frame ${typeRecordNumber}-UK`;
-        pidSuffix = 'UK106-010000';
-      } else if (data.frameProductionLocation === 'wisconsin') {
-        componentName = `APA Frame ${typeRecordNumber}-US`;
-        pidSuffix = 'US200-010000';
-      }
 
-      dunePid = `D00300200001-${typeRecordNumber}-${pidSuffix}`;
-    } else if (typeFormId === 'APAShippingFrame') {
-      let pidSuffix = '';
+// NOT WORKING ... KEEPS GIVING A 'MongoNetworkTimeoutError: connection <monitor> to 172.19.0.2:27017 timed out' ERROR
+// Might be due to querying too many (i.e. all!) action records ... works fine with a smaller number (specifying a single action type)
+async function addComponentInfoToActionRecords() {
+  db.collection('actions')
+    .find({})
+    .forEach(async function (actionRecord) {
+      const componentRecord = await Components.retrieve(actionRecord.componentUuid);
+      const componentName = (componentRecord) ? componentRecord.data.componentName : '[no component record found!]';
+      const componentTypeFormId = (componentRecord) ? componentRecord.formId : '[no component record found!]';
+      const componentTypeFormName = (componentRecord) ? componentRecord.formName : '[no component record found!]';
 
-      if (data.asfLocation === 'chicago') {
-        componentName = `ASF ${typeRecordNumber}-US`;
-        pidSuffix = 'US175-010000';
-      } else if (data.asfLocation === 'daresbury') {
-        componentName = `ASF ${typeRecordNumber}-UK`;
-        pidSuffix = 'UK106-010000';
-      } else if (data.asfLocation === 'wisconsin') {
-        componentName = `ASF ${typeRecordNumber}-US`;
-        pidSuffix = 'US200-010000';
-      }
-
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-${pidSuffix}`;
-    } else if (typeFormId === 'AssembledAPA') {
-      let pidPrefix = '';
-      let pidSuffix = '';
-
-      if (data.apaConfiguration === 'top') {
-        pidPrefix = 'D00300100001';
-      } else {
-        pidPrefix = 'D00300100002';
-      }
-
-      if (data.apaAssemblyLocation === 'chicago') {
-        componentName = `APA ${typeRecordNumber}-US`;
-        pidSuffix = 'US175-010000';
-      } else if (data.apaAssemblyLocation === 'daresbury') {
-        componentName = `APA ${typeRecordNumber}-UK`;
-        pidSuffix = 'UK106-010000';
-      } else if (data.apaAssemblyLocation === 'wisconsin') {
-        componentName = `APA ${typeRecordNumber}-US`;
-        pidSuffix = 'US200-010000';
-      }
-
-      dunePid = `${pidPrefix}-${typeRecordNumber}-${pidSuffix}`;
-    } else if (typeFormId === 'APAShipment') {
-      let name_apa1 = '[not set]';
-      let name_apa2 = '[not set]';
-
-      if (data.apaUuiDs[0].component_uuid !== '') {
-        const apa = await retrieve(data.apaUuiDs[0].component_uuid);
-        name_apa1 = apa.data.componentName;
-      }
-
-      if (data.apaUuiDs[1].component_uuid !== '') {
-        const apa = await retrieve(data.apaUuiDs[1].component_uuid);
-        name_apa2 = apa.data.componentName;
-      }
-
-      componentName = `${typeFormName} (${name_apa1} and ${name_apa2})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'BoardShipment') {
-      componentName = `Geometry ${typeFormName} (${data.boardUuiDs.length}.${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'CEAdapterBoard') {
-      componentName = `${typeFormName} ${typeRecordNumber}`;
-      dunePid = `D00300400003-${typeRecordNumber}-US200-010000`;
-    } else if (typeFormId === 'CEAdapterBoardBatch') {
-      componentName = `${typeFormName} (${data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'CEAdapterBoardShipment') {
-      componentName = `${typeFormName} ${typeRecordNumber} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'CRBoard') {
-      componentName = `${typeFormName} ${typeRecordNumber}`;
-      dunePid = `D00300400001-${typeRecordNumber}-US200-010000`;
-    } else if (typeFormId === 'CRBoardBatch') {
-      componentName = `${typeFormName} (${data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'CRBoardShipment') {
-      componentName = `${typeFormName} ${typeRecordNumber} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'CableHarness') {
-      if (data.cableHarnessSide === 'a') {
-        componentName = `${typeFormName} ${typeRecordNumber} (Side A)`;
-        dunePid = `D00300500002-${typeRecordNumber}-US200-010000`;
-      } else if (data.cableHarnessSide === 'b') {
-        componentName = `${typeFormName} ${typeRecordNumber} (Side B)`;
-        dunePid = `D00300500003-${typeRecordNumber}-US200-010000`;
-      }
-    } else if (typeFormId === 'CableHarnessShipment') {
-      componentName = `${typeFormName} ${typeRecordNumber} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'DWA') {
-      componentName = `${typeFormName} ${typeRecordNumber}`;
-      dunePid = `D00300800001-${typeRecordNumber}-US136-010000`;
-    } else if (typeFormId === 'DWAComponentShipment') {
-      componentName = `${typeFormName} (${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'DWAPDB') {
-      componentName = `DWA PDB ${typeRecordNumber}`;
-      dunePid = `D00300800002-${typeRecordNumber}-US136-010000`;
-    } else if (typeFormId === 'GBiasBoard') {
-      componentName = `${typeFormName} ${typeRecordNumber}`;
-      dunePid = `D00300400002-${typeRecordNumber}-US200-010000`;
-    } else if (typeFormId === 'GBiasBoardBatch') {
-      componentName = `${typeFormName} (${data.subComponent_count}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'GBiasBoardShipment') {
-      componentName = `${typeFormName} ${typeRecordNumber} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'GeometryBoard') {
-      componentName = `${typeFormName} ${typeRecordNumber} (${data.partString})`;
-      dunePid = `D003003${utils.dictionary_geometryBoardPIDs[data.partNumber]}-${typeRecordNumber}-UK109-010000`;
-    } else if (typeFormId === 'GeometryBoardBatch') {
-      componentName = `${typeFormName} (${data.subComponent_count}.PN${data.subComponent_partNumber}.ON${data.orderNumber})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'GroundingMeshPanel') {
-      componentName = `${typeFormName} ${typeRecordNumber}`;
-      dunePid = `D00300200004-${typeRecordNumber}-UK106-010000`;
-    } else if (typeFormId === 'GroundingMeshShipment') {
-      componentName = `Grounding Mesh Panel Shipment (${data.apaUuiDs.length}.${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'PopulatedBoardShipment') {
-      componentName = `Multi-Type Populated Board Shipment ${typeRecordNumber} (${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'ReturnedGeometryBoardBatch') {
-      componentName = `${typeFormName} (${data.subComponent_count}.PN${data.subComponent_partNumber}.ON${data.orderNumber})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'SHVBoard') {
-      componentName = `${typeFormName} ${typeRecordNumber}`;
-      dunePid = `D00300500001-${typeRecordNumber}-US200-010000`;
-    } else if (typeFormId === 'SHVBoardShipment') {
-      componentName = `${typeFormName} ${typeRecordNumber} (${data.boardUuiDs.length}.${validityStartDate.substring(0, 10)})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'Yoke') {
-      componentName = `${typeFormName} ${typeRecordNumber}`;
-      dunePid = `D00301000001-${typeRecordNumber}-US200-010000`;
-    } else if (typeFormId === 'wire_bobbin') {
-      componentName = `${typeFormName} ${data.bobbinId} (Lot ${data.wireLot})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    }
-
-    // Set up a 'matching condition' object containing the component UUID (remembering that the UUID has to be of 'MUUID' type, not a string)
-    const componentUuid = component.componentUuid;
-    let match_condition = { componentUuid };
-
-    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
-
-    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
-
-    // Update the component name and DUNE PID fields of ALL records with the matching component UUID (i.e. all versions of the component in question)
-    const result = await db.collection('components')
-      .updateMany(
-        match_condition,
-        [
+      const result = db.collection('actions')
+        .updateOne(
+          { _id: actionRecord._id },
           {
             $set: {
-              'data.componentName': componentName,
-              'data.dunePid': dunePid,
+              'componentName': componentName,
+              'componentTypeFormId': componentTypeFormId,
+              'componentTypeFormName': componentTypeFormName,
             }
           },
-        ]
-      )
+        );
 
-    if (result.ok === 0) throw new Error(`Admin_Functions::setComponentNames() - failed to update the component records!`);
-  }
+    });
 
-  return typeFormId;
+  return 'ALL_ACTIONS';
 }
-
-
-async function updateComponentLocations(typeFormId) {
-  // Retrieve a list of component UUIDs corresponding to all components with 'formId' matching the specified component type form ID
-  let aggregation_stages = [];
-
-  aggregation_stages.push({ $match: { formId: typeFormId } });
-  aggregation_stages.push({ $project: { componentUuid: true } });
-
-  let uuids = await db.collection('components')
-    .aggregate(aggregation_stages)
-    .toArray();
-
-  // For each retrieved UUID ...
-  for (let uuid of uuids) {
-    // Get the full component record corresponding to the UUID
-    // This will always be the latest version, and therefore contain the most recently set reception information
-    const component = await Components.retrieve(uuid.componentUuid);
-
-    if (component.reception != null) {
-      // Set up a 'matching condition' object containing the component UUID (remembering that the UUID has to be of 'MUUID' type, not a string)
-      const componentUuid = component.componentUuid;
-      let match_condition = { componentUuid };
-
-      if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
-
-      match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
-
-      // Update the reception information of ALL records with the matching component UUID (i.e. all versions of the component in question)
-      const result = await db.collection('components')
-        .updateMany(
-          match_condition,
-          [
-            {
-              $set: {
-                'reception.location': component.reception.location,
-                'reception.date': component.reception.date,
-                'reception.detail': component.reception.detail,
-              }
-            },
-          ]
-        )
-
-      if (result.ok === 0) throw new Error(`Admin_Functions::updateComponentLocations() - failed to update the component records!`);
-    } else {
-      logger.info(uuid.componentUuid, 'Component reception object is null!');
-    }
-  }
-
-  return typeFormId;
-}
-
-
-async function updateComponentLocations_viaActions(actionTypeFormId) {
-  // Retrieve a list of all 'Factory Board Rejection' actions
-  let aggregation_stages = [];
-
-  aggregation_stages.push({
-    $match: { 'typeFormId': actionTypeFormId }
-  });
-
-  // Project only the fields that will be needed for the later steps
-  aggregation_stages.push({
-    $project: {
-      actionId: true,
-      componentUuid: true,
-      data: true,
-      validity: true,
-    }
-  });
-
-  // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
-  // Then group the records by the action ID (i.e. each group contains all versions of the same action), and select only the first (highest version number) entry in each group
-  // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
-  aggregation_stages.push({
-    $group: {
-      _id: { actionId: '$actionId' },
-      actionId: { '$first': '$actionId' },
-      componentUuid: { '$first': '$componentUuid' },
-      data: { '$first': '$data' },
-      validity: { '$first': '$validity' },
-    },
-  });
-
-  let allBoards_boardRejectionActions = await db.collection('actions')
-    .aggregate(aggregation_stages)
-    .toArray();
-
-  // For each retrieved action ...
-  for (let action of allBoards_boardRejectionActions) {
-    // Get the full geometry board component record corresponding to the UUID in the action record, and check if the 'reception' object actually exists ...
-    // ... if it doesn't, attempting to change the fields within it will cause a crash
-    const board = await Components.retrieve(action.componentUuid);
-
-    if (board.reception != null) {
-      // Get the latest version of the MOST RECENT 'Factory Board Rejection' action performed on the board
-      const match_condition = {
-        typeFormId: 'FactoryBoardRejection',
-        componentUuid: board.componentUuid,
-      }
-
-      const singleBoard_boardRejectionActionIDs = await Actions.list(match_condition);
-      const mostRecentRejectionAction = await Actions.retrieve(singleBoard_boardRejectionActionIDs[0].actionId);
-
-      // If the most recent rejection action has a disposition of 'rejected' ...
-      if (mostRecentRejectionAction.data.disposition === 'rejected') {
-        const rejectionLocation = utils.dictionary_locations[mostRecentRejectionAction.data.boardRejectionLocation];
-        let rejectionReason = '';
-        let boardNeedsUpdating = false;
-
-        if ((mostRecentRejectionAction.data.reasonForRejectionFromInventory.step) || (mostRecentRejectionAction.data.reasonForRejectionFromInventory.stepBetweenBoardAndStripTooLarge)) {
-          rejectionReason = 'Step Failure';
-          boardNeedsUpdating = true;
-        }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.solderMaskScratch) { rejectionReason = 'Solder Mask Scratch' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.scratchInCopperTrace) { rejectionReason = 'Copper Trace Scratch' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.brokenTooth) { rejectionReason = 'Broken Tooth' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.delaminationOfLayers) { rejectionReason = 'Delamination of Layers' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.bentPins) { rejectionReason = 'Bent Pins' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.epoxyOnSolderPadsOrToothStrip) { rejectionReason = 'Misplaced Epoxy' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.toothStripNotProperlyAttached) { rejectionReason = 'Misattached Tooth Strip' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.qrCodeIssue) { rejectionReason = 'QR Code Issue' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.installationCausedDamage) { rejectionReason = 'Installation Damage' }
-        //    else if (mostRecentRejectionAction.data.reasonForRejectionFromInventory.removedFromApa) { rejectionReason = 'Removed from APA' }
-        else if ((mostRecentRejectionAction.data.reasonForRejectionFromInventory.other) || (mostRecentRejectionAction.data.reasonForRejectionFromInventory.otherProvideDetailsInTheCommentsBoxOnTheRight)) {
-          rejectionReason = 'Unspecified Reason';
-
-          if (board.reception.detail !== '[Chicago - Removed from APA]') {
-            boardNeedsUpdating = true;
-          } else {
-            boardNeedsUpdating = false;
-          }
-        }
-
-        if (boardNeedsUpdating) {
-          const result = await Components.updateLocation(mostRecentRejectionAction.componentUuid, 'rejected', mostRecentRejectionAction.validity.startDate.toISOString().slice(0, 10), `[${rejectionLocation} - ${rejectionReason}]`);
-        }
-      }
-    } else {
-      logger.info(action.componentUuid, 'Component reception object is null!');
-    }
-  }
-
-  return actionTypeFormId;
-}
-
 
 module.exports = {
-  setComponentNames,
-  updateComponentLocations,
-  updateComponentLocations_viaActions,
+  cleanComponentRecords,
+//  addComponentInfoToActionRecords,
 }

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -52,10 +52,14 @@ block content
             option(value = 'SHVBoardShipment') SHV Board Kit
             option(value = 'Yoke') Yoke
             option(value = 'wire_bobbin') Wire Bobbin
-          
+
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'FactoryBoardRejection') Factory Board Rejection
+            option(value = 'ALL_COMPONENTS') ALL COMPONENT TYPES
+            option(value = 'APAFrame') APA Frame 
+            option(value = 'AssembledAPA') Assembled APA 
+            option(value = 'DWA') DWA
+            option(value = 'DWAPDB') DWA PDB 
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -226,7 +226,7 @@ router.post(['/json/administratorUtility/:inputString', '/api/administratorUtili
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
 
-    const result = await Admin_Functions.updateComponentLocations_viaActions(req.params.inputString);    // Change as appropriate for the required utility
+    const result = await Admin_Functions.cleanComponentRecords(req.params.inputString);    // Change as appropriate for the required utility
 
     return res.status(201).json(result);
   } catch (err) {

--- a/app/static/pages/administratorUtility.js
+++ b/app/static/pages/administratorUtility.js
@@ -26,8 +26,12 @@ async function renderInputForm() {
 }
 
 
-function postSuccess(result) {
-  window.location.href = `/actions/${result}/list`;    // Change as appropriate for the required utility
+function postSuccess(result) {    // Change as appropriate for the required utility
+  if (result === 'ALL_COMPONENTS') {
+    window.location.href = `/componentTypes/list`;
+  } else {
+    window.location.href = `/components/${result}/list`;
+  }
 }
 
 


### PR DESCRIPTION
Ready for Use
- we used to include secondary identifiers (i.e. part numbers, under various names) for components of certain types
- these are no longer needed, since the component 'typeRecordNumber' field is now used universally as a secondary identifier (together with the type form ID or name)
- new admin utility function to remove the no-longer-used secondary identifiers, with associated changes to interface page and route

Work in Progress
- also added a new admin utility function that will (in principle) add some more component information to action records ... name, type form ID and type form name
- this function is not currently working properly ... likely because it queries every single action record in the collection, so is probably overloading memory - works fine with smaller numbers of actions ... need to look into it in more detail