### PR TITLE
Improving action retrieval speeds using new record fields

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -412,11 +412,11 @@ async function versions(actionId) {
 
 
 /// Retrieve a list of action records matching a specified condition
-async function list(match_condition, options) {
+async function list(match_condition) {
   let aggregation_stages = [];
 
-  // If a matching condition has been specified, set it as the first aggregation stage
-  // If the matching condition additionally contains a (string format) component UUID, first convert it to binary format
+  // The passed match condition will usually contain an action type form ID ... set it as the first aggregation stage
+  // If the matching condition also contains a (string format) component UUID, convert it to binary format
   if (match_condition) {
     if (match_condition.componentUuid) match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
 
@@ -430,6 +430,7 @@ async function list(match_condition, options) {
       typeFormId: true,
       typeFormName: true,
       componentUuid: true,
+      componentName: true,
       workflowId: true,
       validity: true,
       data: true,
@@ -448,6 +449,7 @@ async function list(match_condition, options) {
       typeFormId: { '$first': '$typeFormId' },
       typeFormName: { '$first': '$typeFormName' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$componentName' },
       workflowId: { '$first': '$workflowId' },
       lastEditDate: { '$first': '$validity.startDate' },
       data: { '$first': '$data' },
@@ -465,36 +467,8 @@ async function list(match_condition, options) {
     .aggregate(aggregation_stages)
     .toArray();
 
-  // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display
-  // Then add the corresponding component name to each matching record
-  // Finally, apply the optional filter on the component type form ID if it is needed - if the action passes the filter, save it into a new list of matching and filtered records ...
-  // ... or if the optional filter is not needed, simply save all matching records into the list of matching and filtered records
-  let filteredRecords = [];
-
-  for (let record of records) {
-    const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-
-    if (!component) {
-      record.componentName = '[UUID does not exist!]';
-    } else {
-      record.componentName = component.data.componentName;
-    }
-
-    if (options) {
-      if (options.componentTypeFormId) {
-        if (component.formId === options.componentTypeFormId) {
-          filteredRecords.push(record);
-        }
-      } else {
-        filteredRecords.push(record);
-      }
-    } else {
-      filteredRecords.push(record);
-    }
-  }
-
-  // Return a limited slice of the matching (and possibly filtered) records
-  return filteredRecords.slice(0, 200);
+  // Return a limited slice of the matching records
+  return records.slice(0, 200);
 }
 
 

--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -1,8 +1,6 @@
 const MUUID = require('uuid-mongodb');
 
-const Components = require('./Components');
 const { db } = require('./db');
-const utils = require('./utils');
 
 const dictionary_apaNCRs_types = {
   damagedWireSegment: 'Damaged Wire Segment',
@@ -71,12 +69,14 @@ async function nonConformanceByComponentType(componentType, disposition, status)
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
+  // Then sort the records reverse alphabetically by the 'componentName' field
   aggregation_stages.push({ $sort: { 'validity.version': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
       actionId: { '$first': '$actionId' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$componentName' },
       title: { '$first': '$data.nonConformanceTitle' },
       componentType: { '$first': '$data.componentType' },
       nonConfTypes_apas: { '$first': '$data.nonConformanceType' },
@@ -85,6 +85,8 @@ async function nonConformanceByComponentType(componentType, disposition, status)
       status: { '$first': '$data.status' },
     },
   });
+
+  aggregation_stages.push({ $sort: { 'componentName': -1 } });
 
   // Match against the specified component type, disposition and status
   // For the disposition and status, set up 'matching' strings that can be used by MongoDB to match against specific record field values, and then match against them
@@ -108,9 +110,6 @@ async function nonConformanceByComponentType(componentType, disposition, status)
   // Add the corresponding component name to each matching record
   // Additionally, get the first 'true' non-conformance type in each record, convert it to something more readable and save this new string to the record
   for (let result of results) {
-    const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
-    result.componentName = component.data.componentName;
-
     if (result.componentType === 'assembledApa') {
       if (result.nonConfTypes_apas != null) {
         result.nonConfType = dictionary_apaNCRs_types[Object.keys(result.nonConfTypes_apas).filter(k => result.nonConfTypes_apas[k])[0]];
@@ -125,10 +124,6 @@ async function nonConformanceByComponentType(componentType, disposition, status)
       }
     }
   }
-
-  // Re-sort the records by the component name, in reverse alphanumerical order
-  // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  results.sort(utils.byField_decreasing('componentName'));
 
   // Return the list of matching actions
   return results;
@@ -148,12 +143,14 @@ async function nonConformanceByUUID(componentUUID) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
+  // Then sort the records reverse alphabetically by the 'actionId' field
   aggregation_stages.push({ $sort: { 'validity.version': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
       actionId: { '$first': '$actionId' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$componentName' },
       title: { '$first': '$data.nonConformanceTitle' },
       componentType: { '$first': '$data.componentType' },
       nonConfTypes_apas: { '$first': '$data.nonConformanceType' },
@@ -163,6 +160,8 @@ async function nonConformanceByUUID(componentUUID) {
     },
   });
 
+  aggregation_stages.push({ $sort: { 'actionId': -1 } });
+
   // Query the 'actions' records collection using the aggregation stages defined above
   let results = await db.collection('actions')
     .aggregate(aggregation_stages)
@@ -171,9 +170,6 @@ async function nonConformanceByUUID(componentUUID) {
   // Add the corresponding component name to each matching record
   // Additionally, get the first 'true' non-conformance type in each record, convert it to something more readable and save this new string to the record
   for (let result of results) {
-    const component = await Components.retrieve(MUUID.from(result.componentUuid).toString());
-    result.componentName = component.data.componentName;
-
     if (result.componentType === 'assembledApa') {
       if (result.nonConfTypes_apas != null) {
         result.nonConfType = dictionary_apaNCRs_types[Object.keys(result.nonConfTypes_apas).filter(k => result.nonConfTypes_apas[k])[0]];
@@ -188,10 +184,6 @@ async function nonConformanceByUUID(componentUUID) {
       }
     }
   }
-
-  // Re-sort the records by the NCR action ID, in reverse alphanumerical order
-  // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  results.sort(utils.byField_decreasing('actionId'));
 
   // Return the list of  atching actions
   return results;
@@ -217,6 +209,7 @@ async function boardInstallByReferencedComponent(componentUUID) {
       actionId: { '$first': '$actionId' },
       typeFormName: { '$first': '$typeFormName' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$componentName' },
       data: { '$first': '$data' },
     },
   });
@@ -259,12 +252,6 @@ async function boardInstallByReferencedComponent(componentUUID) {
     }
   }
 
-  // Add the corresponding component name to each matching record
-  for (let record of boardInstalls) {
-    const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-    record.componentName = component.data.componentName;
-  }
-
   // Return the list of matching actions
   return boardInstalls;
 }
@@ -289,6 +276,7 @@ async function windingByReferencedComponent(componentUUID) {
       actionId: { '$first': '$actionId' },
       typeFormName: { '$first': '$typeFormName' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$componentName' },
       data: { '$first': '$data' },
     },
   });
@@ -309,12 +297,6 @@ async function windingByReferencedComponent(componentUUID) {
         if (bobbin.bobbinUuid === componentUUID) windings.push(action);
       }
     }
-  }
-
-  // Add the corresponding component name to each matching record
-  for (let record of windings) {
-    const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-    record.componentName = component.data.componentName;
   }
 
   // Return the list of matching actions
@@ -342,6 +324,7 @@ async function boardRejectionByReferencedComponent(componentUUID) {
       actionId: { '$first': '$actionId' },
       typeFormName: { '$first': '$typeFormName' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$componentName' },
       data: { '$first': '$data' },
     },
   });
@@ -350,12 +333,6 @@ async function boardRejectionByReferencedComponent(componentUUID) {
   let results = await db.collection('actions')
     .aggregate(aggregation_stages)
     .toArray();
-
-  // Add the corresponding component name to each matching record
-  for (let record of results) {
-    const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-    record.componentName = component.data.componentName;
-  }
 
   // Return the list of matching actions
   return results;

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -248,14 +248,18 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
   action_aggregation_stages.push({ $match: match_condition });
 
   // Select the latest version of each record, and pass through only the fields required for later use
+  // Then sort the records reverse alphabetically by the 'componentName' field
   action_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
   action_aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
       actionId: { '$first': '$actionId' },
       componentUuid: { '$first': '$componentUuid' },
+      componentName: { '$first': '$componentName' },
     },
   });
+
+  action_aggregation_stages.push({ $sort: { 'componentName': -1 } });
 
   // Query the 'actions' records collection using the aggregation stages defined above
   let apasCompletedToStep_allLocations = await db.collection('actions')
@@ -274,16 +278,11 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
     if (component.data.apaAssemblyLocation === location) {
       uuids_apasCompletedToStep_atLocation.push(action.componentUuid);
 
-      action.componentName = component.data.componentName;
       action.workflowId = component.workflowId;
 
       apasCompletedToStep_atLocation.push(action);
     }
   }
-
-  // Re-sort the records by the component name, in reverse alphanumerical order
-  // This must be done here using JavaScript, rather than as part of the MongoDB aggregation, because component names are only added to the records after the aggregation is complete
-  apasCompletedToStep_atLocation.sort(utils.byField_decreasing('componentName'));
 
   let comp_aggregation_stages = [];
 
@@ -298,28 +297,23 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
+  // Then sort the records reverse alphabetically by the 'componentName' field
   comp_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
   comp_aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
       componentUuid: { '$first': '$componentUuid' },
       workflowId: { '$first': '$workflowId' },
+      componentName: { '$first': '$data.componentName' },
     },
   });
