### PR TITLE
Changing APA Frame Shipment component type form ID ...

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -208,7 +208,7 @@ async function save(input, req) {
       newRecord.reception.location = newRecord.data.originOfShipment;
     } else if (newRecord.formId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
-    } else if ((newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
@@ -231,22 +231,9 @@ async function save(input, req) {
   // The DUNE PID of such components should technically be fixed at creation, but it is simpler code-wise to assign and re-assign that here as well
   const typeRecordNumber = String(newRecord.data.typeRecordNumber).padStart(5, '0');
 
-  if (newRecord.formId === 'APADoublet') {
-    let name_topApa = '[not set]';
-    let name_bottomApa = '[not set]';
-
-    if (newRecord.data.topApa !== '') {
-      const apa = await retrieve(newRecord.data.topApa);
-      name_topApa = apa.data.componentName;
-    }
-
-    if (newRecord.data.bottomApa !== '') {
-      const apa = await retrieve(newRecord.data.bottomApa);
-      name_bottomApa = apa.data.componentName;
-    }
-
-    newRecord.data.componentName = `${newRecord.formName} (${name_topApa} and ${name_bottomApa})`;
-    newRecord.data.dunePid = `D00200000000-${typeRecordNumber}-US000-010000`;
+  if (newRecord.formId === 'APAFrameShipment') {
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.frameUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'APAShipment') {
     let name_apa1 = '[not set]';
     let name_apa2 = '[not set]';
@@ -277,9 +264,6 @@ async function save(input, req) {
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'DWAComponentShipment') {
     newRecord.data.componentName = `${newRecord.formName} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
-    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'FrameShipment') {
-    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.frameUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GBiasBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
@@ -318,7 +302,7 @@ async function save(input, req) {
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
   if (newRecord.formId === 'APAShipment') {
     const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if ((newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'FrameShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
@@ -422,7 +406,12 @@ async function updateLocations_inShipment(componentUuid, location, date) {
 
   // Loop over all sub-components in the shipment, and update each one's location information appropriately for the shipment type and contents
   // In all cases, if successful, the updating function returns 'result = 1', but we don't actually use this value anywhere
-  if (shipment.formId === 'APAShipment') {
+  if (shipment.formId === 'APAFrameShipment') {
+    // Extract the UUID and update the location information of each APA frame in a shipment of frames
+    for (const frame of shipment.data.frameUuiDs) {
+      const result = await updateLocation(frame.component_uuid, location, date, '');
+    }
+  } else if (shipment.formId === 'APAShipment') {
     // Extract the UUID and update the location information of each assembled APA and the ASF in a shipment of APAs
     for (const apa of shipment.data.apaUuiDs) {
       const result = await updateLocation(apa.component_uuid, location, date, '');
@@ -438,11 +427,6 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     // Extract the UUID and update the location information of each component in a (combined) shipment of DWAs and DWAPDBs
     for (const dwa of shipment.data.componentUUIDs) {
       const result = await updateLocation(dwa.component_uuid, location, date, '');
-    }
-  } else if (shipment.formId === 'FrameShipment') {
-    // Extract the UUID and update the location information of each APA frame in a shipment of frames
-    for (const frame of shipment.data.frameUuiDs) {
-      const result = await updateLocation(frame.component_uuid, location, date, '');
     }
   } else if (shipment.formId === 'GroundingMeshShipment') {
     // Extract the UUID and update the location information of each mesh in a shipment of meshes

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -21,8 +21,8 @@ block content
 
           //select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'APADoublet') APA Doublet
             option(value = 'APAFrame') APA Frame 
+            option(value = 'APAFrameShipment') APA Frame Shipment
             option(value = 'APAShipment') APA Shipment 
             option(value = 'APAShippingFrame') APA Shipping Frame (ASF)
             option(value = 'AssembledAPA') Assembled APA 
@@ -38,7 +38,6 @@ block content
             option(value = 'DWA') DWA
             option(value = 'DWAComponentShipment') DWA Component Shipment
             option(value = 'DWAPDB') DWA PDB 
-            option(value = 'FrameShipment') Frame Shipment
             option(value = 'GBiasBoard') G-Bias Board
             option(value = 'GBiasBoardBatch') G-Bias Board Batch
             option(value = 'GBiasBoardShipment') G-Bias Board Kit

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -156,7 +156,38 @@ block content
 
           p.small.text-center #{base_url}/c/#{component.shortUuid.toString()}
 
-    if component.formId === 'BoardShipment'
+    if component.formId === 'APAFrameShipment'
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt Origin Location
+        dd #{dictionary_locations[component.data.originOfShipment]}
+
+        dt Destination Location
+        dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+        dt Frames in Shipment
+        dd
+          table.table 
+            thead 
+              tr 
+                th.col-md-2 UUID 
+                th.col-md-1 Factory ID
+                th.col-md-1 DUNE PID
+                th.col-md-3 QR Code Link 
+
+            tbody 
+              each info in collectionDetails
+                tr
+                  td
+                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
+                  td #{info[1]}
+                  td #{info[2]}
+                  td #{`${base_url}/c/${info[3]}`}
+
+        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
+          img.small-icon(src = '/images/checklist_icon.svg')
+          | &nbsp; Print all sub-component QR codes
+    else if component.formId === 'BoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location 
         dd #{dictionary_locations[component.data.originOfShipment]}
@@ -245,37 +276,6 @@ block content
 
                   td #{info[2]}
                   td #{info[1]}
-                  td #{`${base_url}/c/${info[3]}`}
-
-        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-          img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'FrameShipment'
-      .vert-space-x1.border-success.border.rounded.p-2
-        dt Origin Location
-        dd #{dictionary_locations[component.data.originOfShipment]}
-
-        dt Destination Location
-        dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-        dt Frames in Shipment
-        dd
-          table.table 
-            thead 
-              tr 
-                th.col-md-2 UUID 
-                th.col-md-1 Factory ID
-                th.col-md-1 DUNE PID
-                th.col-md-3 QR Code Link 
-
-            tbody 
-              each info in collectionDetails
-                tr
-                  td
-                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
-
-                  td #{info[1]}
-                  td #{info[2]}
                   td #{`${base_url}/c/${info[3]}`}
 
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -31,7 +31,7 @@ block content
               th.col-md-2 Installed on APA
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'FrameShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'FrameShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -40,7 +40,7 @@ block allbody
 
               dt Component UUID
               dd #{component.componentUuid}
-              
+
               if component.formId == 'BoardShipment' || component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
                 dt Number of Boards in Shipment
                 dd #{component.data.boardUuiDs.length}
@@ -62,7 +62,30 @@ block allbody
             if component.insertion.user
               |  by !{' '} #{component.insertion.user.displayName}
 
-      if component.formId === 'BoardShipment'
+      if component.formId === 'APAFrameShipment'
+        .vert-space-x1.border-success.border.rounded.p-2
+          dt Origin Location
+          dd #{dictionary_locations[component.data.originOfShipment]}
+
+          dt Destination Location
+          dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+          dt Frames in Shipment
+          dd
+            table.table 
+              thead 
+                tr 
+                  th.col-sm-1 UUID 
+                  th.col-sm-1 Factory ID
+                  th.col-sm-1 DUNE PID 
+
+              tbody 
+                each info in collectionDetails
+                  tr
+                    td #{info[0]}
+                    td #{info[1]}
+                    td #{info[2]}
+      else if component.formId === 'BoardShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location 
           dd #{dictionary_locations[component.data.originOfShipment]}
@@ -125,29 +148,6 @@ block allbody
                     td #{info[0]}
                     td #{info[2]}
                     td #{info[1]}
-      else if component.formId === 'FrameShipment'
-        .vert-space-x1.border-success.border.rounded.p-2
-          dt Origin Location
-          dd #{dictionary_locations[component.data.originOfShipment]}
-
-          dt Destination Location
-          dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-          dt Frames in Shipment
-          dd
-            table.table 
-              thead 
-                tr 
-                  th.col-sm-1 UUID 
-                  th.col-sm-1 Factory ID
-                  th.col-sm-1 DUNE PID 
-
-              tbody 
-                each info in collectionDetails
-                  tr
-                    td #{info[0]}
-                    td #{info[1]}
-                    td #{info[2]}
       else if component.formId === 'GroundingMeshShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location

--- a/app/pug/search_componentsByIdentifier.pug
+++ b/app/pug/search_componentsByIdentifier.pug
@@ -63,7 +63,6 @@ block content
           .vert-space-x1
             select.form-control#componentTypeSelection
               option(value = '')
-              option(value = 'APADoublet') APA Doublet 
               option(value = 'APAFrame') APA Frame
               option(value = 'APAShippingFrame') APA Shipping Frame (ASF)
               option(value = 'AssembledAPA') Assembled APA

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -178,6 +178,16 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // For the other shipment and batch component types, set up an array containing more detailed information about each sub-component
     let collectionDetails = [];
 
+    if (component.formId === 'APAFrameShipment') {
+      for (const info of component.data.frameUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.dunePid, componentRecord.shortUuid]);
+        }
+      }
+    }
+
     if (component.formId === 'BoardShipment') {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
@@ -204,16 +214,6 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
           const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
-        }
-      }
-    }
-
-    if (component.formId === 'FrameShipment') {
-      for (const info of component.data.frameUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.dunePid, componentRecord.shortUuid]);
         }
       }
     }
@@ -390,6 +390,16 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
     // ... but for batch-type components, they are already saved in the batch component's own record, so the individual sub-component records are not needed
     let shortUUIDs = [];
 
+    if (component.formId === 'APAFrameShipment') {
+      for (const info of component.data.frameUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
+        }
+      }
+    }
+
     if ((component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
@@ -402,16 +412,6 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
 
     if (component.formId === 'DWAComponentShipment') {
       for (const info of component.data.componentUUIDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
-        }
-      }
-    }
-
-    if (component.formId === 'FrameShipment') {
-      for (const info of component.data.frameUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
 
@@ -554,6 +554,16 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
     // For specific shipment and batch component types, set up an array containing more detailed information about each sub-component
     let collectionDetails = [];
 
+    if (component.formId === 'APAFrameShipment') {
+      for (const info of component.data.frameUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.dunePid]);
+        }
+      }
+    }
+
     if (component.formId === 'BoardShipment') {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
@@ -580,16 +590,6 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
           const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
-        }
-      }
-    }
-
-    if (component.formId === 'FrameShipment') {
-      for (const info of component.data.frameUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.dunePid]);
         }
       }
     }
@@ -863,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'FrameShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.reception != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.reception.location]; }
         else { shipment.additionalInformation = '[reception object missing!]'; }


### PR DESCRIPTION
- the 'APA Frame Shipment' component type currently has an form ID and name of 'Frame Shipment'
- changed to 'APA Frame Shipment' to make it consistent with the actual APA Frames
- change already made to type form (actually just made a new one with the corrected name, since I cannot change an existing type form's ID) ... simple to do for this one, since there are no components of this type