### PR TITLE
Component Type Form ID and Name Consistency Changes

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -18,6 +18,9 @@ async function cleanComponentTypeFormIds(typeFormId) {
   } else if (typeFormId === 'wire_bobbin') {
     newTypeFormId = 'WireBobbin';
     newTypeFormName = 'Wire Bobbin';
+  } else if (typeFormId === 'BoardShipment') {
+    newTypeFormId = 'GeometryBoardShipment';
+    newTypeFormName = 'Geometry Board Shipment';
   }
 
   const result = await db.collection('components')

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -8,109 +8,34 @@ const logger = require('./logger');
 const utils = require('./utils');
 
 
-async function cleanComponentRecords(typeFormId) {
-  let deleteCondition = null;
+async function cleanComponentTypeFormIds(typeFormId) {
+  let newTypeFormId = null;
+  let newTypeFormName = null;
 
-  if (typeFormId === 'ALL_COMPONENTS') {
-    deleteCondition = { $unset: { 'data.name': "" } };
-  } else if (typeFormId === 'APAFrame') {
-    deleteCondition = { $unset: { 'data.frameNumber': "" } };
-  } else if (typeFormId === 'AssembledAPA') {
-    deleteCondition = { $unset: { 'data.apaNumberAtLocation': "" } };
-  } else if (typeFormId === 'DWA') {
-    deleteCondition = { $unset: { 'data.dwaNumber': "" } };
-  } else if (typeFormId === 'DWAPDB') {
-    deleteCondition = { $unset: { 'data.pdbNumber': "" } };
+  if (typeFormId === 'GroundingMeshShipment') {
+    newTypeFormId = 'GroundingMeshPanelShipment';
+    newTypeFormName = 'Grounding Mesh Panel Shipment';
   }
-
-  const matchCondition = (typeFormId === 'ALL_COMPONENTS') ? {} : { formId: typeFormId };
 
   const result = await db.collection('components')
     .updateMany(
-      matchCondition,
-      deleteCondition,
+      { formId: typeFormId },
+      [
+        {
+          $set: {
+            'formId': newTypeFormId,
+            'formName': newTypeFormName,
+          }
+        },
+      ]
     )
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentRecords() - failed to delete fields from the component records!`);
+  if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
 
-  return typeFormId;
+  return newTypeFormId;
 }
 
-
-async function addComponentInfoToActionRecords(componentType) {
-  const apaFramesAndShipments = ['DeliveredFrameQAChecks', 'CompletedFrameQCChecklist', 'InstallationSurveys', 'IntakeSurveys', 'APAShipmentReception', 'APAShipmentTransport', 'ASFCloseUp'];
-  let assembledAPAs = [];
-
-  const apaWorkflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
-  let actionTypeForms = await Forms.list('actionForms');
-  let list_apaWorkflowActionNames = [];
-
-  for (const step of apaWorkflowTypeForm.path.slice(1)) {
-    list_apaWorkflowActionNames.push(step.formName);
-  }
-
-  for (const [typeFormID, typeForm] of Object.entries(actionTypeForms)) {
-    if (list_apaWorkflowActionNames.includes(typeForm.formName)) {
-      assembledAPAs.push(typeFormID);
-    }
-  }
-
-  const geometryBoards = ['BoardToothStripAttachment', 'BoardVisualInspection', 'FactoryBoardRejection'];
-  const groundingMeshPanels = ['EpoxyApplication', 'FinalInspection', 'MeshQAInspection', 'APANonConformance', 'ReceiptInspection'];
-
-  const combined = apaFramesAndShipments.concat(assembledAPAs, geometryBoards, groundingMeshPanels);
-  let otherComponents = [];
-
-  for (const [typeFormID, typeForm] of Object.entries(actionTypeForms)) {
-    if (!(combined.includes(typeFormID)) && !(typeForm.tags.includes('Trash'))) {
-      otherComponents.push(typeFormID);
-    }
-  }
-
-  let filterCondition = null;
-
-  if (componentType === 'APAFramesAndShipments') {
-    filterCondition = { 'typeFormId': { $in: apaFramesAndShipments } }
-  } else if (componentType === 'AssembledAPAs') {
-    filterCondition = { 'typeFormId': { $in: assembledAPAs } }
-  } else if (componentType === 'GeometryBoards_BoardToothStripAttachment') {
-    filterCondition = { 'typeFormId': 'BoardToothStripAttachment' }
-  } else if (componentType === 'GeometryBoards_BoardVisualInspection') {
-    filterCondition = { 'typeFormId': 'BoardVisualInspection' }
-  } else if (componentType === 'GeometryBoards_FactoryBoardRejection') {
-    filterCondition = { 'typeFormId': 'FactoryBoardRejection' }
-  } else if (componentType === 'GroundingMeshPanels') {
-    filterCondition = { 'typeFormId': { $in: groundingMeshPanels } }
-  } else if (componentType === 'OtherComponents') {
-    filterCondition = { 'typeFormId': { $in: otherComponents } }
-  }
-
-  const result = await db.collection('actions')
-    .find(filterCondition)
-    .forEach(async function (actionRecord) {
-      const componentRecord = await Components.retrieve(actionRecord.componentUuid);
-      const componentName = (componentRecord) ? componentRecord.data.componentName : '[no component record found!]';
-      const componentTypeFormId = (componentRecord) ? componentRecord.formId : '[no component record found!]';
-      const componentTypeFormName = (componentRecord) ? componentRecord.formName : '[no component record found!]';
-
-      const innerResult = db.collection('actions')
-        .updateOne(
-          { _id: actionRecord._id },
-          {
-            $set: {
-              'componentName': componentName,
-              'componentTypeFormId': componentTypeFormId,
-              'componentTypeFormName': componentTypeFormName,
-            }
-          },
-        );
-
-    });
-
-  return 'ALL_ACTIONS';
-}
 
 module.exports = {
-  cleanComponentRecords,
-  addComponentInfoToActionRecords,
+  cleanComponentTypeFormIds,
 }

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -15,6 +15,9 @@ async function cleanComponentTypeFormIds(typeFormId) {
   if (typeFormId === 'GroundingMeshShipment') {
     newTypeFormId = 'GroundingMeshPanelShipment';
     newTypeFormName = 'Grounding Mesh Panel Shipment';
+  } else if (typeFormId === 'wire_bobbin') {
+    newTypeFormId = 'WireBobbin';
+    newTypeFormName = 'Wire Bobbin';
   }
 
   const result = await db.collection('components')

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -1,4 +1,5 @@
 const MUUID = require('uuid-mongodb');
+const ObjectId = require('mongodb').ObjectId;
 
 const Actions = require('./Actions');
 const { db } = require('./db');
@@ -6,6 +7,7 @@ const Components = require('./Components');
 const Forms = require('./Forms');
 const logger = require('./logger');
 const utils = require('./utils');
+const Workflows = require('./Workflows');
 
 
 async function cleanComponentTypeFormIds(typeFormId) {
@@ -21,6 +23,9 @@ async function cleanComponentTypeFormIds(typeFormId) {
   } else if (typeFormId === 'BoardShipment') {
     newTypeFormId = 'GeometryBoardShipment';
     newTypeFormName = 'Geometry Board Shipment';
+  } else if (typeFormId === 'APAShipment') {
+    newTypeFormId = 'AssembledAPAShipment';
+    newTypeFormName = 'Assembled APA Shipment';
   }
 
   const result = await db.collection('components')
@@ -37,6 +42,67 @@ async function cleanComponentTypeFormIds(typeFormId) {
     )
 
   if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
+
+  if (typeFormId === 'APAShipment') {
+    let aggregation_stages = [];
+
+    aggregation_stages.push({ $match: { formId: newTypeFormId } });
+    aggregation_stages.push({ $project: { componentUuid: true } });
+
+    let uuids = await db.collection('components')
+      .aggregate(aggregation_stages)
+      .toArray();
+
+    for (let uuid of uuids) {
+      const component = await Components.retrieve(uuid.componentUuid);
+      const data = component.data;
+
+      let name_apa1 = '[not set]';
+      let name_apa2 = '[not set]';
+
+      if (data.apaUuiDs[0].component_uuid !== '') {
+        const apa = await Components.retrieve(data.apaUuiDs[0].component_uuid);
+        name_apa1 = apa.data.componentName.substring(4);
+      }
+
+      if (data.apaUuiDs[1].component_uuid !== '') {
+        const apa = await Components.retrieve(data.apaUuiDs[1].component_uuid);
+        name_apa2 = apa.data.componentName.substring(4);
+      }
+
+      const componentName = `Assembled APA Shipment (${name_apa1} + ${name_apa2})`;
+
+      const componentUuid = component.componentUuid;
+      let match_condition = { componentUuid };
+
+      if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
+
+      match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
+
+      let resultInner = await db.collection('components')
+        .updateMany(
+          match_condition,
+          [
+            {
+              $set: { 'data.componentName': componentName }
+            },
+          ]
+        )
+
+      if (resultInner.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to update Assembled APA Shipment component names!`);
+
+      let update = { '$set': {} };
+      update['$set']['path.' + 0 + '.formName'] = newTypeFormName;
+
+      resultInner = await db.collection('workflows')
+        .updateMany(
+          { workflowId: new ObjectId(component.workflowId) },
+          update,
+        )
+
+      if (resultInner.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form name in the workflow records!`);
+    }
+  }
 
   return newTypeFormId;
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -185,12 +185,12 @@ async function save(input, req) {
     } else if (newRecord.formId === 'SHVBoard') {
       newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300500001-${typeRecordNumber}-US200-010000`;
+    } else if (newRecord.formId === 'WireBobbin') {
+      newRecord.data.componentName = `${newRecord.formName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
+      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     } else if (newRecord.formId === 'Yoke') {
       newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00301000001-${typeRecordNumber}-US200-010000`;
-    } else if (newRecord.formId === 'wire_bobbin') {
-      newRecord.data.componentName = `${newRecord.formName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
-      newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     }
 
     // Set up a new 'Reception' object to hold the component's current location and the date at which it was received at this location ... and we can immediately set the date to be the current one
@@ -202,7 +202,7 @@ async function save(input, req) {
 
     // Almost all component types will always start at specific fixed locations ...
     // ... the only exceptions are the 'batch' types (these still need the location field to exist, but it can be left as an empty string)
-    if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'wire_bobbin')) {
+    if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'WireBobbin')) {
       newRecord.reception.location = 'daresbury';
     } else if (newRecord.formId === 'APAShipment') {
       newRecord.reception.location = newRecord.data.originOfShipment;

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -208,7 +208,7 @@ async function save(input, req) {
       newRecord.reception.location = newRecord.data.originOfShipment;
     } else if (newRecord.formId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
-    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
@@ -250,9 +250,6 @@ async function save(input, req) {
 
     newRecord.data.componentName = `${newRecord.formName} (${name_apa1} and ${name_apa2})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'BoardShipment') {
-    newRecord.data.componentName = `Geometry ${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
-    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'CEAdapterBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
@@ -267,6 +264,9 @@ async function save(input, req) {
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GBiasBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.formId === 'GeometryBoardShipment') {
+    newRecord.data.componentName = `Geometry ${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GroundingMeshPanelShipment') {
     newRecord.data.componentName = `Grounding Mesh Panel Shipment (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
@@ -302,7 +302,7 @@ async function save(input, req) {
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
   if (newRecord.formId === 'APAShipment') {
     const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
@@ -418,7 +418,7 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     }
 
     const result = await updateLocation(shipment.data.asfUuid, location, date, '');
-  } else if ((shipment.formId === 'BoardShipment') || (shipment.formId === 'CEAdapterBoardShipment') || (shipment.formId === 'CRBoardShipment') || (shipment.formId === 'CableHarnessShipment') || (shipment.formId === 'GBiasBoardShipment') || (shipment.formId === 'SHVBoardShipment')) {
+  } else if ((shipment.formId === 'CEAdapterBoardShipment') || (shipment.formId === 'CRBoardShipment') || (shipment.formId === 'CableHarnessShipment') || (shipment.formId === 'GBiasBoardShipment') || (shipment.formId === 'GeometryBoardShipment') || (shipment.formId === 'SHVBoardShipment')) {
     // Extract the UUID and update the location information of each board in a shipment of (single type) boards
     for (const board of shipment.data.boardUuiDs) {
       const result = await updateLocation(board.component_uuid, location, date, '');

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -204,14 +204,14 @@ async function save(input, req) {
     // ... the only exceptions are the 'batch' types (these still need the location field to exist, but it can be left as an empty string)
     if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'WireBobbin')) {
       newRecord.reception.location = 'daresbury';
-    } else if (newRecord.formId === 'APAShipment') {
-      newRecord.reception.location = newRecord.data.originOfShipment;
     } else if (newRecord.formId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
     } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
+    } else if (newRecord.formId === 'AssembledAPAShipment') {
+      newRecord.reception.location = newRecord.data.originOfShipment;
     } else if ((newRecord.formId === 'CEAdapterBoard') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'CRBoard') || (newRecord.formId === 'CRBoardShipment') || (newRecord.formId === 'CableHarness') || (newRecord.formId === 'CableHarnessShipment') || (newRecord.formId === 'GBiasBoard') || (newRecord.formId === 'GBiasBoardShipment') || (newRecord.formId === 'SHVBoard') || (newRecord.formId === 'SHVBoardShipment') || (newRecord.formId === 'Yoke')) {
       newRecord.reception.location = 'wisconsin';
     } else if ((newRecord.formId === 'DWA') || (newRecord.formId === 'DWAPDB')) {
@@ -234,21 +234,21 @@ async function save(input, req) {
   if (newRecord.formId === 'APAFrameShipment') {
     newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.frameUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'APAShipment') {
+  } else if (newRecord.formId === 'AssembledAPAShipment') {
     let name_apa1 = '[not set]';
     let name_apa2 = '[not set]';
 
     if (newRecord.data.apaUuiDs[0].component_uuid !== '') {
       const apa = await retrieve(newRecord.data.apaUuiDs[0].component_uuid);
-      name_apa1 = apa.data.componentName;
+      name_apa1 = apa.data.componentName.substring(4);
     }
 
     if (newRecord.data.apaUuiDs[1].component_uuid !== '') {
       const apa = await retrieve(newRecord.data.apaUuiDs[1].component_uuid);
-      name_apa2 = apa.data.componentName;
+      name_apa2 = apa.data.componentName.substring(4);
     }
 
-    newRecord.data.componentName = `${newRecord.formName} (${name_apa1} and ${name_apa2})`;
+    newRecord.data.componentName = `${newRecord.formName} (${name_apa1} + ${name_apa2})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'CEAdapterBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
@@ -266,13 +266,13 @@ async function save(input, req) {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GeometryBoardShipment') {
-    newRecord.data.componentName = `Geometry ${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GroundingMeshPanelShipment') {
-    newRecord.data.componentName = `Grounding Mesh Panel Shipment (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'PopulatedBoardShipment') {
-    newRecord.data.componentName = `Multi-Type Populated Board Shipment ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'SHVBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
@@ -293,19 +293,19 @@ async function save(input, req) {
   if (!result.acknowledged) throw new Error(`Components::save() - failed to insert a new component record into the database!`);
 
   // Once the component record has been successfully saved, deal with the reception information for any related components:
-  // - for an 'APA Shipment', update the reception information of the underlying 'Assembled APA' and 'ASF' components to be the same as the shipment
+  // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
+  // - for an 'Assembled APA Shipment', update the reception information of the underlying 'Assembled APA' and 'ASF' components to be the same as the shipment
   //    (they should already be at the same location as the shipment, but this is a double-check on that)
   // - for other types of shipment, update the reception information of the various sub-components to indicate that they are in transit
-  // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
   // - for a 'Populated Board Shipment', update the reception information of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
   // - for a 'Return Geometry Board Batch', update the reception information of the individual geometry board sub-components to indicate they are at Lancaster (where the batch is put together)
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
-  if (newRecord.formId === 'APAShipment') {
-    const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
+  } else if (newRecord.formId === 'AssembledAPAShipment') {
+    const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'ReturnedGeometryBoardBatch') {
     for (const board of newRecord.data.boardUuids) {
       const result = await updateLocation(board.component_uuid, 'lancaster', (new Date()).toISOString().slice(0, 10), '');
@@ -411,7 +411,7 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     for (const frame of shipment.data.frameUuiDs) {
       const result = await updateLocation(frame.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'APAShipment') {
+  } else if (shipment.formId === 'AssembledAPAShipment') {
     // Extract the UUID and update the location information of each assembled APA and the ASF in a shipment of APAs
     for (const apa of shipment.data.apaUuiDs) {
       const result = await updateLocation(apa.component_uuid, location, date, '');

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -208,7 +208,7 @@ async function save(input, req) {
       newRecord.reception.location = newRecord.data.originOfShipment;
     } else if (newRecord.formId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
-    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
@@ -268,7 +268,7 @@ async function save(input, req) {
   } else if (newRecord.formId === 'GBiasBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'GroundingMeshShipment') {
+  } else if (newRecord.formId === 'GroundingMeshPanelShipment') {
     newRecord.data.componentName = `Grounding Mesh Panel Shipment (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'PopulatedBoardShipment') {
@@ -302,7 +302,7 @@ async function save(input, req) {
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
   if (newRecord.formId === 'APAShipment') {
     const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'BoardShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
@@ -428,7 +428,7 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     for (const dwa of shipment.data.componentUUIDs) {
       const result = await updateLocation(dwa.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'GroundingMeshShipment') {
+  } else if (shipment.formId === 'GroundingMeshPanelShipment') {
     // Extract the UUID and update the location information of each mesh in a shipment of meshes
     for (const mesh of shipment.data.apaUuiDs) {
       const result = await updateLocation(mesh.component_uuid, location, date, '');

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -744,27 +744,52 @@ async function forExecSummary(componentUUID) {
 /// Retrieve information about a specified component in a format suitable for the DUNE HWDB
 async function forHWDB(componentUUID) {
   // First retrieve the component record with the specified UUID, and then extract the component's type - the specific information to be retrieved for the HWDB will depend on this
-  const component = await Components.retrieve(componentUUID);
+  const componentRecord = await Components.retrieve(componentUUID);
 
-  if (!component) {
+  if (!componentRecord) {
     return { error: `There is no component record with component UUID = ${componentUUID}` }
   }
 
-  const componentTypeFormId = component.formId;
+  const componentTypeFormId = componentRecord.formId;
+  const componentDUNEPID = componentRecord.data.dunePid;
 
-  // Retrieve and return the information
+  // Set up the top-level information object that will hold the component information in the format required by the HWDB
+  // The general structure of this object is common and consistent across all component types, with only the field values changing depending on the specific component
+  // The data specific to a particular component type is all held within a single sub-object, the structure of which will be tailored to that type later on
+  let hwdbInfo = {
+    component_type: {
+      part_type_id: componentDUNEPID.substring(0, 12),
+    },
+    country_code: 'GB',     // (KRISH) The HWDB currently has a bug that means it uses 'GB' instead of 'UK' ... once that is fixed, change this to 'componentDUNEPID.substring(19, 21),'
+    institution: {
+      id: parseInt(componentDUNEPID.substring(21, 24)),
+    },
+    serial_number: '',      // This field is required to exist by the HWDB, but is not actually relevant for our purposes - it can be safely set as an empty string
+    status: {
+      id: 120,              // We will only send information to the HWDB about complete and finalised components, so this field will always have a value of '120' (signifying all QA/QC checks passed)
+    },
+    subcomponents: {},      // This sub-object will be populated below according to the specific component
+    certified_qaqc: true,   // We will only send information to the HWDB about complete and finalised components, so this field will always have a value of 'true'
+    qaqc_uploaded: true,    // We will only send information to the HWDB about complete and finalised components, so this field will always have a value of 'true'
+    comments: '',           // This field isn't actually required, but it may be useful in the future - in which case, it would be easier to just populate it rather than add it back in from scratch
+    specifications: {
+      component: {},        // This sub-object will be populated below according to the specific component
+    },
+  }
+
+  // Retrieve, save and return the information about the specified component
   if (componentTypeFormId === 'AssembledAPA') {
     // Retrieve collated information about the APA using the already-existing function that does the same for populating Executive Summaries
     // The HWDB requires the same information (just in a different format), so it doesn't make any sense to re-code the retrieval all over again for this function
     const collatedInfo = await forExecSummary(componentUUID);
 
-    // Define the object that will hold the APA information in the format required by the HWDB
-    let singleAPA = {};
-
-    singleAPA = {
-      part_id: "",
+    // Define the object that will hold the APA information ... the structure of this is specific to APA-type components
+    // The 'filename' field is used by the APA DB to set the name of the file when downloading the HWDB information in JSON format via the interface ...
+    // ... it should be accessed in the same way for any and all components and component types, but should not interfere with the HWDB-mandated fields in the top-level information object
+    let component = {
+      filename: `hwdbInfo_${collatedInfo.assembledAPA.componentName.replaceAll(' ', '-')}.json`,
       data: {
-        components: {
+        subComponents: {
           assembledAPA: {},
           apaFrame: {},
           tempSensors: {},
@@ -795,27 +820,27 @@ async function forHWDB(componentUUID) {
     // COMPONENT INFORMATION //
     ///////////////////////////
     // Information about the APA itself is found in the collated information object
-    singleAPA.part_id = collatedInfo.assembledAPA.dunePID;
-
-    singleAPA.data.components.assembledAPA['apaDB_componentName'] = collatedInfo.assembledAPA.componentName;
-    singleAPA.data.components.assembledAPA['apaDB_componentUUID'] = collatedInfo.assembledAPA.componentUUID;
-    singleAPA.data.components.assembledAPA['apaDB_componentQRCode'] = `https://apa.dunedb.org/c/${collatedInfo.assembledAPA.shortUUID}`;
-    singleAPA.data.components.assembledAPA['productionSite'] = collatedInfo.assembledAPA.productionSite;
-    singleAPA.data.components.assembledAPA['configuration'] = collatedInfo.assembledAPA.configuration;
-    singleAPA.data.components.assembledAPA['apaDB_assemblyWorkflow'] = `https://apa.dunedb.org/workflow/${collatedInfo.assembledAPA.workflowID}`;
-    singleAPA.data.components.assembledAPA['assemblyStatus'] = collatedInfo.assembledAPA.assemblyStatus;
+    component.data.subComponents.assembledAPA['dunePID'] = collatedInfo.assembledAPA.dunePID;
+    component.data.subComponents.assembledAPA['apaDB_componentName'] = collatedInfo.assembledAPA.componentName;
+    component.data.subComponents.assembledAPA['apaDB_componentUUID'] = collatedInfo.assembledAPA.componentUUID;
+    component.data.subComponents.assembledAPA['apaDB_componentQRCode'] = `https://apa.dunedb.org/c/${collatedInfo.assembledAPA.shortUUID}`;
+    component.data.subComponents.assembledAPA['productionSite'] = collatedInfo.assembledAPA.productionSite;
+    component.data.subComponents.assembledAPA['configuration'] = collatedInfo.assembledAPA.configuration;
+    component.data.subComponents.assembledAPA['apaDB_assemblyWorkflow'] = `https://apa.dunedb.org/workflow/${collatedInfo.assembledAPA.workflowID}`;
+    component.data.subComponents.assembledAPA['assemblyStatus'] = collatedInfo.assembledAPA.assemblyStatus;
 
     // Additional information about the APA Frame is found in its component record
     const assembledAPA = await Components.retrieve(componentUUID);
     const apaFrame = await Components.retrieve(assembledAPA.data.frameUuid);
 
-    singleAPA.data.components.apaFrame['part_id'] = apaFrame.data.dunePid;
-    singleAPA.data.components.apaFrame['apaDB_componentName'] = apaFrame.data.componentName;
-    singleAPA.data.components.apaFrame['apaDB_componentUUID'] = apaFrame.componentUuid;
-    singleAPA.data.components.apaFrame['apaDB_componentQRCode'] = `https://apa.dunedb.org/c/${apaFrame.shortUuid.toString()}`;
+    component.data.subComponents.apaFrame['dunePID'] = apaFrame.data.dunePid;
+    component.data.subComponents.apaFrame['apaDB_componentName'] = apaFrame.data.componentName;
+    component.data.subComponents.apaFrame['apaDB_componentUUID'] = apaFrame.componentUuid;
+    component.data.subComponents.apaFrame['apaDB_componentQRCode'] = `https://apa.dunedb.org/c/${apaFrame.shortUuid.toString()}`;
 
     // Additional information about the temperature sensors is found in the 'Frame Prep - Photon Detector Cable and Temperature Sensor Installation' action of the workflow ...
     // ... use the mapping document to find the temperature sensors' DUNE PIDs from the serial numbers stored in the action
+    // The temperature sensors also need to be added to the 'subcomponents' sub-object in the top-level information object
     const apaAssemblyWorkflow = await Workflows.retrieve(assembledAPA.workflowId);
     const tempSensorInstallAction = await Actions.retrieve(apaAssemblyWorkflow.path[5].result);
 
@@ -842,44 +867,45 @@ async function forHWDB(componentUUID) {
     ];
 
     for (const [index, serialNumber] of tempSensorSerialNumbers.entries()) {
-      singleAPA.data.components.tempSensors[`Temperature Sensor ${tempSensorLocations[index]} (${serialNumber})`] = tempSensorPIDs[index];
+      hwdbInfo.subcomponents[`Temperature Sensor ${tempSensorLocations[index]}`] = tempSensorPIDs[index];
+      component.data.subComponents.tempSensors[`Temperature Sensor ${tempSensorLocations[index]} (${serialNumber})`] = tempSensorPIDs[index];
     }
 
     /////////////////
     // QC SIGNOFFS //
     /////////////////
     // Information about the QC signoffs is found in the collated information object
-    singleAPA.data.signoffs.frameConstruction['name'] = collatedInfo.frameConstruction.signoff_name;
-    singleAPA.data.signoffs.frameConstruction['date'] = collatedInfo.frameConstruction.signoff_date;
-    singleAPA.data.signoffs.frameConstruction['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.signoff_actionID}`;
-    singleAPA.data.signoffs.frameConstruction['apaDB_intakeSurveys'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.intakeSurveys_actionID}`;
-    singleAPA.data.signoffs.frameConstruction['apaDB_installSurveys'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.installSurveys_actionID}`;
+    component.data.signoffs.frameConstruction['name'] = collatedInfo.frameConstruction.signoff_name;
+    component.data.signoffs.frameConstruction['date'] = collatedInfo.frameConstruction.signoff_date;
+    component.data.signoffs.frameConstruction['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.signoff_actionID}`;
+    component.data.signoffs.frameConstruction['apaDB_intakeSurveys'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.intakeSurveys_actionID}`;
+    component.data.signoffs.frameConstruction['apaDB_installSurveys'] = `https://apa.dunedb.org/action/${collatedInfo.frameConstruction.installSurveys_actionID}`;
 
-    singleAPA.data.signoffs.framePreparation['name'] = collatedInfo.framePreparation.signoff_name;
-    singleAPA.data.signoffs.framePreparation['date'] = collatedInfo.framePreparation.signoff_date;
-    singleAPA.data.signoffs.framePreparation['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.signoff_actionID}`;
-    singleAPA.data.signoffs.framePreparation['apaDB_meshInstall'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.meshInstall_actionID}`;
-    singleAPA.data.signoffs.framePreparation['apaDB_rtdInstall'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.rtdInstall_actionID}`;
+    component.data.signoffs.framePreparation['name'] = collatedInfo.framePreparation.signoff_name;
+    component.data.signoffs.framePreparation['date'] = collatedInfo.framePreparation.signoff_date;
+    component.data.signoffs.framePreparation['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.signoff_actionID}`;
+    component.data.signoffs.framePreparation['apaDB_meshInstall'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.meshInstall_actionID}`;
+    component.data.signoffs.framePreparation['apaDB_rtdInstall'] = `https://apa.dunedb.org/action/${collatedInfo.framePreparation.rtdInstall_actionID}`;
 
     for (let i = 0; i < layers.length; i++) {
-      singleAPA.data.signoffs[`${layers[i]}Layer`]['name'] = collatedInfo[layers[i]].signoff_name;
-      singleAPA.data.signoffs[`${layers[i]}Layer`]['date'] = collatedInfo[layers[i]].signoff_date;
-      singleAPA.data.signoffs[`${layers[i]}Layer`]['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].signoff_actionID}`;
+      component.data.signoffs[`${layers[i]}Layer`]['name'] = collatedInfo[layers[i]].signoff_name;
+      component.data.signoffs[`${layers[i]}Layer`]['date'] = collatedInfo[layers[i]].signoff_date;
+      component.data.signoffs[`${layers[i]}Layer`]['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].signoff_actionID}`;
     };
 
-    singleAPA.data.signoffs.coverBoardsAndCaps['name'] = collatedInfo.coverBoardsAndCaps.signoff_name;
-    singleAPA.data.signoffs.coverBoardsAndCaps['date'] = collatedInfo.coverBoardsAndCaps.signoff_date;
-    singleAPA.data.signoffs.coverBoardsAndCaps['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.coverBoardsAndCaps.signoff_actionID}`;
+    component.data.signoffs.coverBoardsAndCaps['name'] = collatedInfo.coverBoardsAndCaps.signoff_name;
+    component.data.signoffs.coverBoardsAndCaps['date'] = collatedInfo.coverBoardsAndCaps.signoff_date;
+    component.data.signoffs.coverBoardsAndCaps['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.coverBoardsAndCaps.signoff_actionID}`;
 
-    singleAPA.data.signoffs.postProduction['name'] = collatedInfo.postProduction.signoff_name;
-    singleAPA.data.signoffs.postProduction['date'] = collatedInfo.postProduction.signoff_date;
-    singleAPA.data.signoffs.postProduction['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.signoff_actionID}`;
-    singleAPA.data.signoffs.postProduction['apaDB_panelInstallURL'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.panelInstall_actionID}`;
-    singleAPA.data.signoffs.postProduction['apaDB_conduitInstallURL'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.conduitInstall_actionID}`;
+    component.data.signoffs.postProduction['name'] = collatedInfo.postProduction.signoff_name;
+    component.data.signoffs.postProduction['date'] = collatedInfo.postProduction.signoff_date;
+    component.data.signoffs.postProduction['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.signoff_actionID}`;
+    component.data.signoffs.postProduction['apaDB_panelInstallURL'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.panelInstall_actionID}`;
+    component.data.signoffs.postProduction['apaDB_conduitInstallURL'] = `https://apa.dunedb.org/action/${collatedInfo.postProduction.conduitInstall_actionID}`;
 
-    singleAPA.data.signoffs.completedAPA['name'] = collatedInfo.completedAPA.signoff_name;
-    singleAPA.data.signoffs.completedAPA['date'] = collatedInfo.completedAPA.signoff_date;
-    singleAPA.data.signoffs.completedAPA['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.completedAPA.signoff_actionID}`;
+    component.data.signoffs.completedAPA['name'] = collatedInfo.completedAPA.signoff_name;
+    component.data.signoffs.completedAPA['date'] = collatedInfo.completedAPA.signoff_date;
+    component.data.signoffs.completedAPA['apaDB_signoff'] = `https://apa.dunedb.org/action/${collatedInfo.completedAPA.signoff_actionID}`;
 
     //////////////////
     // BROKEN WIRES //
@@ -887,7 +913,7 @@ async function forHWDB(componentUUID) {
     // Information about broken (damaged, missing or shorted) wires is found in the 'ncrs_useAsIs_withWires' section of the collated information object
     for (const ncr of collatedInfo.ncrs_useAsIs_withWires) {
       for (const wire of ncr.missingShortedWires) {
-        singleAPA.data.brokenWires.push({
+        component.data.brokenWires.push({
           type: wire.wireType,
           sideAndLayer: wire.wireLayer,
           headBoardAndPad: wire.headBoardAndPad,
@@ -910,32 +936,34 @@ async function forHWDB(componentUUID) {
     ];
 
     for (const [index, serialNumber] of tempSensorSerialNumbers.entries()) {
-      singleAPA.data.measurements.tempSensorResistances[`Temperature Sensor ${tempSensorLocations[index]} (${serialNumber})`] = tempSensorResistances[index];
+      component.data.measurements.tempSensorResistances[`Temperature Sensor ${tempSensorLocations[index]} (${serialNumber})`] = tempSensorResistances[index];
     }
 
     // Information about the layer assemblies is found in the collated information object
     for (let i = 0; i < layers.length; i++) {
-      singleAPA.data.measurements[`${layers[i]}Layer`]['winder'] = collatedInfo[layers[i]].winding_winder;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['winderHead'] = collatedInfo[layers[i]].winding_winderHead;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['wireBobbinManufacturers'] = collatedInfo[layers[i]].winding_bobbinManufacturers;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['winderMaintenanceSignoff'] = collatedInfo[layers[i]].winding_winderMaintenanceSignoff;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['tensionControlSignoff'] = collatedInfo[layers[i]].winding_tensionControlSignoff;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['numberOfReplacedWires'] = collatedInfo[layers[i]].winding_numberOfReplacedWires;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['numberOfTensionAlarms'] = collatedInfo[layers[i]].winding_numberOfTensionAlarms;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['apaDB_winding'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].winding_actionID}`;
+      component.data.measurements[`${layers[i]}Layer`]['winder'] = collatedInfo[layers[i]].winding_winder;
+      component.data.measurements[`${layers[i]}Layer`]['winderHead'] = collatedInfo[layers[i]].winding_winderHead;
+      component.data.measurements[`${layers[i]}Layer`]['wireBobbinManufacturers'] = collatedInfo[layers[i]].winding_bobbinManufacturers;
+      component.data.measurements[`${layers[i]}Layer`]['winderMaintenanceSignoff'] = collatedInfo[layers[i]].winding_winderMaintenanceSignoff;
+      component.data.measurements[`${layers[i]}Layer`]['tensionControlSignoff'] = collatedInfo[layers[i]].winding_tensionControlSignoff;
+      component.data.measurements[`${layers[i]}Layer`]['numberOfReplacedWires'] = collatedInfo[layers[i]].winding_numberOfReplacedWires;
+      component.data.measurements[`${layers[i]}Layer`]['numberOfTensionAlarms'] = collatedInfo[layers[i]].winding_numberOfTensionAlarms;
+      component.data.measurements[`${layers[i]}Layer`]['apaDB_winding'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].winding_actionID}`;
 
-      singleAPA.data.measurements[`${layers[i]}Layer`]['numberOfReworkedSolders'] = collatedInfo[layers[i]].soldering_numberOfReworkedSolders;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['apaDB_soldering'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].soldering_actionID}`;
+      component.data.measurements[`${layers[i]}Layer`]['numberOfReworkedSolders'] = collatedInfo[layers[i]].soldering_numberOfReworkedSolders;
+      component.data.measurements[`${layers[i]}Layer`]['apaDB_soldering'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].soldering_actionID}`;
 
-      singleAPA.data.measurements[`${layers[i]}Layer`]['tensionMeasurementLocation'] = collatedInfo[layers[i]].tensions_location;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['tensionSystem'] = collatedInfo[layers[i]].tensions_system;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['tensions_A'] = collatedInfo[layers[i]].tensions_A;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['tensions_B'] = collatedInfo[layers[i]].tensions_B;
-      singleAPA.data.measurements[`${layers[i]}Layer`]['apaDB_tensionMeasurements'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].tensions_actionID}`;
+      component.data.measurements[`${layers[i]}Layer`]['tensionMeasurementLocation'] = collatedInfo[layers[i]].tensions_location;
+      component.data.measurements[`${layers[i]}Layer`]['tensionSystem'] = collatedInfo[layers[i]].tensions_system;
+      component.data.measurements[`${layers[i]}Layer`]['tensions_A'] = collatedInfo[layers[i]].tensions_A;
+      component.data.measurements[`${layers[i]}Layer`]['tensions_B'] = collatedInfo[layers[i]].tensions_B;
+      component.data.measurements[`${layers[i]}Layer`]['apaDB_tensionMeasurements'] = `https://apa.dunedb.org/action/${collatedInfo[layers[i]].tensions_actionID}`;
     }
 
-    // Return the information about this APA
-    return singleAPA;
+    // Copy the APA information object to the designated 'component-specific' sub-object in the top-level component object, and then return the latter
+    hwdbInfo.specifications.component = component;
+
+    return hwdbInfo;
   } else {
     return { error: `This component's type form ID (${componentTypeFormId}) does not have an HWDB format defined yet!` }
   }

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -6,7 +6,7 @@ const { db } = require('./db');
 
 
 /// Retrieve a list of geometry board shipments that match the specified reception details
-async function boardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment) {
+async function geoBoardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment) {
   // Set up 'matching' strings that can be used by MongoDB to match against specific record field values
   // For each potential location (origin or destination), if it has been specified, just use it as the matching string ... otherwise use a fully wildcard regular expression
   const originString = (origin) ? origin : /(.*?)/;
@@ -14,10 +14,10 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
 
   let comp_aggregation_stages = [];
 
-  // Match against the type form ID and both locations to get records of all 'Board Shipment' components that were supposed to travel between the specified locations
+  // Match against the type form ID and both locations to get records of all 'Geometry Board Shipment' components that were supposed to travel between the specified locations
   comp_aggregation_stages.push({
     $match: {
-      'formId': 'BoardShipment',
+      'formId': 'GeometryBoardShipment',
       'data.originOfShipment': originString,
       'data.destinationOfShipment': destinationString,
     }
@@ -39,7 +39,7 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
     .aggregate(comp_aggregation_stages)
     .toArray();
 
-  // At this point, we have a list of 'Board Shipment' component records that:
+  // At this point, we have a list of 'Geometry Board Shipment' component records that:
   //   - originated at the specified origin location (if one was specified), or at any location (if not)
   //   - were supposed to end up at the specified destination location (if one was specified), or at any location (if not)
   // But what we actually want is a combination of some information from both the shipment component record and the corresponding reception action record (if the shipment has been received)
@@ -49,7 +49,7 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
   for (const shipmentRecord of component_results) {
     let action_aggregation_stages = [];
 
-    // Match against the type form ID and component UUID to get records of all 'Board Reception' actions performed on the specified board shipment component
+    // Match against the type form ID and component UUID to get records of all 'Board Reception' actions performed on the specified geometry board shipment component
     action_aggregation_stages.push({
       $match: {
         'typeFormId': 'BoardReception',
@@ -145,11 +145,11 @@ async function boardShipmentsByReceptionDetails(status, origin, destination, ear
 
 
 /// Retrieve a list of geometry board shipments that reference a single component, specified by its UUID
-async function boardShipmentsByBoardUUID(componentUUID) {
+async function geoBoardShipmentsByBoardUUID(componentUUID) {
   let aggregation_stages = [];
 
-  // Match against the type form ID to get records of all 'Board Shipment' components
-  aggregation_stages.push({ $match: { 'formId': 'BoardShipment' } });
+  // Match against the type form ID to get records of all 'Geometry Board Shipment' components
+  aggregation_stages.push({ $match: { 'formId': 'GeometryBoardShipment' } });
 
   // Select the latest version of each record, and pass through only the fields required for later use
   aggregation_stages.push({ $sort: { 'validity.version': -1 } });
@@ -810,8 +810,8 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
 
 
 module.exports = {
-  boardShipmentsByReceptionDetails,
-  boardShipmentsByBoardUUID,
+  geoBoardShipmentsByReceptionDetails,
+  geoBoardShipmentsByBoardUUID,
   apasByProductionLocationAndNumber,
   apasByProductionLocationAndAssemblyStep,
   componentsByDUNEPID,

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -125,6 +125,7 @@ module.exports = {
     stephenSumner: 'Stephen Sumner',
     chrisSutton: 'Chris Sutton',
     jasonThornhill: 'Jason Thornhill',
+    douglasTsim: 'Douglas Tsim',
     oliverUnwin: 'Oliver Unwin',
     anthonyWatling: 'Anthony Watling',
     lewisWatson: 'Lewis Watson',

--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -47,7 +47,7 @@ block content
           - const collapseId = `avail_actionTypeGroup_${index}`;
           - let startingDisplay = 'show';
 
-          if actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'APA Frame' || actionFormsGroup._id.componentType === 'APA Shipment'
+          if actionFormsGroup._id.componentType === 'APA Frame' || actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'Assembled APA Shipment'
             - startingDisplay = ''
 
           .panel.panel-default

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -23,11 +23,9 @@ block content
             option(value = '')
             option(value = 'APAFrame') APA Frame 
             option(value = 'APAFrameShipment') APA Frame Shipment
-            option(value = 'APAShipment') APA Shipment 
             option(value = 'APAShippingFrame') APA Shipping Frame (ASF)
             option(value = 'AssembledAPA') Assembled APA 
             option(value = 'AssembledAPAShipment') Assembled APA Shipment
-            option(value = 'BoardShipment') Board Shipment 
             option(value = 'CEAdapterBoard') CE Adapter Board
             option(value = 'CEAdapterBoardBatch') CE Adapter Board Batch 
             option(value = 'CEAdapterBoardShipment') CE Adapter Board Shipment 
@@ -46,16 +44,14 @@ block content
             option(value = 'GeometryBoardBatch') Geometry Board Batch
             option(value = 'GeometryBoardShipment') Geometry Board Shipment 
             option(value = 'GroundingMeshPanel') Grounding Mesh Panel
-            option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
             option(value = 'GroundingMeshPanelShipment') Grounding Mesh Shipment 
             option(value = 'PopulatedBoardShipment') Multi-Type Populated Board Shipment
             option(value = 'ReturnedGeometryBoardBatch') Returned Geometry Board Batch
             option(value = 'SHVBoard') SHV Board
             option(value = 'SHVBoardShipment') SHV Board Kit
+            option(value = 'WireBobbin') Wire Bobbin
             option(value = 'Yoke') Yoke
             option(value = 'YokeShipment') Yoke Shipment
-            option(value = 'wire_bobbin') Wire Bobbin
-            option(value = 'WireBobbin') Wire Bobbin
 
           select.form-control#inputStringSelection
             option(value = '')

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -26,6 +26,7 @@ block content
             option(value = 'APAShipment') APA Shipment 
             option(value = 'APAShippingFrame') APA Shipping Frame (ASF)
             option(value = 'AssembledAPA') Assembled APA 
+            option(value = 'AssembledAPAShipment') Assembled APA Shipment
             option(value = 'BoardShipment') Board Shipment 
             option(value = 'CEAdapterBoard') CE Adapter Board
             option(value = 'CEAdapterBoardBatch') CE Adapter Board Batch 
@@ -43,8 +44,10 @@ block content
             option(value = 'GBiasBoardShipment') G-Bias Board Kit
             option(value = 'GeometryBoard') Geometry Board
             option(value = 'GeometryBoardBatch') Geometry Board Batch
+            option(value = 'GeometryBoardShipment') Geometry Board Shipment 
             option(value = 'GroundingMeshPanel') Grounding Mesh Panel
             option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
+            option(value = 'GroundingMeshPanelShipment') Grounding Mesh Shipment 
             option(value = 'PopulatedBoardShipment') Multi-Type Populated Board Shipment
             option(value = 'ReturnedGeometryBoardBatch') Returned Geometry Board Batch
             option(value = 'SHVBoard') SHV Board
@@ -52,22 +55,15 @@ block content
             option(value = 'Yoke') Yoke
             option(value = 'YokeShipment') Yoke Shipment
             option(value = 'wire_bobbin') Wire Bobbin
+            option(value = 'WireBobbin') Wire Bobbin
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'ALL_COMPONENTS') ALL COMPONENT TYPES
-            option(value = 'APAFrame') APA Frame 
-            option(value = 'AssembledAPA') Assembled APA 
-            option(value = 'DWA') DWA
-            option(value = 'DWAPDB') DWA PDB 
-            option(value = 'N.A.') ----------
-            option(value = 'APAFramesAndShipments') APA Frames and Shipments
-            option(value = 'AssembledAPAs') Assembled APAs
-            option(value = 'GeometryBoards_BoardToothStripAttachment') Geometry Boards (Tooth Strip Attachment)
-            option(value = 'GeometryBoards_BoardVisualInspection') Geometry Boards (Visual Inspection)
-            option(value = 'GeometryBoards_FactoryBoardRejection') Geometry Boards (Factory Rejection)
-            option(value = 'GroundingMeshPanels') Grounding Mesh Panels
-            option(value = 'OtherComponents') ALL OTHER COMPONENT TYPES
+            option(value = 'APAShipment') APA Shipment 
+            option(value = 'BoardShipment') Board Shipment 
+            option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
+            option(value = 'wire_bobbin') Wire Bobbin
+            
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -543,21 +543,21 @@ block content
     .vert-space-x1
       .row
         .col-sm-6
-          if component.formId === 'AssembledAPA'
-            h4 Action History (Non-Workflow Actions Only)
-
-            .vert-space-x1
-              p <b>Existing workflow actions can be accessed through this component's 
-                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
-                | workflow</b>
-          else if component.formId === 'APAFrame'
+          if component.formId === 'APAFrame'
             h4 Action History (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>Existing workflow actions can be accessed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
-          else if component.formId === 'APAShipment'
+          else if component.formId === 'AssembledAPA'
+            h4 Action History (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>Existing workflow actions can be accessed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
+                | workflow</b>
+          else if component.formId === 'AssembledAPAShipment'
             h4 Action History (Non-Workflow Actions Only)
 
             .vert-space-x1
@@ -596,21 +596,21 @@ block content
                         +dateTimeFormat(action.lastEditDate)
 
         .col-sm-6
-          if component.formId === 'AssembledAPA'
-            h4 Select an Action Type to Perform (Non-Workflow Actions Only)
-
-            .vert-space-x1
-              p <b>New workflow actions must be performed through this component's 
-                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
-                | workflow</b>
-          else if component.formId === 'APAFrame'
+          if component.formId === 'APAFrame'
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>New workflow actions must be performed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
-          else if component.formId === 'APAShipment'
+          else if component.formId === 'AssembledAPA'
+            h4 Select an Action Type to Perform (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>New workflow actions must be performed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
+                | workflow</b>
+          else if component.formId === 'AssembledAPAShipment'
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -281,7 +281,7 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'GroundingMeshShipment'
+    else if component.formId === 'GroundingMeshPanelShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
         dd #{dictionary_locations[component.data.originOfShipment]}

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -187,37 +187,6 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'BoardShipment'
-      .vert-space-x1.border-success.border.rounded.p-2
-        dt Origin Location 
-        dd #{dictionary_locations[component.data.originOfShipment]}
-
-        dt Destination Location
-        dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-        dt Boards in Shipment
-        dd
-          table.table
-            thead
-              tr
-                th.col-md-2 UUID
-                th.col-md-1 UK ID
-                th.col-md-1 Part Number
-                th.col-md-3 QR Code Link 
-
-            tbody
-              each info in collectionDetails
-                tr
-                  td
-                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
-
-                  td #{info[1]}
-                  td #{info[2]}
-                  td #{`${base_url}/c/${info[3]}`}
-
-        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-          img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; Print all sub-component QR codes
     else if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         if component.formId === 'CEAdapterBoardShipment'
@@ -276,6 +245,37 @@ block content
 
                   td #{info[2]}
                   td #{info[1]}
+                  td #{`${base_url}/c/${info[3]}`}
+
+        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
+          img.small-icon(src = '/images/checklist_icon.svg')
+          | &nbsp; Print all sub-component QR codes
+    else if component.formId === 'GeometryBoardShipment'
+      .vert-space-x1.border-success.border.rounded.p-2
+        dt Origin Location 
+        dd #{dictionary_locations[component.data.originOfShipment]}
+
+        dt Destination Location
+        dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+        dt Boards in Shipment
+        dd
+          table.table
+            thead
+              tr
+                th.col-md-2 UUID
+                th.col-md-1 UK ID
+                th.col-md-1 Part Number
+                th.col-md-3 QR Code Link 
+
+            tbody
+              each info in collectionDetails
+                tr
+                  td
+                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
+
+                  td #{info[1]}
+                  td #{info[2]}
                   td #{`${base_url}/c/${info[3]}`}
 
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
@@ -462,7 +462,7 @@ block content
             tbody 
               each entry in actions
                 tr 
-                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Board Shipment')
+                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Geometry Board Shipment')
                     td 
                       a(href = `/component/${entry.componentUuid}`) #{entry.typeFormName}
                   else 
@@ -472,7 +472,7 @@ block content
                   td #{entry.lastEditDate.toISOString().slice(0, 10)}
                   td #{dictionary_locations[entry.data.originOfShipment]}
 
-                  if entry.typeFormName === 'Board Shipment'
+                  if entry.typeFormName === 'Geometry Board Shipment'
                     if entry.reception
                       if entry.reception.location === 'in_transit'
                         td #{dictionary_locations[entry.data.destinationOfShipment]}
@@ -487,7 +487,7 @@ block content
                     td -
                     td -
 
-                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Board Shipment')
+                  if (entry.typeFormName === 'Board DB Record Created') || (entry.typeFormName === 'Geometry Board Shipment')
                     td -
                   else 
                     td #{entry.data.checksPassed}

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -31,7 +31,7 @@ block content
               th.col-md-2 Installed on APA
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -31,7 +31,7 @@ block content
               th.col-md-2 Installed on APA
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -31,7 +31,7 @@ block content
               th.col-md-2 Installed on APA
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_listTypes.pug
+++ b/app/pug/component_listTypes.pug
@@ -59,7 +59,7 @@ block content
                   td 0
 
                 td
-                  if (typeFormId === 'AssembledAPA' || typeFormId === 'APAFrame' || typeFormId === 'APAShipment')
+                  if (typeFormId === 'APAFrame' || typeFormId === 'AssembledAPA' || typeFormId === 'AssembledAPAShipment')
                     a.btn-sm.btn-secondary.disabled(href = '')
                       img.small-icon(src = '/images/run_icon.svg')
                       | &nbsp; Create New Components of This Type via Workflows

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.formId === 'APAFrameShipment') || (component.formId === 'AssembledAPAShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -41,7 +41,7 @@ block allbody
               dt Component UUID
               dd #{component.componentUuid}
 
-              if component.formId == 'BoardShipment' || component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
+              if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId == 'GeometryBoardShipment' || component.formId === 'SHVBoardShipment'
                 dt Number of Boards in Shipment
                 dd #{component.data.boardUuiDs.length}
 
@@ -80,29 +80,6 @@ block allbody
                   th.col-sm-1 DUNE PID 
 
               tbody 
-                each info in collectionDetails
-                  tr
-                    td #{info[0]}
-                    td #{info[1]}
-                    td #{info[2]}
-      else if component.formId === 'BoardShipment'
-        .vert-space-x1.border-success.border.rounded.p-2
-          dt Origin Location 
-          dd #{dictionary_locations[component.data.originOfShipment]}
-
-          dt Destination Location
-          dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-          dt Boards in Shipment
-          dd
-            table.table
-              thead
-                tr
-                  th.col-sm-1 UUID
-                  th.col-sm-1 UK ID
-                  th.col-sm-1 Part Number
-
-              tbody
                 each info in collectionDetails
                   tr
                     td #{info[0]}
@@ -148,6 +125,29 @@ block allbody
                     td #{info[0]}
                     td #{info[2]}
                     td #{info[1]}
+      else if component.formId === 'GeometryBoardShipment'
+        .vert-space-x1.border-success.border.rounded.p-2
+          dt Origin Location 
+          dd #{dictionary_locations[component.data.originOfShipment]}
+
+          dt Destination Location
+          dd #{dictionary_locations[component.data.destinationOfShipment]}
+
+          dt Boards in Shipment
+          dd
+            table.table
+              thead
+                tr
+                  th.col-sm-1 UUID
+                  th.col-sm-1 UK ID
+                  th.col-sm-1 Part Number
+
+              tbody
+                each info in collectionDetails
+                  tr
+                    td #{info[0]}
+                    td #{info[1]}
+                    td #{info[2]}
       else if component.formId === 'GroundingMeshPanelShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -148,7 +148,7 @@ block allbody
                     td #{info[0]}
                     td #{info[2]}
                     td #{info[1]}
-      else if component.formId === 'GroundingMeshShipment'
+      else if component.formId === 'GroundingMeshPanelShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location
           dd #{dictionary_locations[component.data.originOfShipment]}

--- a/app/pug/dashboard.pug
+++ b/app/pug/dashboard.pug
@@ -137,7 +137,7 @@ body(class = `deployment-${NODE_ENV}`)
                     |      Geometry Boards by Visual Inspection or Order Number
 
                 li.nav-item
-                  +navlink(href = '/search/boardShipmentsByReceptionDetails')
+                  +navlink(href = '/search/geoBoardShipmentsByReceptionDetails')
                     |      Geometry Board Shipments by Reception Details
 
                 li.nav-item

--- a/app/pug/search_geoBoardShipmentsByReceptionDetails.pug
+++ b/app/pug/search_geoBoardShipmentsByReceptionDetails.pug
@@ -8,7 +8,7 @@ block extrascripts
     const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
 
   block workscripts 
-    script(src = '/pages/search_boardShipmentsByReceptionDetails.js')
+    script(src = '/pages/search_geoBoardShipmentsByReceptionDetails.js')
 
 block content
   .container-fluid

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -945,10 +945,10 @@ router.get(['/json/components/hwdbInformation/:uuid', '/api/components/hwdbInfor
   try {
     // Retrieve the collated information - since this may require extracting specific field values from a number of DB records related to the component ...
     // ... it is easier to collate this information through a single library function, rather than performing multiple library function calls from this route
-    let collatedInfo = await Components_CollateInfo.forHWDB(req.params.uuid);
+    let hwdbInfo = await Components_CollateInfo.forHWDB(req.params.uuid);
 
     // Return the information in JSON format
-    return res.status(200).json(collatedInfo);
+    return res.status(200).json(hwdbInfo);
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);
     res.status(500).json({ error: err.toString() });

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -218,7 +218,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'GroundingMeshShipment') {
+    if (component.formId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -420,7 +420,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if (component.formId === 'GroundingMeshShipment') {
+    if (component.formId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -594,7 +594,7 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if (component.formId === 'GroundingMeshShipment') {
+    if (component.formId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -863,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.reception != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.reception.location]; }
         else { shipment.additionalInformation = '[reception object missing!]'; }

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -56,11 +56,11 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // Add this information to the previously retrieved list of actions performed on the board, and make sure that all of the action entries contain the same (or equivalent) fields
     // Add an entry for the board itself (again, containing the same fields as the action entries), and finally sort all entries in the combined array by the 'lastEditDate' field
     if (component.formId === 'GeometryBoard') {
-      boardShipments = await Search_OtherComponents.boardShipmentsByBoardUUID(req.params.uuid);
-      actions = actions.concat(boardShipments);
+      geoBoardShipments = await Search_OtherComponents.geoBoardShipmentsByBoardUUID(req.params.uuid);
+      actions = actions.concat(geoBoardShipments);
 
       for (let entry of actions) {
-        if (entry.typeFormId !== 'BoardShipment') {
+        if (entry.typeFormId !== 'GeometryBoardShipment') {
           entry.data = {};
           entry.data.checksPassed = '[n.a.]';
 
@@ -188,16 +188,6 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'BoardShipment') {
-      for (const info of component.data.boardUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber, componentRecord.shortUuid]);
-        }
-      }
-    }
-
     if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
@@ -214,6 +204,16 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
           const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+        }
+      }
+    }
+
+    if (component.formId === 'GeometryBoardShipment') {
+      for (const info of component.data.boardUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber, componentRecord.shortUuid]);
         }
       }
     }
@@ -400,7 +400,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if ((component.formId === 'BoardShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
+    if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -564,16 +564,6 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if (component.formId === 'BoardShipment') {
-      for (const info of component.data.boardUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber]);
-        }
-      }
-    }
-
     if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
@@ -590,6 +580,16 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
           const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+        }
+      }
+    }
+
+    if (component.formId === 'GeometryBoardShipment') {
+      for (const info of component.data.boardUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.data.partNumber]);
         }
       }
     }
@@ -863,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAFrameShipment', 'APAShipment', 'BoardShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.reception != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.reception.location]; }
         else { shipment.additionalInformation = '[reception object missing!]'; }

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -131,7 +131,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only a handful of workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
-    const list_workflowComponents = ['AssembledAPA', 'APAFrame', 'APAShipment'];
+    const list_workflowComponents = ['APAFrame', 'AssembledAPA', 'AssembledAPAShipment'];
     const workflowComponent = list_workflowComponents.includes(component.formId);
 
     // If the specified component type is one that is the subject of a workflow, filter out any action types that should be performed through the workflow
@@ -144,11 +144,11 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     if (workflowComponent) {
       let workflowTypeForm = null;
 
-      if (component.formId === 'AssembledAPA') {
-        workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
-      } else if (component.formId === 'APAFrame') {
+      if (component.formId === 'APAFrame') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'FrameAssembly');
-      } else if (component.formId === 'APAShipment') {
+      } else if (component.formId === 'AssembledAPA') {
+        workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
+      } else if (component.formId === 'AssembledAPAShipment') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_PostProduction');
       }
 
@@ -844,7 +844,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only a small number of workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
-    const list_workflowComponents = ['AssembledAPA', 'APAFrame', 'APAShipment'];
+    const list_workflowComponents = ['APAFrame', 'AssembledAPA', 'AssembledAPAShipment'];
     const workflowComponent = list_workflowComponents.includes(req.params.typeFormId);
 
     // For certain component types, it is useful to display some extra information ... either directly about the component itself, or about a related component or action
@@ -863,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.reception != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.reception.location]; }
         else { shipment.additionalInformation = '[reception object missing!]'; }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -109,9 +109,9 @@ module.exports = routes;
   /search/geoBoardsByVisInspectOrOrderNumber
   /json/search/geoBoardsByVisualInspection/:disposition/:issue
   /json/search/geoBoardsByOrderNumber/:orderNumber
-  /search/boardShipmentsByReceptionDetails
-  /json/search/boardShipmentsByReceptionDetails
-  /json/search/boardShipmentsByBoardUUID
+  /search/geoBoardShipmentsByReceptionDetails
+  /json/search/geoBoardShipmentsByReceptionDetails
+  /json/search/geoBoardShipmentsByBoardUUID
   /search/apasByProductionDetails
   /json/search/apasByProductionLocationAndNumber/:apaLocation/:apaNumber
   /json/search/apasByProductionLocationAndAssemblyStep/:apaLocation/:assemblyStep

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -128,14 +128,14 @@ router.get(['/json/search/geoBoardsByOrderNumber/:orderNumber', '/api/search/geo
 
 
 /// Search for geometry board shipments using various shipment reception details (client-side interface)
-router.get('/search/boardShipmentsByReceptionDetails', async function (req, res, next) {
+router.get('/search/geoBoardShipmentsByReceptionDetails', async function (req, res, next) {
   // Render the interface page
-  res.render('search_boardShipmentsByReceptionDetails.pug', { dictionary_locations: utils.dictionary_locations });
+  res.render('search_geoBoardShipmentsByReceptionDetails.pug', { dictionary_locations: utils.dictionary_locations });
 });
 
 
 /// Search for geometry board shipments using various shipment reception details (query to server-side)
-router.get(['/json/search/boardShipmentsByReceptionDetails', '/api/search/boardShipmentsByReceptionDetails'], async function (req, res, next) {
+router.get(['/json/search/geoBoardShipmentsByReceptionDetails', '/api/search/geoBoardShipmentsByReceptionDetails'], async function (req, res, next) {
   try {
     // This search query can have multiple query strings, most of which are optional
     // So first, parse out the strings which have actually been provided (as non-empty strings), and set the rest to 'null'
@@ -153,7 +153,7 @@ router.get(['/json/search/boardShipmentsByReceptionDetails', '/api/search/boardS
     if (latest) latest = latest.replace(' ', '+');
 
     // Retrieve a list of geometry boards shipments that match the specified reception details
-    const shipments = await Search_OtherComponents.boardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment);
+    const shipments = await Search_OtherComponents.geoBoardShipmentsByReceptionDetails(status, origin, destination, earliest, latest, comment);
 
     // Return the list in JSON format
     return res.status(200).json(shipments);
@@ -165,10 +165,10 @@ router.get(['/json/search/boardShipmentsByReceptionDetails', '/api/search/boardS
 
 
 /// Search for geometry board shipments that reference a single component, specified by its UUID (query to server-side)
-router.get(['/json/search/boardShipmentsByBoardUUID/:uuid', '/api/search/boardShipmentsByBoardUUID/:uuid'], async function (req, res, next) {
+router.get(['/json/search/geoBoardShipmentsByBoardUUID/:uuid', '/api/search/geoBoardShipmentsByBoardUUID/:uuid'], async function (req, res, next) {
   try {
     // Retrieve a list of geometry boards shipments that reference the specified component UUID
-    const shipments = await Search_OtherComponents.boardShipmentsByBoardUUID(req.params.uuid);
+    const shipments = await Search_OtherComponents.geoBoardShipmentsByBoardUUID(req.params.uuid);
 
     // Sort the shipments by increasing 'lastEditDate', i.e. the most recent shipment will be first in the list
     shipments.sort(utils.byField_decreasing('lastEditDate'));

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -247,13 +247,7 @@ router.get('/administratorUtility', async function (req, res, next) {
 router.post(['/json/administratorUtility/:inputString', '/api/administratorUtility/:inputString'], async function (req, res, next) {
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
-    let result = null;
-
-    if (['ALL_COMPONENTS', 'APAFrame', 'AssembledAPA', 'DWA', 'DWAPDB'].includes(req.params.inputString)) {
-      result = await Admin_Functions.cleanComponentRecords(req.params.inputString);    // Change as appropriate for the required utility
-    } else {
-      result = await Admin_Functions.addComponentInfoToActionRecords(req.params.inputString);
-    }
+    let result = await Admin_Functions.cleanComponentTypeFormIds(req.params.inputString);    // Change as appropriate for the required utility
 
     return res.status(201).json(result);
   } catch (err) {

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -347,7 +347,7 @@ class ComponentUUID extends TextFieldComponent {
                   }
                 },
               }).fail();
-            } else if (component.formId === 'wire_bobbin') {
+            } else if (component.formId === 'WireBobbin') {
               if (component.data.meanBreakStrength >= 24.0) {
                 info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
               } else {

--- a/app/static/pages/administratorUtility.js
+++ b/app/static/pages/administratorUtility.js
@@ -27,15 +27,7 @@ async function renderInputForm() {
 
 
 function postSuccess(result) {    // Change as appropriate for the required utility
-  if (['ALL_COMPONENTS', 'APAFrame', 'AssembledAPA', 'DWA', 'DWAPDB'].includes(result)) {
-    if (result === 'ALL_COMPONENTS') {
-      window.location.href = `/componentTypes/list`;
-    } else {
-      window.location.href = `/components/${result}/list`;
-    }
-  } else {
-    window.location.href = `/actionTypes/list`;
-  }
+  window.location.href = `/components/${result}/list`;
 }
 
 

--- a/app/static/pages/component_hwdbInformation.js
+++ b/app/static/pages/component_hwdbInformation.js
@@ -1,5 +1,6 @@
 // Declare a variable to hold the user-specified component UUID
 let componentUuid = null;
+let filename = 'hwdbInfo_noComponentSpecified.json';
 
 // Run a specific function when the page is loaded
 window.addEventListener('load', renderSearchForms);
@@ -53,8 +54,10 @@ function postSuccess(result) {
   // Make sure that the page elements where the component information will be displayed are all empty
   $('#componentinfo').empty();
 
-  // Show the component information in its corresponding page element
+  // Show the component information in its corresponding page element, and use the information to set the filename to be used for downloading the JSON file
   $('#componentinfo').val(JSON.stringify(result, null, 2));
+
+  filename = result['specifications']['component']['filename'];
 
   // Re-enable the confirmation button for the next retrieval
   $('#confirmButton').prop('disabled', false);
@@ -80,6 +83,7 @@ function DownloadInfo() {
   const info = $('#componentinfo').val();
   const info_obj = window.URL.createObjectURL(new Blob([info], { type: 'application/JSON' }));
 
+  $('#download_componentinfo').attr('download', filename);
   $('#download_componentinfo').attr('href', info_obj);
 }
 

--- a/app/static/pages/search_geoBoardShipmentsByReceptionDetails.js
+++ b/app/static/pages/search_geoBoardShipmentsByReceptionDetails.js
@@ -1,4 +1,4 @@
-// Declare variables to hold the (initially empty) user-specified board shipment reception details
+// Declare variables to hold the (initially empty) user-specified geometry board shipment reception details
 let shipmentStatus = '';
 let originLocation = '';
 let destinationLocation = '';
@@ -95,7 +95,7 @@ async function renderSearchForms() {
       $.ajax({
         contentType: 'application/json',
         method: 'GET',
-        url: `/json/search/boardShipmentsByReceptionDetails?shipmentStatus=${shipmentStatus}&originLocation=${originLocation}&destinationLocation=${destinationLocation}&earliestDate=${earliestDate}&latestDate=${latestDate}&receptionComment=${receptionComment}`,
+        url: `/json/search/geoBoardShipmentsByReceptionDetails?shipmentStatus=${shipmentStatus}&originLocation=${originLocation}&destinationLocation=${destinationLocation}&earliestDate=${earliestDate}&latestDate=${latestDate}&receptionComment=${receptionComment}`,
         dataType: 'json',
         success: postSuccess,
       }).fail(postFail);


### PR DESCRIPTION
Adding new Daresbury technician to central list

Further changes to the HWDB info dump functionality
- reworked the JSON structure as per discussion with Hajime
- the downloaded JSON file's name will now contain the name of the component in question
- small change to internal variable naming, for clarity and consistency

Component Type Form ID and Name Consistency Changes
- there are 4 component types which have type form IDs and/or names which are inconsistent with all other types - want to clean these up
Grounding Mesh Shipment (GroundingMeshShipment) --> Grounding Mesh Panel Shipment (GroundingMeshPanelShipment)
- Wire Bobbin (wire_bobbin) --> Wire Bobbin (WireBobbin) [ID change only]
- Board Shipment (BoardShipment) --> Geometry Board Shipment (GeometryBoardShipment)
- APA Shipment (APAShipment) --> Assembled APA Shipment (AssembledAPAShipment)
- changed all instances of the formers in the code to the latters ... i.e. where an interface page layout is tailored to a specific component type, or where specific information is to be retrieved depending on the component type
- added a new administrator utility function to directly change the 'formId' and 'formName' fields of all relevant component records, and the 'path[0].formName' field in the relevant workflow records for assembled APA shipments
- corresponding changes to the two search functions that apply to geometry board shipments (library functions, routes and interface page file names)

Note that for each component type, a new type form will need to be created through the interface, and any connected existing action and workflow type forms then edited to point to it (the old component type form can then be trashed)

Changes have been tested on Staging.