+
+  comp_aggregation_stages.push({ $sort: { 'componentName': -1 } });
 
   // Query the 'components' records collection using the aggregation stages defined above
   let apasNotCompletedToStep_atLocation = await db.collection('components')
     .aggregate(comp_aggregation_stages)
     .toArray();
-
-  // Add the corresponding component name to each matching record
-  for (let record of apasNotCompletedToStep_atLocation) {
-    const component = await Components.retrieve(MUUID.from(record.componentUuid).toString());
-    record.componentName = component.data.componentName;
-  }
-
-  // Re-sort the records by the component name ... in reverse alphanumerical order
-  apasNotCompletedToStep_atLocation.sort(utils.byField_decreasing('componentName'));
 
   // Return a nested list, consisting of:
   // - [0] the list of all assembled APAs produced at the specified location that have had matching 'Assembled APA QA Check'  or 'Completed APA QA Checklist' actions performed on them and completed

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -158,12 +158,18 @@ module.exports = {
   // Personnel who are authorised to signoff on tension control and winder maintenance verifications ('? Layer - Winding' APA Assembly workflow actions)
   dictionary_winderMaintenanceSignoff: {
     vincentBaker: 'Vincent Baker',
+    daveBrown: 'Dave Brown',
     carlosChavezBarajas: 'Carlos Chavez Barajas',
     edBlucher: 'Ed Blucher',
+    markFarrell: 'Mark Farrell',
+    lewisGannon: 'Lewis Gannon',
+    darrenKaye: 'Darren Kaye',
+    andrewKelly: 'Andrew Kelly',
     albertoMarchionni: 'Alberto Marchionni',
     benjaminOye: 'Benjamin Oye',
     danielSalisbury: 'Daniel Salisbury',
     daveSim: 'Dave Sim',
+    stephenSumner: 'Stephen Sumner',
   },
 
   // Winding D-band personnel (winding-related APA Assembly workflow actions)

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -6,7 +6,6 @@ block extrascripts
     const action = !{JSON.stringify(action, null, 4)};
     const actionVersions = !{JSON.stringify(actionVersions, null, 4)};
     const actionTypeForm = !{JSON.stringify(actionTypeForm, null, 4)};
-    const component = !{JSON.stringify(component, null, 4)};
     const queryDictionary = !{JSON.stringify(queryDictionary, null, 4)};
     const retensionedWires_versions = !{JSON.stringify(retensionedWires_versions, null, 4)};
     const retensionedWires_values = !{JSON.stringify(retensionedWires_values, null, 4)};
@@ -39,7 +38,7 @@ block content
 
             dt Performed on Component:
             dd 
-              a(href = `/component/${uuid}`) #{component.data.componentName}
+              a(href = `/component/${uuid}`) #{action.componentName}
 
             if action.workflowId
               dt Part of Workflow:
@@ -101,7 +100,7 @@ block content
           if (action.typeFormId == 'x_tension_testing')
             .vert-space-x1 
               if retensionedWires_versions[0] !== null
-                a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${component.data.componentName.slice(5)}_${action.data.apaLayer.toUpperCase()}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
+                a.btn.btn-secondary#download_changedTensions(onclick = 'DownloadChangedTensions(retensionedWires_values)', download = `retensions_${action.componentName.slice(5)}_${action.data.apaLayer.toUpperCase()}_v${retensionedWires_versions[1]}-v${retensionedWires_versions[0]}.txt`, href = '') Download List of Changed Tensions
               else 
                 a.btn.btn-secondary.disabled(href = '') Download List of Changed Tensions
 

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -31,9 +31,6 @@ router.get('/action/:actionId', permissions.checkPermission('actions:view'), asy
 
     if (!actionTypeForm) return res.status(404).send(`There is no action type form with form ID = ${action.typeFormId}`);
 
-    // Retrieve the record of the component that the action was performed on, using its component UUID (also found in the action record)
-    const component = await Components.retrieve(action.componentUuid);
-
     // Set a variable to indicate if the specified action type is one that is part of a workflow
     // First set up a list of action type form names for all actions that are part of any workflow
     // Then check to see if the list of action type form names includes the type form name of the action type being specified
@@ -131,7 +128,6 @@ router.get('/action/:actionId', permissions.checkPermission('actions:view'), asy
       action,
       actionVersions,
       actionTypeForm,
-      component,
       queryDictionary: req.query,
       retensionedWires_versions,
       retensionedWires_values,
@@ -158,9 +154,6 @@ router.get('/action/:actionId/edit', permissions.checkPermission('actions:perfor
 
     if (!actionTypeForm) return res.status(404).send(`There is no action type form with form ID = ${action.typeFormId}`);
 
-    // Retrieve the record of the component that the action was performed on, using its component UUID (found in the action record)
-    const component = await Components.retrieve(action.componentUuid);
-
     // Retrieve the workflow ID if the action record already contains such a field
     let workflowId = '';
 
@@ -171,7 +164,7 @@ router.get('/action/:actionId/edit', permissions.checkPermission('actions:perfor
       action,
       actionTypeForm,
       componentUuid: action.componentUuid,
-      componentName: component.data.componentName,
+      componentName: action.componentName,
       workflowId,
       stepIndex: '-99',
     });
@@ -362,9 +355,15 @@ router.get('/actions/list', permissions.checkPermission('actions:view'), async f
 /// List all actions of a single action type
 router.get('/actions/:typeFormId/list', permissions.checkPermission('actions:view'), async function (req, res, next) {
   try {
-    // Retrieve records of all actions with the specified action type
+    // Set up the object containing the matching conditions ... to start with, this only consists of the specified action type
+    // If a component type form ID has been provided in the query, add it to the object under the appropriate field
+    let match_condition = { typeFormId: req.params.typeFormId };
+
+    if (req.query.componentTypeFormId) { match_condition.componentTypeFormId = req.query.componentTypeFormId; }
+
+    // Retrieve records of all actions with the specified action type, and optionally further match to those that were performed on the specified component type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const actions = await Actions.list({ typeFormId: req.params.typeFormId }, { componentTypeFormId: req.query.componentTypeFormId });
+    const actions = await Actions.list(match_condition);
 
     // Retrieve the action type form corresponding to the specified type form ID
     const actionTypeForm = await Forms.retrieve('actionForms', req.params.typeFormId);


### PR DESCRIPTION
- there are a handful of places in the interface where one or more action records are retrieved, and currently the associated component record must also be retrieved in order to access and display the component name, type, etc.
- this is noticeably slow, particularly for bulk retrievals (action listing pages)
- since the component information is now found within the action record, there is no longer any need for the additional component record retrieval - code has been changed accondingly ... action listing is significantly faster now

Also (hopefully) - the Daresbury Factory Leads have requested that the Winding D-Band personnel be able to sign off on winder maintenance in Winding actions, so these names have been added to the relevant personnel list