### PR TITLE
Component Type Form ID and Name Consistency Changes (PR 1 of 2)

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -18,6 +18,9 @@ async function cleanComponentTypeFormIds(typeFormId) {
   } else if (typeFormId === 'wire_bobbin') {
     newTypeFormId = 'WireBobbin';
     newTypeFormName = 'Wire Bobbin';
+  } else if (typeFormId === 'BoardShipment') {
+    newTypeFormId = 'GeometryBoardShipment';
+    newTypeFormName = 'Geometry Board Shipment';
   }
 
   const result = await db.collection('components')

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -8,109 +8,34 @@ const logger = require('./logger');
 const utils = require('./utils');
 
 
-async function cleanComponentRecords(typeFormId) {
-  let deleteCondition = null;
+async function cleanComponentTypeFormIds(typeFormId) {
+  let newTypeFormId = null;
+  let newTypeFormName = null;
 
-  if (typeFormId === 'ALL_COMPONENTS') {
-    deleteCondition = { $unset: { 'data.name': "" } };
-  } else if (typeFormId === 'APAFrame') {
-    deleteCondition = { $unset: { 'data.frameNumber': "" } };
-  } else if (typeFormId === 'AssembledAPA') {
-    deleteCondition = { $unset: { 'data.apaNumberAtLocation': "" } };
-  } else if (typeFormId === 'DWA') {
-    deleteCondition = { $unset: { 'data.dwaNumber': "" } };
-  } else if (typeFormId === 'DWAPDB') {
-    deleteCondition = { $unset: { 'data.pdbNumber': "" } };
+  if (typeFormId === 'GroundingMeshShipment') {
+    newTypeFormId = 'GroundingMeshPanelShipment';
+    newTypeFormName = 'Grounding Mesh Panel Shipment';
   }
-
-  const matchCondition = (typeFormId === 'ALL_COMPONENTS') ? {} : { formId: typeFormId };
 
   const result = await db.collection('components')
     .updateMany(
-      matchCondition,
-      deleteCondition,
+      { formId: typeFormId },
+      [
+        {
+          $set: {
+            'formId': newTypeFormId,
+            'formName': newTypeFormName,
+          }
+        },
+      ]
     )
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentRecords() - failed to delete fields from the component records!`);
+  if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
 
-  return typeFormId;
+  return newTypeFormId;
 }
 
-
-async function addComponentInfoToActionRecords(componentType) {
-  const apaFramesAndShipments = ['DeliveredFrameQAChecks', 'CompletedFrameQCChecklist', 'InstallationSurveys', 'IntakeSurveys', 'APAShipmentReception', 'APAShipmentTransport', 'ASFCloseUp'];
-  let assembledAPAs = [];
-
-  const apaWorkflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
-  let actionTypeForms = await Forms.list('actionForms');
-  let list_apaWorkflowActionNames = [];
-
-  for (const step of apaWorkflowTypeForm.path.slice(1)) {
-    list_apaWorkflowActionNames.push(step.formName);
-  }
-
-  for (const [typeFormID, typeForm] of Object.entries(actionTypeForms)) {
-    if (list_apaWorkflowActionNames.includes(typeForm.formName)) {
-      assembledAPAs.push(typeFormID);
-    }
-  }
-
-  const geometryBoards = ['BoardToothStripAttachment', 'BoardVisualInspection', 'FactoryBoardRejection'];
-  const groundingMeshPanels = ['EpoxyApplication', 'FinalInspection', 'MeshQAInspection', 'APANonConformance', 'ReceiptInspection'];
-
-  const combined = apaFramesAndShipments.concat(assembledAPAs, geometryBoards, groundingMeshPanels);
-  let otherComponents = [];
-
-  for (const [typeFormID, typeForm] of Object.entries(actionTypeForms)) {
-    if (!(combined.includes(typeFormID)) && !(typeForm.tags.includes('Trash'))) {
-      otherComponents.push(typeFormID);
-    }
-  }
-
-  let filterCondition = null;
-
-  if (componentType === 'APAFramesAndShipments') {
-    filterCondition = { 'typeFormId': { $in: apaFramesAndShipments } }
-  } else if (componentType === 'AssembledAPAs') {
-    filterCondition = { 'typeFormId': { $in: assembledAPAs } }
-  } else if (componentType === 'GeometryBoards_BoardToothStripAttachment') {
-    filterCondition = { 'typeFormId': 'BoardToothStripAttachment' }
-  } else if (componentType === 'GeometryBoards_BoardVisualInspection') {
-    filterCondition = { 'typeFormId': 'BoardVisualInspection' }
-  } else if (componentType === 'GeometryBoards_FactoryBoardRejection') {
-    filterCondition = { 'typeFormId': 'FactoryBoardRejection' }
-  } else if (componentType === 'GroundingMeshPanels') {
-    filterCondition = { 'typeFormId': { $in: groundingMeshPanels } }
-  } else if (componentType === 'OtherComponents') {
-    filterCondition = { 'typeFormId': { $in: otherComponents } }
-  }
-
-  const result = await db.collection('actions')
-    .find(filterCondition)
-    .forEach(async function (actionRecord) {
-      const componentRecord = await Components.retrieve(actionRecord.componentUuid);
-      const componentName = (componentRecord) ? componentRecord.data.componentName : '[no component record found!]';
-      const componentTypeFormId = (componentRecord) ? componentRecord.formId : '[no component record found!]';
-      const componentTypeFormName = (componentRecord) ? componentRecord.formName : '[no component record found!]';
-
-      const innerResult = db.collection('actions')
-        .updateOne(
-          { _id: actionRecord._id },
-          {
-            $set: {
-              'componentName': componentName,
-              'componentTypeFormId': componentTypeFormId,
-              'componentTypeFormName': componentTypeFormName,
-            }
-          },
-        );
-
-    });
-
-  return 'ALL_ACTIONS';
-}
 
 module.exports = {
-  cleanComponentRecords,
-  addComponentInfoToActionRecords,
+  cleanComponentTypeFormIds,
 }

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -15,6 +15,9 @@ async function cleanComponentTypeFormIds(typeFormId) {
   if (typeFormId === 'GroundingMeshShipment') {
     newTypeFormId = 'GroundingMeshPanelShipment';
     newTypeFormName = 'Grounding Mesh Panel Shipment';
+  } else if (typeFormId === 'wire_bobbin') {
+    newTypeFormId = 'WireBobbin';
+    newTypeFormName = 'Wire Bobbin';
   }
 
   const result = await db.collection('components')

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -185,12 +185,12 @@ async function save(input, req) {
     } else if (newRecord.formId === 'SHVBoard') {
       newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300500001-${typeRecordNumber}-US200-010000`;
+    } else if (newRecord.formId === 'WireBobbin') {
+      newRecord.data.componentName = `${newRecord.formName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     } else if (newRecord.formId === 'Yoke') {
       newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00301000001-${typeRecordNumber}-US200-010000`;
-    } else if (newRecord.formId === 'wire_bobbin') {
-      newRecord.data.componentName = `${newRecord.formName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
-      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     }
 
     // Set up a new 'Reception' object to hold the component's current location and the date at which it was received at this location ... and we can immediately set the date to be the current one
@@ -202,7 +202,7 @@ async function save(input, req) {
 
     // Almost all component types will always start at specific fixed locations ...
     // ... the only exceptions are the 'batch' types (these still need the location field to exist, but it can be left as an empty string)
-    if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'wire_bobbin')) {
+    if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'WireBobbin')) {
       newRecord.reception.location = 'daresbury';
     } else if (newRecord.formId === 'APAShipment') {
       newRecord.reception.location = newRecord.data.originOfShipment;

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -208,7 +208,7 @@ async function save(input, req) {
       newRecord.reception.location = newRecord.data.originOfShipment;
     } else if (newRecord.formId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
-    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
@@ -250,9 +250,6 @@ async function save(input, req) {
 
     newRecord.data.componentName = `${newRecord.formName} (${name_apa1} and ${name_apa2})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'BoardShipment') {
-    newRecord.data.componentName = `Geometry ${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
-    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'CEAdapterBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
@@ -267,6 +264,9 @@ async function save(input, req) {
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GBiasBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'GeometryBoardShipment') {
+    newRecord.data.componentName = `Geometry ${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GroundingMeshPanelShipment') {
     newRecord.data.componentName = `Grounding Mesh Panel Shipment (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
@@ -302,7 +302,7 @@ async function save(input, req) {
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
   if (newRecord.formId === 'APAShipment') {
     const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
@@ -418,7 +418,7 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     }
 
     const result = await updateLocation(shipment.data.asfUuid, location, date, '');
-  } else if ((shipment.formId === 'BoardShipment') || (shipment.formId === 'CEAdapterBoardShipment') || (shipment.formId === 'CRBoardShipment') || (shipment.formId === 'CableHarnessShipment') || (shipment.formId === 'GBiasBoardShipment') || (shipment.formId === 'SHVBoardShipment')) {
+  } else if ((shipment.formId === 'CEAdapterBoardShipment') || (shipment.formId === 'CRBoardShipment') || (shipment.formId === 'CableHarnessShipment') || (shipment.formId === 'GBiasBoardShipment') || (shipment.formId === 'GeometryBoardShipment') || (shipment.formId === 'SHVBoardShipment')) {
     // Extract the UUID and update the location information of each board in a shipment of (single type) boards
     for (const board of shipment.data.boardUuiDs) {
       const result = await updateLocation(board.component_uuid, location, date, '');

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -208,7 +208,7 @@ async function save(input, req) {
       newRecord.reception.location = newRecord.data.originOfShipment;
     } else if (newRecord.formId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
-    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
@@ -268,7 +268,7 @@ async function save(input, req) {
   } else if (newRecord.formId === 'GBiasBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'GroundingMeshShipment') {
+  } else if (newRecord.formId === 'GroundingMeshPanelShipment') {
     newRecord.data.componentName = `Grounding Mesh Panel Shipment (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'PopulatedBoardShipment') {
@@ -302,7 +302,7 @@ async function save(input, req) {
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
   if (newRecord.formId === 'APAShipment') {
     const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
@@ -428,7 +428,7 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     for (const dwa of shipment.data.componentUUIDs) {
       const result = await updateLocation(dwa.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'GroundingMeshShipment') {
+  } else if (shipment.formId === 'GroundingMeshPanelShipment') {
     // Extract the UUID and update the location information of each mesh in a shipment of meshes
     for (const mesh of shipment.data.apaUuiDs) {
       const result = await updateLocation(mesh.component_uuid, location, date, '');

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -6,7 +6,7 @@ const { db } = require('./db');
 
 
 /// Retrieve a list of geometry board shipments that match the specified reception details
-async function boardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment) {
+async function geoBoardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment) {
   // Set up 'matching' strings that can be used by MongoDB to match against specific record field values
   // For each potential location (origin or destination), if it has been specified, just use it as the matching string ... otherwise use a fully wildcard regular expression
   const originString = (origin) ? origin : /(.*?)/;
@@ -14,10 +14,10 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
 
   let comp_aggregation_stages = [];
 
-  // Match against the type form ID and both locations to get records of all 'Board Shipment' components that were supposed to travel between the specified locations
+  // Match against the type form ID and both locations to get records of all 'Geometry Board Shipment' components that were supposed to travel between the specified locations
   comp_aggregation_stages.push({
     $match: {
-      'formId': 'BoardShipment',
+      'formId': 'GeometryBoardShipment',
       'data.originOfShipment': originString,
       'data.destinationOfShipment': destinationString,
     }
@@ -39,7 +39,7 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
     .aggregate(comp_aggregation_stages)
     .toArray();
 
-  // At this point, we have a list of 'Board Shipment' component records that:
+  // At this point, we have a list of 'Geometry Board Shipment' component records that:
   //   - originated at the specified origin location (if one was specified), or at any location (if not)
   //   - were supposed to end up at the specified destination location (if one was specified), or at any location (if not)
   // But what we actually want is a combination of some information from both the shipment component record and the corresponding reception action record (if the shipment has been received)
@@ -49,7 +49,7 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
   for (const shipmentRecord of component_results) {
     let action_aggregation_stages = [];
 
-    // Match against the type form ID and component UUID to get records of all 'Board Reception' actions performed on the specified board shipment component
+    // Match against the type form ID and component UUID to get records of all 'Board Reception' actions performed on the specified geometry board shipment component
     action_aggregation_stages.push({
       $match: {
         'typeFormId': 'BoardReception',
@@ -145,11 +145,11 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
 
 
 /// Retrieve a list of geometry board shipments that reference a single component, specified by its UUID
-async function boardShipmentsByBoardUUID(componentUUID) {
+async function geoBoardShipmentsByBoardUUID(componentUUID) {
   let aggregation_stages = [];
 
-  // Match against the type form ID to get records of all 'Board Shipment' components
-  aggregation_stages.push({ $match: { 'formId': 'BoardShipment' } });
+  // Match against the type form ID to get records of all 'Geometry Board Shipment' components
+  aggregation_stages.push({ $match: { 'formId': 'GeometryBoardShipment' } });
 
   // Select the latest version of each record, and pass through only the fields required for later use
   aggregation_stages.push({ $sort: { 'validity.version': -1 } });
@@ -810,8 +810,8 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
 
 
 module.exports = {
-  boardShipmentsByReceptionDetails,
-  boardShipmentsByBoardUUID,
+  geoBoardShipmentsByReceptionDetails,
+  geoBoardShipmentsByBoardUUID,
   apasByProductionLocationAndNumber,
   apasByProductionLocationAndAssemblyStep,
   componentsByDUNEPID,

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -125,6 +125,7 @@ module.exports = {
     stephenSumner: 'Stephen Sumner',
     chrisSutton: 'Chris Sutton',
     jasonThornhill: 'Jason Thornhill',
+    douglasTsim: 'Douglas Tsim',
     oliverUnwin: 'Oliver Unwin',
     anthonyWatling: 'Anthony Watling',
     lewisWatson: 'Lewis Watson',

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -23,11 +23,9 @@ block content
             option(value = '')
             option(value = 'APAFrame') APA Frame 
             option(value = 'APAFrameShipment') APA Frame Shipment
-            option(value = 'APAShipment') APA Shipment 
             option(value = 'APAShippingFrame') APA Shipping Frame (ASF)
             option(value = 'AssembledAPA') Assembled APA 
             option(value = 'AssembledAPAShipment') Assembled APA Shipment
-            option(value = 'BoardShipment') Board Shipment 
             option(value = 'CEAdapterBoard') CE Adapter Board
             option(value = 'CEAdapterBoardBatch') CE Adapter Board Batch 
             option(value = 'CEAdapterBoardShipment') CE Adapter Board Shipment 
@@ -46,16 +44,14 @@ block content
             option(value = 'GeometryBoardBatch') Geometry Board Batch
             option(value = 'GeometryBoardShipment') Geometry Board Shipment 
             option(value = 'GroundingMeshPanel') Grounding Mesh Panel
-            option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
             option(value = 'GroundingMeshPanelShipment') Grounding Mesh Shipment 
             option(value = 'PopulatedBoardShipment') Multi-Type Populated Board Shipment
             option(value = 'ReturnedGeometryBoardBatch') Returned Geometry Board Batch
             option(value = 'SHVBoard') SHV Board
             option(value = 'SHVBoardShipment') SHV Board Kit
+            option(value = 'WireBobbin') Wire Bobbin
             option(value = 'Yoke') Yoke
             option(value = 'YokeShipment') Yoke Shipment
-            option(value = 'wire_bobbin') Wire Bobbin
-            option(value = 'WireBobbin') Wire Bobbin
 
           select.form-control#inputStringSelection
             option(value = '')

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -26,6 +26,7 @@ block content
             option(value = 'APAShipment') APA Shipment 
             option(value = 'APAShippingFrame') APA Shipping Frame (ASF)
             option(value = 'AssembledAPA') Assembled APA 
+            option(value = 'AssembledAPAShipment') Assembled APA Shipment
             option(value = 'BoardShipment') Board Shipment 
             option(value = 'CEAdapterBoard') CE Adapter Board
             option(value = 'CEAdapterBoardBatch') CE Adapter Board Batch 
@@ -43,8 +44,10 @@ block content
             option(value = 'GBiasBoardShipment') G-Bias Board Kit
             option(value = 'GeometryBoard') Geometry Board
             option(value = 'GeometryBoardBatch') Geometry Board Batch
+            option(value = 'GeometryBoardShipment') Geometry Board Shipment 
             option(value = 'GroundingMeshPanel') Grounding Mesh Panel
             option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
+            option(value = 'GroundingMeshPanelShipment') Grounding Mesh Shipment 
             option(value = 'PopulatedBoardShipment') Multi-Type Populated Board Shipment
             option(value = 'ReturnedGeometryBoardBatch') Returned Geometry Board Batch
             option(value = 'SHVBoard') SHV Board
@@ -52,22 +55,15 @@ block content
             option(value = 'Yoke') Yoke
             option(value = 'YokeShipment') Yoke Shipment
             option(value = 'wire_bobbin') Wire Bobbin
+            option(value = 'WireBobbin') Wire Bobbin
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'ALL_COMPONENTS') ALL COMPONENT TYPES
-            option(value = 'APAFrame') APA Frame 
-            option(value = 'AssembledAPA') Assembled APA 
-            option(value = 'DWA') DWA
-            option(value = 'DWAPDB') DWA PDB 
-            option(value = 'N.A.') ----------
-            option(value = 'APAFramesAndShipments') APA Frames and Shipments
-            option(value = 'AssembledAPAs') Assembled APAs
-            option(value = 'GeometryBoards_BoardToothStripAttachment') Geometry Boards (Tooth Strip Attachment)
-            option(value = 'GeometryBoards_BoardVisualInspection') Geometry Boards (Visual Inspection)
-            option(value = 'GeometryBoards_FactoryBoardRejection') Geometry Boards (Factory Rejection)
-            option(value = 'GroundingMeshPanels') Grounding Mesh Panels
-            option(value = 'OtherComponents') ALL OTHER COMPONENT TYPES
+            option(value = 'APAShipment') APA Shipment 
+            option(value = 'BoardShipment') Board Shipment 
+            option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
+            option(value = 'wire_bobbin') Wire Bobbin
+            
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -281,7 +281,7 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'GroundingMeshShipment'
+    else if component.formId === 'GroundingMeshPanelShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
         dd #{dictionary_locations[component.data.originOfShipment]}

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -187,37 +187,6 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'BoardShipment'
-      .vert-space-x1.border-success.border.rounded.p-2
-        dt Origin Location 
-        dd #{dictionary_locations[component.data.originOfShipment]}
-
-        dt Destination Location
-        dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-        dt Boards in Shipment
-        dd
-          table.table
-            thead
-              tr
-                th.col-md-2 UUID
-                th.col-md-1 UK ID
-                th.col-md-1 Part Number
-                th.col-md-3 QR Code Link 
-
-            tbody
-              each info in collectionDetails
-                tr
-                  td
-                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
-
-                  td #{info[1]}
-                  td #{info[2]}
-                  td #{`${base_url}/c/${info[3]}`}
-
-        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-          img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; Print all sub-component QR codes
     else if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         if component.formId === 'CEAdapterBoardShipment'
@@ -276,6 +245,37 @@ block content
 
                   td #{info[2]}
                   td #{info[1]}
+                  td #{`${base_url}/c/${info[3]}`}
+
+        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
+          img.small-icon(src = '/images/checklist_icon.svg')
+          | &nbsp; Print all sub-component QR codes
+    else if component.formId === 'GeometryBoardShipment'
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt Origin Location 
+        dd #{dictionary_locations[component.data.originOfShipment]}
+
+        dt Destination Location
+        dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+        dt Boards in Shipment
+        dd
+          table.table
+            thead
+              tr
+                th.col-md-2 UUID
+                th.col-md-1 UK ID
+                th.col-md-1 Part Number
+                th.col-md-3 QR Code Link 
+
+            tbody
+              each info in collectionDetails
+                tr
+                  td
+                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
+                  td #{info[1]}
+                  td #{info[2]}
                   td #{`${base_url}/c/${info[3]}`}
 
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
@@ -462,7 +462,7 @@ block content
             tbody 
               each entry in actions
                 tr 
-                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Board Shipment')
+                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Geometry Board Shipment')
                     td 
                       a(href = `/component/${entry.componentUuid}`) #{entry.typeFormName}
                   else 
@@ -472,7 +472,7 @@ block content
                   td #{entry.lastEditDate.toISOString().slice(0, 10)}
                   td #{dictionary_locations[entry.data.originOfShipment]}
 
-                  if entry.typeFormName === 'Board Shipment'
+                  if entry.typeFormName === 'Geometry Board Shipment'
                     if entry.reception
                       if entry.reception.location === 'in_transit'
                         td #{dictionary_locations[entry.data.destinationOfShipment]}
@@ -487,7 +487,7 @@ block content
                     td -
                     td -
 
-                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Board Shipment')
+                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Geometry Board Shipment')
                     td -
                   else 
                     td #{entry.data.checksPassed}

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -31,7 +31,7 @@ block content
               th.col-md-2 Installed on APA
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -31,7 +31,7 @@ block content
               th.col-md-2 Installed on APA
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -41,7 +41,7 @@ block allbody
               dt Component UUID
               dd #{component.componentUuid}
 
-              if component.formId == 'BoardShipment' || component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
+              if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId == 'GeometryBoardShipment' || component.formId === 'SHVBoardShipment'
                 dt Number of Boards in Shipment
                 dd #{component.data.boardUuiDs.length}
 
@@ -80,29 +80,6 @@ block allbody
                   th.col-sm-1 DUNE PID 
 
               tbody 
-                each info in collectionDetails
-                  tr
-                    td #{info[0]}
-                    td #{info[1]}
-                    td #{info[2]}
-      else if component.formId === 'BoardShipment'
-        .vert-space-x1.border-success.border.rounded.p-2
-          dt Origin Location 
-          dd #{dictionary_locations[component.data.originOfShipment]}
-
-          dt Destination Location
-          dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-          dt Boards in Shipment
-          dd
-            table.table
-              thead
-                tr
-                  th.col-sm-1 UUID
-                  th.col-sm-1 UK ID
-                  th.col-sm-1 Part Number
-
-              tbody
                 each info in collectionDetails
                   tr
                     td #{info[0]}
@@ -148,6 +125,29 @@ block allbody
                     td #{info[0]}
                     td #{info[2]}
                     td #{info[1]}
+      else if component.formId === 'GeometryBoardShipment'
+        .vert-space-x1.border-success.border.rounded.p-2
+          dt Origin Location 
+          dd #{dictionary_locations[component.data.originOfShipment]}
+
+          dt Destination Location
+          dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+          dt Boards in Shipment
+          dd
+            table.table
+              thead
+                tr
+                  th.col-sm-1 UUID
+                  th.col-sm-1 UK ID
+                  th.col-sm-1 Part Number
+
+              tbody
+                each info in collectionDetails
+                  tr
+                    td #{info[0]}
+                    td #{info[1]}
+                    td #{info[2]}
       else if component.formId === 'GroundingMeshPanelShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -148,7 +148,7 @@ block allbody
                     td #{info[0]}
                     td #{info[2]}
                     td #{info[1]}
-      else if component.formId === 'GroundingMeshShipment'
+      else if component.formId === 'GroundingMeshPanelShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location
           dd #{dictionary_locations[component.data.originOfShipment]}

--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -137,7 +137,7 @@ body(class = `deployment-${NODE_ENV}`)
                     |      Geometry Boards by Visual Inspection or Order Number
 
                 li.nav-item
-                  +navlink(href = '/search/boardShipmentsByReceptionDetails')
+                  +navlink(href = '/search/geoBoardShipmentsByReceptionDetails')
                     |      Geometry Board Shipments by Reception Details
 
                 li.nav-item

--- a/app/pug/search_geoBoardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_geoBoardShipmentsByReceptionDetails.pug
@@ -8,7 +8,7 @@ block extrascripts
     const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
 
   block workscripts 
-    script(src = '/pages/search_boardShipmentsByReceptionDetails.js')
+    script(src = '/pages/search_geoBoardShipmentsByReceptionDetails.js')
 
 block content
   .container-fluid

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -218,7 +218,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'GroundingMeshShipment') {
+    if (component.formId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -420,7 +420,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if (component.formId === 'GroundingMeshShipment') {
+    if (component.formId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -594,7 +594,7 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if (component.formId === 'GroundingMeshShipment') {
+    if (component.formId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -863,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.reception != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.reception.location]; }
         else { shipment.additionalInformation = '[reception object missing!]'; }

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -56,11 +56,11 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // Add this information to the previously retrieved list of actions performed on the board, and make sure that all of the action entries contain the same (or equivalent) fields
     // Add an entry for the board itself (again, containing the same fields as the action entries), and finally sort all entries in the combined array by the 'lastEditDate' field
     if (component.formId === 'GeometryBoard') {
-      boardShipments = await Search_OtherComponents.boardShipmentsByBoardUUID(req.params.uuid);
-      actions = actions.concat(boardShipments);
+      geoBoardShipments = await Search_OtherComponents.geoBoardShipmentsByBoardUUID(req.params.uuid);
+      actions = actions.concat(geoBoardShipments);
 
       for (let entry of actions) {
-        if (entry.typeFormId !== 'BoardShipment') {
+        if (entry.typeFormId !== 'GeometryBoardShipment') {
           entry.data = {};
           entry.data.checksPassed = '[n.a.]';
 
@@ -188,16 +188,6 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'BoardShipment') {
-      for (const info of component.data.boardUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber, componentRecord.shortUuid]);
-        }
-      }
-    }
-
     if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
@@ -214,6 +204,16 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
           const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+        }
+      }
+    }
+
+    if (component.formId === 'GeometryBoardShipment') {
+      for (const info of component.data.boardUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber, componentRecord.shortUuid]);
         }
       }
     }
@@ -400,7 +400,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if ((component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
+    if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -564,16 +564,6 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if (component.formId === 'BoardShipment') {
-      for (const info of component.data.boardUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber]);
-        }
-      }
-    }
-
     if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
@@ -590,6 +580,16 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
           const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+        }
+      }
+    }
+
+    if (component.formId === 'GeometryBoardShipment') {
+      for (const info of component.data.boardUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber]);
         }
       }
     }
@@ -863,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.reception != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.reception.location]; }
         else { shipment.additionalInformation = '[reception object missing!]'; }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -109,9 +109,9 @@ module.exports = routes;
   /search/geoBoardsByVisInspectOrOrderNumber
   /json/search/geoBoardsByVisualInspection/:disposition/:issue
   /json/search/geoBoardsByOrderNumber/:orderNumber
-  /search/boardShipmentsByReceptionDetails
-  /json/search/boardShipmentsByReceptionDetails
-  /json/search/boardShipmentsByBoardUUID
+  /search/geoBoardShipmentsByReceptionDetails
+  /json/search/geoBoardShipmentsByReceptionDetails
+  /json/search/geoBoardShipmentsByBoardUUID
   /search/apasByProductionDetails
   /json/search/apasByProductionLocationAndNumber/:apaLocation/:apaNumber
   /json/search/apasByProductionLocationAndAssemblyStep/:apaLocation/:assemblyStep

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -128,14 +128,14 @@ router.get(['/json/search/geoBoardsByOrderNumber/:orderNumber', '/api/search/geo
 
 
 /// Search for geometry board shipments using various shipment reception details (client-side interface)
-router.get('/search/boardShipmentsByReceptionDetails', async function (req, res, next) {
+router.get('/search/geoBoardShipmentsByReceptionDetails', async function (req, res, next) {
   // Render the interface page
-  res.render('search_boardShipmentsByReceptionDetails.pug', { dictionary_locations: utils.dictionary_locations });
+  res.render('search_geoBoardShipmentsByReceptionDetails.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 
 /// Search for geometry board shipments using various shipment reception details (query to server-side)
-router.get(['/json/search/boardShipmentsByReceptionDetails', '/api/search/boardShipmentsByReceptionDetails'], async function (req, res, next) {
+router.get(['/json/search/geoBoardShipmentsByReceptionDetails', '/api/search/geoBoardShipmentsByReceptionDetails'], async function (req, res, next) {
   try {
     // This search query can have multiple query strings, most of which are optional
     // So first, parse out the strings which have actually been provided (as non-empty strings), and set the rest to 'null'
@@ -153,7 +153,7 @@ router.get(['/json/search/boardShipmentsByReceptionDetails', '/api/search/boardS
     if (latest) latest = latest.replace(' ', '+');
 
     // Retrieve a list of geometry boards shipments that match the specified reception details
-    const shipments = await Search_OtherComponents.boardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment);
+    const shipments = await Search_OtherComponents.geoBoardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment);
 
     // Return the list in JSON format
     return res.status(200).json(shipments);
@@ -165,10 +165,10 @@ router.get(['/json/search/boardShipmentsByReceptionDetails', '/api/search/boardS
 
 
 /// Search for geometry board shipments that reference a single component, specified by its UUID (query to server-side)
-router.get(['/json/search/boardShipmentsByBoardUUID/:uuid', '/api/search/boardShipmentsByBoardUUID/:uuid'], async function (req, res, next) {
+router.get(['/json/search/geoBoardShipmentsByBoardUUID/:uuid', '/api/search/geoBoardShipmentsByBoardUUID/:uuid'], async function (req, res, next) {
   try {
     // Retrieve a list of geometry boards shipments that reference the specified component UUID
-    const shipments = await Search_OtherComponents.boardShipmentsByBoardUUID(req.params.uuid);
+    const shipments = await Search_OtherComponents.geoBoardShipmentsByBoardUUID(req.params.uuid);
 
     // Sort the shipments by increasing 'lastEditDate', i.e. the most recent shipment will be first in the list
     shipments.sort(utils.byField_decreasing('lastEditDate'));

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -247,13 +247,7 @@ router.get('/administratorUtility', async function (req, res, next) {
 router.post(['/json/administratorUtility/:inputString', '/api/administratorUtility/:inputString'], async function (req, res, next) {
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
-    let result = null;
-
-    if (['ALL_COMPONENTS', 'APAFrame', 'AssembledAPA', 'DWA', 'DWAPDB'].includes(req.params.inputString)) {
-      result = await Admin_Functions.cleanComponentRecords(req.params.inputString);    // Change as appropriate for the required utility
-    } else {
-      result = await Admin_Functions.addComponentInfoToActionRecords(req.params.inputString);
-    }
+    let result = await Admin_Functions.cleanComponentTypeFormIds(req.params.inputString);    // Change as appropriate for the required utility
 
     return res.status(201).json(result);
   } catch (err) {

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -347,7 +347,7 @@ class ComponentUUID extends TextFieldComponent {
                   }
                 },
               }).fail();
-            } else if (component.formId === 'wire_bobbin') {
+            } else if (component.formId === 'WireBobbin') {
               if (component.data.meanBreakStrength >= 24.0) {
                 info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
               } else {

--- a/app/static/pages/administratorUtility.js
+++ b/app/static/pages/administratorUtility.js
@@ -27,15 +27,7 @@ async function renderInputForm() {
 
 
 function postSuccess(result) {    // Change as appropriate for the required utility
-  if (['ALL_COMPONENTS', 'APAFrame', 'AssembledAPA', 'DWA', 'DWAPDB'].includes(result)) {
-    if (result === 'ALL_COMPONENTS') {
-      window.location.href = `/componentTypes/list`;
-    } else {
-      window.location.href = `/components/${result}/list`;
-    }
-  } else {
-    window.location.href = `/actionTypes/list`;
-  }
+  window.location.href = `/components/${result}/list`;
 }
 
 

--- a/app/static/pages/search_geoBoardShipmentsByReceptionDetails.js
+++ b/app/static/pages/search_geoBoardShipmentsByReceptionDetails.js
@@ -1,4 +1,4 @@
-// Declare variables to hold the (initially empty) user-specified board shipment reception details
+// Declare variables to hold the (initially empty) user-specified geometry board shipment reception details
 let shipmentStatus = '';
 let originLocation = '';
 let destinationLocation = '';
@@ -95,7 +95,7 @@ async function renderSearchForms() {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/boardShipmentsByReceptionDetails?shipmentStatus=${shipmentStatus}&originLocation=${originLocation}&destinationLocation=${destinationLocation}&earliestDate=${earliestDate}&latestDate=${latestDate}&receptionComment=${receptionComment}`,
+        url: `/json/search/geoBoardShipmentsByReceptionDetails?shipmentStatus=${shipmentStatus}&originLocation=${originLocation}&destinationLocation=${destinationLocation}&earliestDate=${earliestDate}&latestDate=${latestDate}&receptionComment=${receptionComment}`,
         dataType: 'json',
         success: postSuccess,
       }).fail(postFail);


### PR DESCRIPTION
Adding new Daresbury technician to central list

Component Type Form ID and Name Consistency Changes (PR 1 of 2)
- there are 4 component types which have type form IDs and/or names which are inconsistent with all other types - want to clean these up ... 3 to be dealt with in this PR
- Grounding Mesh Shipment (GroundingMeshShipment) --> Grounding Mesh Panel Shipment (GroundingMeshPanelShipment)
- Wire Bobbin (wire_bobbin) --> Wire Bobbin (WireBobbin) [ID change only]
- Board Shipment (BoardShipment) --> Geometry Board Shipment (GeometryBoardShipment)
- changed all instances of the formers in the code to the latters ... i.e. where an interface page layout is tailored to a specific component type, or where specific information is to be retrieved depending on the component type
- added a new administrator utility function to directly change the 'formId' and 'formName' fields of all relevant component records
- corresponding changes to the two search functions that apply to geometry board shipments (library functions, routes and interface page file names)

Note that for each component type, a new type form will need to be created through the interface, and any connected existing action type forms then edited to point to it (the old component type form can then be trashed)