### PR TITLE
Additions to component location tracking ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -185,8 +185,10 @@ async function save(input, req) {
   // - for shipment or batch reception actions, update the reception information of each individual sub-component (as well as the shipment itself) to match where and when it was received
   // - for board and mesh installation actions, update the reception information of each component referenced in the action to be 'Installed on APA' 
   // - for 'Factory Board Rejection' actions ...
-  //   ... where the rejection disposition is 'Rejected', update the board's reception information to to indicate that it has been 'Rejected'
-  //   ... where the rejection disposition is something other than 'Rejected', update the board's reception information match where and when the action was performed
+  //   ... where the rejection disposition is 'Rejected', update the board's reception information to indicate that it has been 'Rejected'
+  //   ... where the rejection disposition is something other than 'Rejected', update the board's reception information to match where and when the action was performed
+  // - for 'Tooth Strip Attachment' actions, update the board's reception information to match where and when the action was performed
+  // - for some (but not all) actions performed on grounding mesh panels, update the mesh's reception information to match where and when the action was performed
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
   if (transport_typeFormIDs.includes(newRecord.typeFormId)) {
     const result = await Components.updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
@@ -257,6 +259,10 @@ async function save(input, req) {
     } else {
       const result = await Components.updateLocation(newRecord.componentUuid, newRecord.data.boardRejectionLocation, (new Date()).toISOString().slice(0, 10), '');
     }
+  } else if (newRecord.typeFormId === 'BoardToothStripAttachment') {
+    const result = await Components.updateLocation(newRecord.componentUuid, newRecord.data.locationWorkPerformed, (new Date()).toISOString().slice(0, 10), '');
+  } else if (['EpoxyApplication', 'FinalInspection', 'ReceiptInspection'].includes(newRecord.typeFormId)) {
+    const result = await Components.updateLocation(newRecord.componentUuid, newRecord.data.location, newRecord.data.date.slice(0, 10), '');
   }
 
   // If the insertion and post-insertion changes are all successful, return the record's action ID as confirmation

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -200,16 +200,19 @@ async function save(input, req) {
     newRecord.reception.date = (new Date()).toISOString().slice(0, 10);
     newRecord.reception.detail = '';
 
-    // Components of certain types will always start at specific fixed locations, whereas the rest do not need any initial location set (only for the record field to exist)
+    // Almost all component types will always start at specific fixed locations ...
+    // ... the only exceptions are the 'batch' types (these still need the location field to exist, but it can be left as an empty string)
     if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'wire_bobbin')) {
       newRecord.reception.location = 'daresbury';
     } else if (newRecord.formId === 'APAShipment') {
       newRecord.reception.location = newRecord.data.originOfShipment;
+    } else if (newRecord.formId === 'APAShippingFrame') {
+      newRecord.reception.location = newRecord.data.asfLocation;
     } else if ((newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
-    } else if ((newRecord.formId === 'CEAdapterBoard') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'CRBoard') || (newRecord.formId === 'CRBoardShipment') || (newRecord.formId === 'CableHarness') || (newRecord.formId === 'CableHarnessShipment') || (newRecord.formId === 'GBiasBoard') || (newRecord.formId === 'GBiasBoardShipment') || (newRecord.formId === 'SHVBoard') || (newRecord.formId === 'SHVBoardShipment')) {
+    } else if ((newRecord.formId === 'CEAdapterBoard') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'CRBoard') || (newRecord.formId === 'CRBoardShipment') || (newRecord.formId === 'CableHarness') || (newRecord.formId === 'CableHarnessShipment') || (newRecord.formId === 'GBiasBoard') || (newRecord.formId === 'GBiasBoardShipment') || (newRecord.formId === 'SHVBoard') || (newRecord.formId === 'SHVBoardShipment') || (newRecord.formId === 'Yoke')) {
       newRecord.reception.location = 'wisconsin';
     } else if ((newRecord.formId === 'DWA') || (newRecord.formId === 'DWAPDB')) {
       newRecord.reception.location = newRecord.data.productionLocation;
@@ -303,7 +306,7 @@ async function save(input, req) {
   if (!result.acknowledged) throw new Error(`Components::save() - failed to insert a new component record into the database!`);
 
   // Once the component record has been successfully saved, deal with the reception information for any related components:
-  // - for an 'APA Shipment', update the reception information of the underlying 'Assembled APA' components to be the same as the shipment
+  // - for an 'APA Shipment', update the reception information of the underlying 'Assembled APA' and 'ASF' components to be the same as the shipment
   //    (they should already be at the same location as the shipment, but this is a double-check on that)
   // - for other types of shipment, update the reception information of the various sub-components to indicate that they are in transit
   // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
@@ -383,10 +386,12 @@ async function updateLocations_inShipment(componentUuid, location, date) {
   // Loop over all sub-components in the shipment, and update each one's location information appropriately for the shipment type and contents
   // In all cases, if successful, the updating function returns 'result = 1', but we don't actually use this value anywhere
   if (shipment.formId === 'APAShipment') {
-    // Extract the UUID and update the location information of each assembled APA in a shipment of APAs
+    // Extract the UUID and update the location information of each assembled APA and the ASF in a shipment of APAs
     for (const apa of shipment.data.apaUuiDs) {
       const result = await updateLocation(apa.component_uuid, location, date, '');
     }
+
+    const result = await updateLocation(shipment.data.asfUuid, location, date, '');
   } else if ((shipment.formId === 'BoardShipment') || (shipment.formId === 'CEAdapterBoardShipment') || (shipment.formId === 'CRBoardShipment') || (shipment.formId === 'CableHarnessShipment') || (shipment.formId === 'GBiasBoardShipment') || (shipment.formId === 'SHVBoardShipment')) {
     // Extract the UUID and update the location information of each board in a shipment of (single type) boards
     for (const board of shipment.data.boardUuiDs) {

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -39,6 +39,7 @@ module.exports = {
     sussex: 'Sussex',
     ukWarehouse: 'UK Warehouse',
     unknown: 'Unknown / Lost',
+    usWarehouse: 'US Warehouse',
     williamAndMary: 'William and Mary',
     wisconsin: 'Wisconsin',
   },


### PR DESCRIPTION
- added assignment of initial locations for APA Shipping Frames (frame location) and Yokes ('Wisconsin') - now only batch-type components have no initial location set
- ASF location can now be changed (to 'In Transit') when referencing it in an APA Shipment, and again (to the reception destination) when receiving an APA Shipment via its reception action
- added additional geometry board and mesh panel actions that can change the component location (all of these action types contain an 'action location' field) ... this will help to fill in the gaps between shipments of the components
- added 'US Warehouse' as a new entry in the central list of locations ... will be used in the future as the destination for shipping yokes (not yet implemented)