### PR TITLE
Reworking HWDB Information Dump functionality

### DIFF
--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -741,20 +741,24 @@ async function forExecSummary(componentUUID) {
 }
 
 
-/// Retrieve collated information about two specified APAs comprising a single doublet, for use in the DUNE HWDB
-async function forHWDB(apa1UUID, apa2UUID) {
-  // Set up an array of the APA UUIDs ... this will allow the collating of information to be done in a loop, instead of having to explicitly duplicate the code
-  // Then set up a corresponding array that will contain (and return) the combined collated information about both APAs
-  const apaUuids = [apa1UUID, apa2UUID];
-  let apaInformation = [];
+/// Retrieve information about a specified component in a format suitable for the DUNE HWDB
+async function forHWDB(componentUUID) {
+  // First retrieve the component record with the specified UUID, and then extract the component's type - the specific information to be retrieved for the HWDB will depend on this
+  const component = await Components.retrieve(componentUUID);
 
-  // For each APA UUID ...
-  for (const apaUuid of apaUuids) {
+  if (!component) {
+    return { error: `There is no component record with component UUID = ${componentUUID}` }
+  }
+
+  const componentTypeFormId = component.formId;
+
+  // Retrieve and return the information
+  if (componentTypeFormId === 'AssembledAPA') {
     // Retrieve collated information about the APA using the already-existing function that does the same for populating Executive Summaries
-    // Since the information is identical here, it doesn't make any sense to re-code the retrieval all over again for this function
-    const collatedInfo = await forExecSummary(apaUuid);
+    // The HWDB requires the same information (just in a different format), so it doesn't make any sense to re-code the retrieval all over again for this function
+    const collatedInfo = await forExecSummary(componentUUID);
 
-    // Define the object that will hold the information about a single APA in the structure required by the HWDB
+    // Define the object that will hold the APA information in the format required by the HWDB
     let singleAPA = {};
 
     singleAPA = {
@@ -802,7 +806,7 @@ async function forHWDB(apa1UUID, apa2UUID) {
     singleAPA.data.components.assembledAPA['assemblyStatus'] = collatedInfo.assembledAPA.assemblyStatus;
 
     // Additional information about the APA Frame is found in its component record
-    const assembledAPA = await Components.retrieve(apaUuid);
+    const assembledAPA = await Components.retrieve(componentUUID);
     const apaFrame = await Components.retrieve(assembledAPA.data.frameUuid);
 
     singleAPA.data.components.apaFrame['part_id'] = apaFrame.data.dunePid;
@@ -930,12 +934,11 @@ async function forHWDB(apa1UUID, apa2UUID) {
       singleAPA.data.measurements[`${layers[i]}Layer`]['apaDB_tensionMeasurements'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].tensions_actionID}`;
     }
 
-    // Save the collated information about this APA into the array
-    apaInformation.push(singleAPA);
+    // Return the information about this APA
+    return singleAPA;
+  } else {
+    return { error: `This component's type form ID (${componentTypeFormId}) does not have an HWDB format defined yet!` }
   }
-
-  // Return the array containing the combined collated information about both APAs
-  return apaInformation;
 }
 
 

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -502,7 +502,7 @@ block content
             else 
               p <b>[use the tool to the left to upload an image showing shocklogger data plots]</b>
 
-      if action.typeFormId == 'APANonConformance' || action.typeFormId == 'APAShipmentReception' || action.typeFormId == 'x_tension_testing' || action.typeFormId == 'MeshQAInspection'
+      if action.typeFormId == 'APAColdTest' || action.typeFormId == 'APANonConformance' || action.typeFormId == 'APAShipmentReception' || action.typeFormId == 'x_tension_testing' || action.typeFormId == 'MeshQAInspection'
         .vert-space-x2 
           hr
 

--- a/app/pug/component_hwdbInformation.pug
+++ b/app/pug/component_hwdbInformation.pug
@@ -1,7 +1,7 @@
 extend default
 
 block vars 
-  - const page_title = 'View APA HWDB Information';
+  - const page_title = 'View HWDB Component Information';
 
 block extrascripts
   block workscripts
@@ -10,69 +10,55 @@ block extrascripts
 block content
   .container-fluid
     .vert-space-x2
-      h2 View APA HWDB Information
+      h2 View HWDB Component Information
 
     .vert-space-x2 
       hr
 
       .row 
-        .col-md-5 
-          h4 Select APA 1
+        .col-md-4 
+          h4 Select Component
 
           .vert-space-x1 
             p
-            | Enter the UUID of the doublet's first APA below.<br>
-            | Alternatively, take a picture of the APA's QR code 
+            | Enter the UUID of the component below.<br>
+            | Alternatively, take a picture of the component's QR code.
 
           .vert-space-x1 
-            #apa1uuidform
+            #componentuuidform
 
-        .col-md-5 
-          h4 Select APA 2
+        .col-md-1 
 
-          .vert-space-x1 
-            p
-            | Enter the UUID of the doublet's second APA below.<br>
-            | Alternatively, take a picture of the APA's QR code 
-
-          .vert-space-x1 
-            #apa2uuidform
-
-        .col-md-2
+        .col-md-3
           .vert-space-x2
             input.form-control.spacer
 
           .vert-space-x2
             button.btn-primary.btn-lg#confirmButton Retrieve HWDB Information 
 
+        .col-md-2
+          .vert-space-x2
+            input.form-control.spacer
+
+          .vert-space-x2
+            a#download_componentinfo(onclick = 'DownloadInfo()', download = `hwdbInformation.json`, href = '') Download Component Info
+
+        .col-md-2
+          .vert-space-x2
+            input.form-control.spacer
+
+          .vert-space-x2
+            a.button.btn.btn-primary(onclick = 'CopyInfoToClipboard()') Copy Component Info to Clipboard
+
     .vert-space-x2 
       hr
 
     .vert-space-x1 
       .row 
-        .col-md-5
-          | <b>APA 1:</b>
-          textarea.form-control#apa1info(rows = 10)
+        .col-md-8
+          | <b>Component Information:</b>
+          textarea.form-control#componentinfo(rows = 10)
 
-        .col-md-5
-          | <b>APA 2:</b>
-          textarea.form-control#apa2info(rows = 10)
-
-        .col-md-2
-
-      .row.vert-space-x1
-        .col-md-5
-          a#download_apa1info(onclick = 'DownloadInfo(1)', download = `APA1.json`, href = '') Download APA 1 Info
-
-          .vert-space-x1
-            a.button.btn.btn-primary(onclick = 'CopyInfoToClipboard(1)') Copy APA 1 Info to Clipboard
-
-        .col-md-5
-          a#download_apa2info(onclick = 'DownloadInfo(2)', download = `APA2.json`, href = '') Download APA 2 Info
-
-          .vert-space-x1
-            a.button.btn.btn-primary(onclick = 'CopyInfoToClipboard(2)') Copy APA 2 Info to Clipboard
-
-        .col-md-2
+        .col-md-4
 
     .vert-space-x2

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -933,19 +933,19 @@ router.get('/components/bulkQRCodes/:typeFormId/:firstNumber/:lastNumber', permi
 });
 
 
-/// View information about two specified APAs comprising a single doublet, for use in the DUNE HWDB (client-side interface)
+/// View information about a specified component in a format suitable for the DUNE HWDB (client-side interface)
 router.get('/components/hwdbInformation', async function (req, res, next) {
   // Render the interface page
   res.render('component_hwdbInformation.pug');
 });
 
 
-/// View information about two  specified APAs comprising a single doublet, for use in the DUNE HWDB (query to server-side)
-router.get(['/json/components/hwdbInformation/:apa1uuid/:apa2uuid', '/api/components/hwdbInformation/:apa1uuid/:apa2uuid'], async function (req, res, next) {
+/// View information about a specified component in a format suitable for the DUNE HWDB (query to server-side)
+router.get(['/json/components/hwdbInformation/:uuid', '/api/components/hwdbInformation/:uuid'], async function (req, res, next) {
   try {
-    // Retrieve the collated information about the APAs - since this requires extracting specific field values from a number of DB records related to the APAs ...
+    // Retrieve the collated information - since this may require extracting specific field values from a number of DB records related to the component ...
     // ... it is easier to collate this information through a single library function, rather than performing multiple library function calls from this route
-    let collatedInfo = await Components_CollateInfo.forHWDB(req.params.apa1uuid, req.params.apa2uuid);
+    let collatedInfo = await Components_CollateInfo.forHWDB(req.params.uuid);
 
     // Return the information in JSON format
     return res.status(200).json(collatedInfo);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -41,7 +41,7 @@ module.exports = routes;
   /json/components/:typeFormId/list
   /json/components/boardCounts_byPartNumberAndLocation
   /components/hwdbInformation
-  /json/components/hwdbInformation/:apa1uuid/:apa2uuid
+  /json/components/hwdbInformation/:uuid
 
   /action/:actionId
   /action/:actionId/edit

--- a/app/static/pages/component_hwdbInformation.js
+++ b/app/static/pages/component_hwdbInformation.js
@@ -1,6 +1,5 @@
-// Declare variables to hold the user-specified APA UUIDs
-let apa1Uuid = null;
-let apa2Uuid = null;
+// Declare a variable to hold the user-specified component UUID
+let componentUuid = null;
 
 // Run a specific function when the page is loaded
 window.addEventListener('load', renderSearchForms);
@@ -8,7 +7,7 @@ window.addEventListener('load', renderSearchForms);
 
 // Function to run when the page is loaded
 async function renderSearchForms() {
-  // Create a Formio form consisting of a component UUID input box, and render it in the page elements called 'apa1uuidform' and 'apa2uuidform'
+  // Create a Formio form consisting of a component UUID input box, and render it in the page element called 'componentuuidform'
   const componentUuidSchema = {
     components: [{
       type: 'ComponentUUID',
@@ -19,24 +18,15 @@ async function renderSearchForms() {
     }],
   }
 
-  const apa1UuidForm = await Formio.createForm(document.getElementById('apa1uuidform'), componentUuidSchema);
-  const apa2UuidForm = await Formio.createForm(document.getElementById('apa2uuidform'), componentUuidSchema);
+  const componentUuidForm = await Formio.createForm(document.getElementById('componentuuidform'), componentUuidSchema);
 
-  // When the content of either component UUID input box is changed, get the text string from the box
+  // When the content of the component UUID input box is changed, get the text string from the box
   // If the string is consistent with a valid UUID, set the value of the corresponding parameter
-  apa1UuidForm.on('change', function () {
-    if (apa1UuidForm.isValid()) {
-      const apa1UuidInput = apa1UuidForm.submission.data.componentUuid;
+  componentUuidForm.on('change', function () {
+    if (componentUuidForm.isValid()) {
+      const componentUuidInput = componentUuidForm.submission.data.componentUuid;
 
-      if (apa1UuidInput && apa1UuidInput.length === 36) apa1Uuid = apa1UuidInput;
-    }
-  });
-
-  apa2UuidForm.on('change', function () {
-    if (apa2UuidForm.isValid()) {
-      const apa2UuidInput = apa2UuidForm.submission.data.componentUuid;
-
-      if (apa2UuidInput && apa2UuidInput.length === 36) apa2Uuid = apa2UuidInput;
+      if (componentUuidInput && componentUuidInput.length === 36) componentUuid = componentUuidInput;
     }
   });
 
@@ -45,11 +35,11 @@ async function renderSearchForms() {
   $('#confirmButton').on('click', function () {
     $('#confirmButton').prop('disabled', true);
 
-    if (apa1Uuid && apa2Uuid) {
+    if (componentUuid) {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/components/hwdbInformation/${apa1Uuid}/${apa2Uuid}`,
+        url: `/json/components/hwdbInformation/${componentUuid}`,
         dataType: 'json',
         success: postSuccess,
       }).fail(postFail);
@@ -60,13 +50,11 @@ async function renderSearchForms() {
 
 // Function to run for a successful retrieval query
 function postSuccess(result) {
-  // Make sure that the page elements where the information will be displayed are all empty
-  $('#apa1info').empty();
-  $('#apa2info').empty();
+  // Make sure that the page elements where the component information will be displayed are all empty
+  $('#componentinfo').empty();
 
-  // Show the APA and doublet information in their corresponding page elements
-  $('#apa1info').val(JSON.stringify(result[0], null, 2));
-  $('#apa2info').val(JSON.stringify(result[1], null, 2));
+  // Show the component information in its corresponding page element
+  $('#componentinfo').val(JSON.stringify(result, null, 2));
 
   // Re-enable the confirmation button for the next retrieval
   $('#confirmButton').prop('disabled', false);
@@ -87,37 +75,20 @@ function postFail(result, statusCode, statusMsg) {
 };
 
 
-// When any of the 'Download Info' links are clicked, write the contents of the corresponding JSON schema box to a file and then download the file
-function DownloadInfo(selector) {
-  let info = null;
-  let info_obj = null;
+// When the 'Download Info' link is clicked, write the contents of the JSON schema box to a file and then download the file
+function DownloadInfo() {
+  const info = $('#componentinfo').val();
+  const info_obj = window.URL.createObjectURL(new Blob([info], { type: 'application/JSON' }));
 
-  if (selector === 1) {
-    info = $('#apa1info').val();
-    info_obj = window.URL.createObjectURL(new Blob([info], { type: 'application/JSON' }));
-
-    $('#download_apa1info').attr('href', info_obj);
-  } else if (selector === 2) {
-    info = $('#apa2info').val();
-    info_obj = window.URL.createObjectURL(new Blob([info], { type: 'application/JSON' }));
-
-    $('#download_apa2info').attr('href', info_obj);
-  }
+  $('#download_componentinfo').attr('href', info_obj);
 }
 
 
-// When any of the 'Copy Info to Clipboard' buttons are pressed, copy the contents of the corresponding JSON schema box to the device's clipboard
-function CopyInfoToClipboard(selector) {
-  if (selector === 1) {
-    navigator.clipboard.writeText($('#apa1info').val()).then({
-    }, function (err) {
-      console.error('Error - could not copy APA 1 info', err);
-    })
-  } else if (selector === 2) {
-    navigator.clipboard.writeText($('#apa2info').val()).then({
-    }, function (err) {
-      console.error('Error - could not copy APA 2 info', err);
-    })
-  }
+// When the 'Copy Info to Clipboard' button is pressed, copy the contents of the JSON schema box to the device's clipboard
+function CopyInfoToClipboard() {
+  navigator.clipboard.writeText($('#componentinfo').val()).then({
+  }, function (err) {
+    console.error('Error - could not copy component info', err);
+  })
 };
 


### PR DESCRIPTION
- after discussion with Brian, we realised that the HWDB info dump needs to (eventually) work for other component types, but doesn't need to output simultaneously for more than one at a time
- interface page now only needs one component UUID specified ... fixed surrounding layout accordingly
- changed route and library function accordingly - framework is now in place to extend functionality to other component types as needed in the future
- existing functionality for Assembled APAs remains unchanged

Also making a small change to allow APA Cold Test actions to include images
