### PR TITLE
Miscellaneous Requested Changes

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -3,8 +3,8 @@ const MUUID = require('uuid-mongodb');
 const Actions = require('./Actions');
 const { db } = require('./db');
 const Components = require('./Components');
-const Forms = require('../lib/Forms');
-const logger = require('../lib/logger');
+const Forms = require('./Forms');
+const logger = require('./logger');
 const utils = require('./utils');
 
 

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -1,9 +1,12 @@
 const MUUID = require('uuid-mongodb');
 
+const Actions = require('./Actions');
 const Components = require('./Components');
 const { db } = require('./db');
+const logger = require('./logger');
 const Search_ActionsWorkflows = require('./Search_ActionsWorkflows');
 const utils = require('./utils');
+const Workflows = require('./Workflows');
 
 const layers = ['x', 'v', 'u', 'g'];
 const typeForms_winding = ['x_winding', 'v_winding', 'u_winding', 'g_winding'];
@@ -45,6 +48,10 @@ const dictionary_tensionSystems = {
   laser3: 'Laser #3',
   laser4: 'Laser #4',
   laser5: 'Laser #5',
+  laser6: 'Laser #6',
+  laser7: 'Laser #7',
+  laser8: 'Laser #8',
+  laser9: 'Laser #9',
 };
 
 const dictionary_ncrTypes = {
@@ -735,60 +742,199 @@ async function forExecSummary(componentUUID) {
 
 /// Retrieve collated information about two specified APAs comprising a single doublet, for use in the DUNE HWDB
 async function forHWDB(apa1UUID, apa2UUID) {
-  // Set up an object to store the collated information, and then set up the various sections of the collated information object
-  // Information will be saved as [key, value] pairs for easier access on the interface page, and we know what keys are required ahead of time, so they can be hardcoded
-  let collatedInfo = {};
+  // Set up an array of the APA UUIDs ... this will allow the collating of information to be done in a loop, instead of having to explicitly duplicate the code
+  // Then set up a corresponding array that will contain (and return) the combined collated information about both APAs
+  const apaUuids = [apa1UUID, apa2UUID];
+  let apaInformation = [];
 
-  collatedInfo.apa1 = {
-    componentName: '',
-    componentUUID: '',
-    shortUUID: '',
-    dunePID: '',
-    productionSite: '',
-    configuration: '',
-  };
+  // For each APA UUID ...
+  for (const apaUuid of apaUuids) {
+    // Retrieve collated information about the APA using the already-existing function that does the same for populating Executive Summaries
+    // Since the information is identical here, it doesn't make any sense to re-code the retrieval all over again for this function
+    const collatedInfo = await forExecSummary(apaUuid);
 
-  collatedInfo.apa2 = {
-    componentName: '',
-    componentUUID: '',
-    shortUUID: '',
-    dunePID: '',
-    productionSite: '',
-    configuration: '',
-  };
+    // Define the object that will hold the information about a single APA in the structure required by the HWDB
+    let singleAPA = {};
 
-  ///////////////////////
-  // APA 1 INFORMATION //
-  ///////////////////////
-  // Get the component record of the first Assembled APA
-  const apa1 = await Components.retrieve(apa1UUID);
+    singleAPA = {
+      part_id: "",
+      data: {
+        components: {
+          assembledAPA: {},
+          apaFrame: {},
+          tempSensors: {},
+        },
+        signoffs: {
+          frameConstruction: {},
+          framePreparation: {},
+          xLayer: {},
+          vLayer: {},
+          uLayer: {},
+          gLayer: {},
+          coverBoardsAndCaps: {},
+          postProduction: {},
+          completedAPA: {},
+        },
+        brokenWires: [],
+        measurements: {
+          tempSensorResistances: {},
+          xLayer: {},
+          vLayer: {},
+          uLayer: {},
+          gLayer: {},
+        },
+      },
+    };
 
-  // Add relevant information from this Assembled APA component record to the 'apa1' section of the collated information object
-  collatedInfo.apa1.componentName = apa1.data.componentName;
-  collatedInfo.apa1.componentUUID = apa1.componentUuid;
-  collatedInfo.apa1.shortUUID = apa1.shortUuid.toString();
-  collatedInfo.apa1.dunePID = apa1.data.dunePid;
-  collatedInfo.apa1.productionSite = utils.dictionary_locations[apa1.data.apaAssemblyLocation];
-  collatedInfo.apa1.configuration = apa1.data.apaConfiguration[0].toUpperCase() + apa1.data.apaConfiguration.slice(1);
+    ///////////////////////////
+    // COMPONENT INFORMATION //
+    ///////////////////////////
+    // Information about the APA itself is found in the collated information object
+    singleAPA.part_id = collatedInfo.assembledAPA.dunePID;
 
-  ///////////////////////
-  // APA 2 INFORMATION //
-  ///////////////////////
-  // Get the component record of the second Assembled APA
-  const apa2 = await Components.retrieve(apa2UUID);
+    singleAPA.data.components.assembledAPA['apaDB_componentName'] = collatedInfo.assembledAPA.componentName;
+    singleAPA.data.components.assembledAPA['apaDB_componentUUID'] = collatedInfo.assembledAPA.componentUUID;
+    singleAPA.data.components.assembledAPA['apaDB_componentQRCode'] = `https://apa.dunedb.org/c/${collatedInfo.assembledAPA.shortUUID}`;
+    singleAPA.data.components.assembledAPA['productionSite'] = collatedInfo.assembledAPA.productionSite;
+    singleAPA.data.components.assembledAPA['configuration'] = collatedInfo.assembledAPA.configuration;
+    singleAPA.data.components.assembledAPA['apaDB_assemblyWorkflow'] = `https://apa.dunedb.org/workflow/${collatedInfo.assembledAPA.workflowID}`;
+    singleAPA.data.components.assembledAPA['assemblyStatus'] = collatedInfo.assembledAPA.assemblyStatus;
 
-  // Add relevant information from this Assembled APA component record to the 'apa2' section of the collated information object
-  collatedInfo.apa2.componentName = apa2.data.componentName;
-  collatedInfo.apa2.componentUUID = apa2.componentUuid;
-  collatedInfo.apa2.shortUUID = apa2.shortUuid.toString();
-  collatedInfo.apa2.dunePID = apa2.data.dunePid;
-  collatedInfo.apa2.productionSite = utils.dictionary_locations[apa2.data.apaAssemblyLocation];
-  collatedInfo.apa2.configuration = apa2.data.apaConfiguration[0].toUpperCase() + apa2.data.apaConfiguration.slice(1);
+    // Additional information about the APA Frame is found in its component record
+    const assembledAPA = await Components.retrieve(apaUuid);
+    const apaFrame = await Components.retrieve(assembledAPA.data.frameUuid);
 
-  ///////////////////////
+    singleAPA.data.components.apaFrame['part_id'] = apaFrame.data.dunePid;
+    singleAPA.data.components.apaFrame['apaDB_componentName'] = apaFrame.data.componentName;
+    singleAPA.data.components.apaFrame['apaDB_componentUUID'] = apaFrame.componentUuid;
+    singleAPA.data.components.apaFrame['apaDB_componentQRCode'] = `https://apa.dunedb.org/c/${apaFrame.shortUuid.toString()}`;
 
-  // Return the completed collated information object
-  return collatedInfo;
+    // Additional information about the temperature sensors is found in the 'Frame Prep - Photon Detector Cable and Temperature Sensor Installation' action of the workflow ...
+    // ... use the mapping document to find the temperature sensors' DUNE PIDs from the serial numbers stored in the action
+    const apaAssemblyWorkflow = await Workflows.retrieve(assembledAPA.workflowId);
+    const tempSensorInstallAction = await Actions.retrieve(apaAssemblyWorkflow.path[5].result);
+
+    const tempSensorSerialNumbers = [
+      tempSensorInstallAction.data.tempSensorSerialNumber,
+      tempSensorInstallAction.data.tempSensorSerialNumber1,
+      tempSensorInstallAction.data.tempSensorSerialNumber2,
+      tempSensorInstallAction.data.tempSensorSerialNumber3,
+    ];
+
+    const tempSensorLocations = [
+      tempSensorInstallAction.data.tempSensorLocation1,
+      tempSensorInstallAction.data.tempSensorLocation2,
+      tempSensorInstallAction.data.tempSensorLocation3,
+      tempSensorInstallAction.data.tempSensorLocation4,
+    ];
+
+    // ********** TBD - mapping from temperature sensor serial number to DUNE PID ********** //
+    const tempSensorPIDs = [
+      '[DUNE PID goes here]',
+      '[DUNE PID goes here]',
+      '[DUNE PID goes here]',
+      '[DUNE PID goes here]',
+    ];
+
+    for (const [index, serialNumber] of tempSensorSerialNumbers.entries()) {
+      singleAPA.data.components.tempSensors[`Temperature Sensor ${tempSensorLocations[index]} (${serialNumber})`] = tempSensorPIDs[index];
+    }
+
+    /////////////////
+    // QC SIGNOFFS //
+    /////////////////
+    // Information about the QC signoffs is found in the collated information object
+    singleAPA.data.signoffs.frameConstruction['name'] = collatedInfo.frameConstruction.signoff_name;
+    singleAPA.data.signoffs.frameConstruction['date'] = collatedInfo.frameConstruction.signoff_date;
+    singleAPA.data.signoffs.frameConstruction['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.signoff_actionID}`;
+    singleAPA.data.signoffs.frameConstruction['apaDB_intakeSurveys'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.intakeSurveys_actionID}`;
+    singleAPA.data.signoffs.frameConstruction['apaDB_installSurveys'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.installSurveys_actionID}`;
+
+    singleAPA.data.signoffs.framePreparation['name'] = collatedInfo.framePreparation.signoff_name;
+    singleAPA.data.signoffs.framePreparation['date'] = collatedInfo.framePreparation.signoff_date;
+    singleAPA.data.signoffs.framePreparation['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.signoff_actionID}`;
+    singleAPA.data.signoffs.framePreparation['apaDB_meshInstall'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.meshInstall_actionID}`;
+    singleAPA.data.signoffs.framePreparation['apaDB_rtdInstall'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.rtdInstall_actionID}`;
+
+    for (let i = 0; i < layers.length; i++) {
+      singleAPA.data.signoffs[`${layers[i]}Layer`]['name'] = collatedInfo[layers[i]].signoff_name;
+      singleAPA.data.signoffs[`${layers[i]}Layer`]['date'] = collatedInfo[layers[i]].signoff_date;
+      singleAPA.data.signoffs[`${layers[i]}Layer`]['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].signoff_actionID}`;
+    };
+
+    singleAPA.data.signoffs.coverBoardsAndCaps['name'] = collatedInfo.coverBoardsAndCaps.signoff_name;
+    singleAPA.data.signoffs.coverBoardsAndCaps['date'] = collatedInfo.coverBoardsAndCaps.signoff_date;
+    singleAPA.data.signoffs.coverBoardsAndCaps['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.coverBoardsAndCaps.signoff_actionID}`;
+
+    singleAPA.data.signoffs.postProduction['name'] = collatedInfo.postProduction.signoff_name;
+    singleAPA.data.signoffs.postProduction['date'] = collatedInfo.postProduction.signoff_date;
+    singleAPA.data.signoffs.postProduction['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.signoff_actionID}`;
+    singleAPA.data.signoffs.postProduction['apaDB_panelInstallURL'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.panelInstall_actionID}`;
+    singleAPA.data.signoffs.postProduction['apaDB_conduitInstallURL'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.conduitInstall_actionID}`;
+
+    singleAPA.data.signoffs.completedAPA['name'] = collatedInfo.completedAPA.signoff_name;
+    singleAPA.data.signoffs.completedAPA['date'] = collatedInfo.completedAPA.signoff_date;
+    singleAPA.data.signoffs.completedAPA['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.completedAPA.signoff_actionID}`;
+
+    //////////////////
+    // BROKEN WIRES //
+    //////////////////
+    // Information about broken (damaged, missing or shorted) wires is found in the 'ncrs_useAsIs_withWires' section of the collated information object
+    for (const ncr of collatedInfo.ncrs_useAsIs_withWires) {
+      for (const wire of ncr.missingShortedWires) {
+        singleAPA.data.brokenWires.push({
+          type: wire.wireType,
+          sideAndLayer: wire.wireLayer,
+          headBoardAndPad: wire.headBoardAndPad,
+          endPointsForMissingSegment: wire.endPointsForMissingSegment,
+          offlineChannel: wire.offlineChannel,
+          coldElectronicsChannel: wire.coldElectronicsChannel,
+        })
+      }
+    }
+
+    //////////////////
+    // MEASUREMENTS //
+    //////////////////
+    // Additional information about the temperature sensor resistances is found in the previously retrieved 'Frame Prep - Photon Detector Cable and Temperature Sensor Installation' action
+    const tempSensorResistances = [
+      tempSensorInstallAction.data.sensorResistance1,
+      tempSensorInstallAction.data.sensorResistance2,
+      tempSensorInstallAction.data.sensorResistance3,
+      tempSensorInstallAction.data.sensorResistance4,
+    ];
+
+    for (const [index, serialNumber] of tempSensorSerialNumbers.entries()) {
+      singleAPA.data.measurements.tempSensorResistances[`Temperature Sensor ${tempSensorLocations[index]} (${serialNumber})`] = tempSensorResistances[index];
+    }
+
+    // Information about the layer assemblies is found in the collated information object
+    for (let i = 0; i < layers.length; i++) {
+      singleAPA.data.measurements[`${layers[i]}Layer`]['winder'] = collatedInfo[layers[i]].winding_winder;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['winderHead'] = collatedInfo[layers[i]].winding_winderHead;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['wireBobbinManufacturers'] = collatedInfo[layers[i]].winding_bobbinManufacturers;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['winderMaintenanceSignoff'] = collatedInfo[layers[i]].winding_winderMaintenanceSignoff;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['tensionControlSignoff'] = collatedInfo[layers[i]].winding_tensionControlSignoff;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['numberOfReplacedWires'] = collatedInfo[layers[i]].winding_numberOfReplacedWires;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['numberOfTensionAlarms'] = collatedInfo[layers[i]].winding_numberOfTensionAlarms;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['apaDB_winding'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].winding_actionID}`;
+
+      singleAPA.data.measurements[`${layers[i]}Layer`]['numberOfReworkedSolders'] = collatedInfo[layers[i]].soldering_numberOfReworkedSolders;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['apaDB_soldering'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].soldering_actionID}`;
+
+      singleAPA.data.measurements[`${layers[i]}Layer`]['tensionMeasurementLocation'] = collatedInfo[layers[i]].tensions_location;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['tensionSystem'] = collatedInfo[layers[i]].tensions_system;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['tensions_A'] = collatedInfo[layers[i]].tensions_A;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['tensions_B'] = collatedInfo[layers[i]].tensions_B;
+      singleAPA.data.measurements[`${layers[i]}Layer`]['apaDB_tensionMeasurements'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].tensions_actionID}`;
+    }
+
+    // Save the collated information about this APA into the array
+    apaInformation.push(singleAPA);
+  }
+
+  // Return the array containing the combined collated information about both APAs
+  return apaInformation;
 }
 
 

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -3,7 +3,6 @@ const MUUID = require('uuid-mongodb');
 const Actions = require('./Actions');
 const Components = require('./Components');
 const { db } = require('./db');
-const utils = require('./utils');
 
 
 /// Retrieve a list of geometry board shipments that match the specified reception details

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -96,6 +96,7 @@ module.exports = {
     benFurey: 'Ben Furey',
     lewisGannon: 'Lewis Gannon',
     wayneGreen: 'Wayne Green',
+    rowanGreenhalgh: 'Rowan Greenhalgh',
     thomasHanley: 'Thomas Hanley',
     nicholasHays: 'Nicholas Hays',
     adamJones: 'Adam Jones',

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -35,6 +35,8 @@ block content
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
+            else if componentTypeForm.formId == 'Yoke'
+              th.col-md-2 Load Test Status
             else 
               th.col-md-2 
 

--- a/app/pug/search_apasByProductionDetails.pug
+++ b/app/pug/search_apasByProductionDetails.pug
@@ -29,7 +29,7 @@ block content
 
         p The <b><u>production location</u></b> is a required parameter for both scenarios - this <b>must</b> be selected from the associated dropdown menu.  Users may then either manually enter an (integer) production number, or select one of the QA action types from the associated dropdown menu.
 
-        p If searching by production number, if the specified information corresponds to a single Assembled APA component record in the database, the user will be automatically redirected to the corresponding component information page.
+        p If searching by production number, if the specified information corresponds to a single Assembled APA component record in the database, the user will be automatically redirected to either the APA's component information page or directly to its Executive Summary - depending on which of the 'Search by Production Number' buttons is used.
           br
           |  If there is no such APA, i.e. the information does not match an existing component record, a message will be displayed in the results panel below the input selections.
           br
@@ -68,7 +68,10 @@ block content
             input.form-control#numberSelection
 
           .vert-space-x2
-            button.btn-primary.btn-lg#confirmButton_number Search by Production Number
+            .form-inline.font-weight-bold
+              button.btn-primary.btn-lg#confirmButton_numberToInfoPage Search by Production Number
+              br
+              | &nbsp; (Information page)
 
         .col-md-4
           h4 Search by Last Completed QA Action
@@ -91,6 +94,16 @@ block content
 
           .vert-space-x2
             button.btn-primary.btn-lg#confirmButton_assemblyStep Search by Last Completed QA Action
+      .row 
+        .col-md-4
+        .col-md-4
+          .vert-space-x2
+            .form-inline.font-weight-bold
+              button.btn-primary.btn-lg#confirmButton_numberToSummary Search by Production Number
+              br
+              | &nbsp; (Executive Summary)
+
+        .col-md-4
 
       .vert-space-x2 
         hr

--- a/app/pug/workflow_listOfSingleType.pug
+++ b/app/pug/workflow_listOfSingleType.pug
@@ -21,7 +21,13 @@ block content
         thead
           tr
             th.col-md-2 Workflow ID
-            th.col-md-3 Associated Component
+
+            if workflowTypeForm.formName == 'APA Assembly'
+              th.col-md-1 Component
+              th.col-md-2 
+            else 
+              th.col-md-3 Component
+
             th.col-md-1 Completion %
             th.col-md-3 Next Action to Complete
             th.col-md-1
@@ -38,6 +44,12 @@ block content
                     a(href = `/component/${workflow.path[0].result}`) #{workflow.componentName}
                 else 
                   td (component not yet created)
+
+                if workflowTypeForm.formName == 'APA Assembly'
+                  td
+                    a.btn-sm.btn-secondary(href = `/component/${workflow.path[0].result}/execSummary`, target = '_blank')
+                      img.small-icon(src = '/images/checklist_icon.svg')
+                      | &nbsp; Exec. Summary
 
                 if workflow.completionStatus != null
                   if workflow.completionStatus < 50.0

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -880,6 +880,10 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
           board.additionalInformation = '[reception object missing!]';
         }
       }
+    } else if (componentTypeForm.formId === 'Yoke') {
+      for (let yoke of components) {
+        yoke.additionalInformation = dict_yokeLoadTestResults[yoke.data.loadTestStatus];
+      }
     } else {
       for (let component of components) { component.additionalInformation = ''; }
     }

--- a/app/static/pages/component_hwdbInformation.js
+++ b/app/static/pages/component_hwdbInformation.js
@@ -65,8 +65,8 @@ function postSuccess(result) {
   $('#apa2info').empty();
 
   // Show the APA and doublet information in their corresponding page elements
-  $('#apa1info').val(JSON.stringify(result.apa1, null, 2));
-  $('#apa2info').val(JSON.stringify(result.apa2, null, 2));
+  $('#apa1info').val(JSON.stringify(result[0], null, 2));
+  $('#apa2info').val(JSON.stringify(result[1], null, 2));
 
   // Re-enable the confirmation button for the next retrieval
   $('#confirmButton').prop('disabled', false);

--- a/app/static/pages/search_apasByProductionDetails.js
+++ b/app/static/pages/search_apasByProductionDetails.js
@@ -2,6 +2,8 @@
 let apaLocation = null;
 let apaNumber = null;
 let assemblyStep = null;
+let userDirect_toInfoPage = false;
+let userDirect_toSummary = false;
 
 // Run a specific function when the page is loaded
 window.addEventListener('load', renderSearchForms);
@@ -23,9 +25,39 @@ async function renderSearchForms() {
   });
 
   // When the appropriate confirmation button is pressed, perform the search by location and number using the appropriate jQuery 'ajax' call and the current values of the search parameters
-  // Additionally, disable both confirmation buttons while the current search is being performed
-  $('#confirmButton_number').on('click', function () {
-    $('#confirmButton_number').prop('disabled', true);
+  // Additionally, disable all confirmation buttons while the current search is being performed
+  $('#confirmButton_numberToInfoPage').on('click', function () {
+    userDirect_toInfoPage = true;
+    userDirect_toSummary = false;
+
+    $('#confirmButton_numberToInfoPage').prop('disabled', true);
+    $('#confirmButton_numberToSummary').prop('disabled', true);
+    $('#confirmButton_assemblyStep').prop('disabled', true);
+    $('#messages').empty().append('<b>Working ...</b>');
+    $('#summary1').empty();
+    $('#summary2').empty();
+    $('#results11').empty()
+    $('#results12').empty()
+    $('#results21').empty()
+    $('#results22').empty()
+
+    if (apaLocation && apaNumber) {
+      $.ajax({
+        contentType: 'application/json',
+        method: 'GET',
+        url: `/json/search/apasByProductionLocationAndNumber/${apaLocation}/${apaNumber}`,
+        dataType: 'json',
+        success: postSuccess_locationAndNumber,
+      }).fail(postFail);
+    }
+  });
+
+  $('#confirmButton_numberToSummary').on('click', function () {
+    userDirect_toInfoPage = false;
+    userDirect_toSummary = true;
+
+    $('#confirmButton_numberToInfoPage').prop('disabled', true);
+    $('#confirmButton_numberToSummary').prop('disabled', true);
     $('#confirmButton_assemblyStep').prop('disabled', true);
     $('#messages').empty().append('<b>Working ...</b>');
     $('#summary1').empty();
@@ -47,9 +79,13 @@ async function renderSearchForms() {
   });
 
   // When the appropriate confirmation button is pressed, perform the search by location and assembly step using the appropriate jQuery 'ajax' call and the current values of the search parameters
-  // Additionally, disable both confirmation buttons while the current search is being performed
+  // Additionally, disable all confirmation buttons while the current search is being performed
   $('#confirmButton_assemblyStep').on('click', function () {
-    $('#confirmButton_number').prop('disabled', true);
+    userDirect_toInfoPage = false;
+    userDirect_toSummary = false;
+
+    $('#confirmButton_numberToInfoPage').prop('disabled', true);
+    $('#confirmButton_numberToSummary').prop('disabled', true);
     $('#confirmButton_assemblyStep').prop('disabled', true);
     $('#messages').empty().append('<b>Working ...</b>');
     $('#summary1').empty();
@@ -83,12 +119,13 @@ function postSuccess_locationAndNumber(result) {
   $('#results21').empty()
   $('#results22').empty()
 
-  // If there are no search results, display a message to indicate this, and then re-enable both confirmation buttons for the next search
+  // If there are no search results, display a message to indicate this, and then re-enable all confirmation buttons for the next search
   // Similarly, if there is more than one search result (i.e. more than one assembled APA matches the provided record details), also display a message and re-enable the buttons
-  // Otherwise (i.e. there is exactly one assembled APA in the search results), redirect the user to the page for viewing the assembled APA component record
+  // Otherwise (i.e. there is exactly one assembled APA in the search results), redirect the user to the page for viewing the assembled APA's component information page or Executive Summary
   if (result.length === 0) {
     $('#messages').append('<b>There is no Assembled APA matching the specified record details.</b>');
-    $('#confirmButton_locationNumber').prop('disabled', false);
+    $('#confirmButton_numberToInfoPage').prop('disabled', false);
+    $('#confirmButton_numberToSummary').prop('disabled', false);
     $('#confirmButton_assemblyStep').prop('disabled', false);
   } else if (result.length > 1) {
     const output = `
@@ -97,10 +134,15 @@ function postSuccess_locationAndNumber(result) {
       <br>Please bring this to the attention of one of the DB Admins, indicating the APA record details that you used for the search.`;
 
     $('#messages').append(output);
-    $('#confirmButton_locationNumber').prop('disabled', false);
+    $('#confirmButton_numberToInfoPage').prop('disabled', false);
+    $('#confirmButton_numberToSummary').prop('disabled', false);
     $('#confirmButton_assemblyStep').prop('disabled', false);
   } else {
-    window.location.href = `/component/${result[0].componentUuid}`;
+    if (userDirect_toInfoPage) {
+      window.location.href = `/component/${result[0].componentUuid}`;
+    } else if (userDirect_toSummary) {
+      window.location.href = `/component/${result[0].componentUuid}/execSummary`;
+    }
   }
 };
 
@@ -191,8 +233,9 @@ function postSuccess_locationAndAssemblyStep(result) {
     $('#results22').append(apaText);
   }
 
-  // Re-enable both confirmation buttons for the next search
-  $('#confirmButton_number').prop('disabled', false);
+  // Re-enable all confirmation buttons for the next search
+  $('#confirmButton_numberToInfoPage').prop('disabled', false);
+  $('#confirmButton_numberToSummary').prop('disabled', false);
   $('#confirmButton_assemblyStep').prop('disabled', false);
 }
 
@@ -207,6 +250,7 @@ function postFail(result, statusCode, statusMsg) {
   }
 
   // Re-enable both confirmation buttons for the next search
-  $('#confirmButton_number').prop('disabled', false);
+  $('#confirmButton_numberToInfoPage').prop('disabled', false);
+  $('#confirmButton_numberToSummary').prop('disabled', false);
   $('#confirmButton_assemblyStep').prop('disabled', false);
 };


### PR DESCRIPTION
Small tweak to component listing page for yokes
- the single-type component listing page will now display the load test status of yokes

Updates to HWDB info dump functionality
- requested that the HWDB dump contains the same information as the Executive Summaries - changes made accordingly
- HWDB dump now uses the existing Executive Summary collation function, and then restructures the data per the HWDB standard
- combined information is now returned to the interface as a simple array of 2 objects, instead of an object

Small cleanup of unneeded and poorly pathed imports

Additional paths to APA Executive Summaries
- when searching for APAs by Production Details, users now have the option to go directly to the APA's Executive Summary - alongside the existing one that redirects to the component information page
- links to Executive Summaries are now shown in the 'Workflows (Single Type)' listing page for APA Assembly workflows
- links are NOT shown in the general workflows listing page ... the layout doesn't work well since it has to cater for all workflow types simultaneously

Adding new UK factory technician to central dictionary

Changes have been tested on Staging