### PR TITLE
Fixing the admin utility for adding component info to actions ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -79,6 +79,19 @@ async function save(input, req) {
   newRecord.typeFormId = input.typeFormId;
   newRecord.typeFormName = typeForm.formName;
   newRecord.componentUuid = MUUID.from(input.componentUuid);
+
+  const componentRecord = await Components.retrieve(newRecord.componentUuid);
+
+  if (componentRecord) {
+    newRecord.componentName = componentRecord.data.componentName;
+    newRecord.componentTypeFormId = componentRecord.formId;
+    newRecord.componentTypeFormName = componentRecord.formName;
+  } else {
+    newRecord.componentName = '[no component record found!]';
+    newRecord.componentTypeFormId = '[no component record found!]';
+    newRecord.componentTypeFormName = '[no component record found!]';
+  }
+
   newRecord.data = input.data;
 
   if (input.workflowId) newRecord.workflowId = input.workflowId;

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -3,6 +3,7 @@ const MUUID = require('uuid-mongodb');
 const Actions = require('./Actions');
 const { db } = require('./db');
 const Components = require('./Components');
+const Forms = require('../lib/Forms');
 const logger = require('../lib/logger');
 const utils = require('./utils');
 
@@ -22,7 +23,7 @@ async function cleanComponentRecords(typeFormId) {
     deleteCondition = { $unset: { 'data.pdbNumber': "" } };
   }
 
-  const matchCondition = (typeFormId === 'ALL') ? {} : { formId: typeFormId };
+  const matchCondition = (typeFormId === 'ALL_COMPONENTS') ? {} : { formId: typeFormId };
 
   const result = await db.collection('components')
     .updateMany(
@@ -36,18 +37,59 @@ async function cleanComponentRecords(typeFormId) {
 }
 
 
-// NOT WORKING ... KEEPS GIVING A 'MongoNetworkTimeoutError: connection <monitor> to 172.19.0.2:27017 timed out' ERROR
-// Might be due to querying too many (i.e. all!) action records ... works fine with a smaller number (specifying a single action type)
-async function addComponentInfoToActionRecords() {
-  db.collection('actions')
-    .find({})
+async function addComponentInfoToActionRecords(componentType) {
+  const apaFramesAndShipments = ['DeliveredFrameQAChecks', 'CompletedFrameQCChecklist', 'InstallationSurveys', 'IntakeSurveys', 'APAShipmentReception', 'APAShipmentTransport', 'ASFCloseUp'];
+  let assembledAPAs = [];
+
+  const apaWorkflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
+  let actionTypeForms = await Forms.list('actionForms');
+  let list_apaWorkflowActionNames = [];
+
+  for (const step of apaWorkflowTypeForm.path.slice(1)) {
+    list_apaWorkflowActionNames.push(step.formName);
+  }
+
+  for (const [typeFormID, typeForm] of Object.entries(actionTypeForms)) {
+    if (list_apaWorkflowActionNames.includes(typeForm.formName)) {
+      assembledAPAs.push(typeFormID);
+    }
+  }
+
+  const geometryBoards = ['BoardToothStripAttachment', 'BoardVisualInspection', 'FactoryBoardRejection'];
+  const groundingMeshPanels = ['EpoxyApplication', 'FinalInspection', 'MeshQAInspection', 'APANonConformance', 'ReceiptInspection'];
+
+  const combined = apaFramesAndShipments.concat(assembledAPAs, geometryBoards, groundingMeshPanels);
+  let otherComponents = [];
+
+  for (const [typeFormID, typeForm] of Object.entries(actionTypeForms)) {
+    if (!(combined.includes(typeFormID)) && !(typeForm.tags.includes('Trash'))) {
+      otherComponents.push(typeFormID);
+    }
+  }
+
+  let filterCondition = null;
+
+  if (componentType === 'APAFramesAndShipments') {
+    filterCondition = { 'typeFormId': { $in: apaFramesAndShipments } }
+  } else if (componentType === 'AssembledAPAs') {
+    filterCondition = { 'typeFormId': { $in: assembledAPAs } }
+  } else if (componentType === 'GeometryBoards') {
+    filterCondition = { 'typeFormId': { $in: geometryBoards } }
+  } else if (componentType === 'GroundingMeshPanels') {
+    filterCondition = { 'typeFormId': { $in: groundingMeshPanels } }
+  } else if (componentType === 'OtherComponents') {
+    filterCondition = { 'typeFormId': { $in: otherComponents } }
+  }
+
+  const result = await db.collection('actions')
+    .find(filterCondition)
     .forEach(async function (actionRecord) {
       const componentRecord = await Components.retrieve(actionRecord.componentUuid);
       const componentName = (componentRecord) ? componentRecord.data.componentName : '[no component record found!]';
       const componentTypeFormId = (componentRecord) ? componentRecord.formId : '[no component record found!]';
       const componentTypeFormName = (componentRecord) ? componentRecord.formName : '[no component record found!]';
 
-      const result = db.collection('actions')
+      const innerResult = db.collection('actions')
         .updateOne(
           { _id: actionRecord._id },
           {
@@ -66,5 +108,5 @@ async function addComponentInfoToActionRecords() {
 
 module.exports = {
   cleanComponentRecords,
-//  addComponentInfoToActionRecords,
+  addComponentInfoToActionRecords,
 }

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -60,6 +60,12 @@ block content
             option(value = 'AssembledAPA') Assembled APA 
             option(value = 'DWA') DWA
             option(value = 'DWAPDB') DWA PDB 
+            option(value = 'N.A.') ----------
+            option(value = 'APAFramesAndShipments') APA Frames and Shipments
+            option(value = 'AssembledAPAs') Assembled APAs
+            option(value = 'GeometryBoards') Geometry Boards
+            option(value = 'GroundingMeshPanels') Grounding Mesh Panels
+            option(value = 'OtherComponents') ALL OTHER COMPONENT TYPES
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -225,8 +225,13 @@ router.get('/administratorUtility', async function (req, res, next) {
 router.post(['/json/administratorUtility/:inputString', '/api/administratorUtility/:inputString'], async function (req, res, next) {
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
+    let result = null;
 
-    const result = await Admin_Functions.cleanComponentRecords(req.params.inputString);    // Change as appropriate for the required utility
+    if (['ALL_COMPONENTS', 'APAFrame', 'AssembledAPA', 'DWA', 'DWAPDB'].includes(req.params.inputString)) {
+      result = await Admin_Functions.cleanComponentRecords(req.params.inputString);    // Change as appropriate for the required utility
+    } else {
+      result = await Admin_Functions.addComponentInfoToActionRecords(req.params.inputString);
+    }
 
     return res.status(201).json(result);
   } catch (err) {

--- a/app/static/pages/administratorUtility.js
+++ b/app/static/pages/administratorUtility.js
@@ -27,10 +27,14 @@ async function renderInputForm() {
 
 
 function postSuccess(result) {    // Change as appropriate for the required utility
-  if (result === 'ALL_COMPONENTS') {
-    window.location.href = `/componentTypes/list`;
+  if (['ALL_COMPONENTS', 'APAFrame', 'AssembledAPA', 'DWA', 'DWAPDB'].includes(result)) {
+    if (result === 'ALL_COMPONENTS') {
+      window.location.href = `/componentTypes/list`;
+    } else {
+      window.location.href = `/components/${result}/list`;
+    }
   } else {
-    window.location.href = `/components/${result}/list`;
+    window.location.href = `/actionTypes/list`;
   }
 }
 


### PR DESCRIPTION
- admin utility will now retrieve and change only the records corresponding to the selected action types - selected via the component type (or group of types)
- the same component information will now be added to all actions when they are first performed or later edited
- fixed a bug in the previous admin utility ... changed one of the interface options, but forgot to change the backend code accordingly