### PR TITLE
Splitting admin utility usage to get around memory overload ...

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -73,8 +73,12 @@ async function addComponentInfoToActionRecords(componentType) {
     filterCondition = { 'typeFormId': { $in: apaFramesAndShipments } }
   } else if (componentType === 'AssembledAPAs') {
     filterCondition = { 'typeFormId': { $in: assembledAPAs } }
-  } else if (componentType === 'GeometryBoards') {
-    filterCondition = { 'typeFormId': { $in: geometryBoards } }
+  } else if (componentType === 'GeometryBoards_BoardToothStripAttachment') {
+    filterCondition = { 'typeFormId': 'BoardToothStripAttachment' }
+  } else if (componentType === 'GeometryBoards_BoardVisualInspection') {
+    filterCondition = { 'typeFormId': 'BoardVisualInspection' }
+  } else if (componentType === 'GeometryBoards_FactoryBoardRejection') {
+    filterCondition = { 'typeFormId': 'FactoryBoardRejection' }
   } else if (componentType === 'GroundingMeshPanels') {
     filterCondition = { 'typeFormId': { $in: groundingMeshPanels } }
   } else if (componentType === 'OtherComponents') {

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -63,7 +63,9 @@ block content
             option(value = 'N.A.') ----------
             option(value = 'APAFramesAndShipments') APA Frames and Shipments
             option(value = 'AssembledAPAs') Assembled APAs
-            option(value = 'GeometryBoards') Geometry Boards
+            option(value = 'GeometryBoards_BoardToothStripAttachment') Geometry Boards (Tooth Strip Attachment)
+            option(value = 'GeometryBoards_BoardVisualInspection') Geometry Boards (Visual Inspection)
+            option(value = 'GeometryBoards_FactoryBoardRejection') Geometry Boards (Factory Rejection)
             option(value = 'GroundingMeshPanels') Grounding Mesh Panels
             option(value = 'OtherComponents') ALL OTHER COMPONENT TYPES
 


### PR DESCRIPTION
- attempting to change all actions related to geometry boards is causing a memory overload on Staging
- changed so that each action type is now called individually