### PR TITLE
New personnel list for tension control verification

### DIFF
--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -155,7 +155,18 @@ module.exports = {
     kimWilliams: 'Kim Williams',
   },
 
-  // Personnel who are authorised to signoff on tension control and winder maintenance verifications ('? Layer - Winding' APA Assembly workflow actions)
+  // Personnel who are authorised to signoff on tension control verification ('? Layer - Winding' APA Assembly workflow actions)
+  dictionary_tensionControlSignoff: {
+    vincentBaker: 'Vincent Baker',
+    carlosChavezBarajas: 'Carlos Chavez Barajas',
+    edBlucher: 'Ed Blucher',
+    albertoMarchionni: 'Alberto Marchionni',
+    benjaminOye: 'Benjamin Oye',
+    danielSalisbury: 'Daniel Salisbury',
+    daveSim: 'Dave Sim',
+  },
+
+  // Personnel who are authorised to signoff on winder maintenance verification ('? Layer - Winding' APA Assembly workflow actions)
   dictionary_winderMaintenanceSignoff: {
     vincentBaker: 'Vincent Baker',
     daveBrown: 'Dave Brown',

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -116,7 +116,18 @@ router.get(['/json/dBandFramePrep.json', '/api/dBandFramePrep.json'], async func
 });
 
 
-/// List personnel who are authorised to signoff on tension control and winder maintenance verifications
+/// List personnel who are authorised to signoff on tension control verification
+router.get(['/json/tensionControlSignoff.json', '/api/tensionControlSignoff.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_tensionControlSignoff));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
+/// List personnel who are authorised to signoff on winder maintenance verification
 router.get(['/json/winderMaintenanceSignoff.json', '/api/winderMaintenanceSignoff.json'], async function (req, res, next) {
   try {
     return res.status(200).json(ConvertDictionaryToList(utils.dictionary_winderMaintenanceSignoff));


### PR DESCRIPTION
- requested that the tension control and winder maintenance personnel lists be separated - recent additions for the latter should not be in the former
- new dictionary and associated route ... will make the corresponding changes on winding action type forms once the code changes have been deployed

Tested on Staging.