### PR TITLE
Component Type Form ID and Name Consistency Changes (Part 4) ...

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -1,4 +1,5 @@
 const MUUID = require('uuid-mongodb');
+const ObjectId = require('mongodb').ObjectId;
 
 const Actions = require('./Actions');
 const { db } = require('./db');
@@ -6,6 +7,7 @@ const Components = require('./Components');
 const Forms = require('./Forms');
 const logger = require('./logger');
 const utils = require('./utils');
+const Workflows = require('./Workflows');
 
 
 async function cleanComponentTypeFormIds(typeFormId) {
@@ -21,6 +23,9 @@ async function cleanComponentTypeFormIds(typeFormId) {
   } else if (typeFormId === 'BoardShipment') {
     newTypeFormId = 'GeometryBoardShipment';
     newTypeFormName = 'Geometry Board Shipment';
+  } else if (typeFormId === 'APAShipment') {
+    newTypeFormId = 'AssembledAPAShipment';
+    newTypeFormName = 'Assembled APA Shipment';
   }
 
   const result = await db.collection('components')
@@ -37,6 +42,67 @@ async function cleanComponentTypeFormIds(typeFormId) {
     )
 
   if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
+
+  if (typeFormId === 'APAShipment') {
+    let aggregation_stages = [];
+
+    aggregation_stages.push({ $match: { formId: newTypeFormId } });
+    aggregation_stages.push({ $project: { componentUuid: true } });
+
+    let uuids = await db.collection('components')
+      .aggregate(aggregation_stages)
+      .toArray();
+
+    for (let uuid of uuids) {
+      const component = await Components.retrieve(uuid.componentUuid);
+      const data = component.data;
+
+      let name_apa1 = '[not set]';
+      let name_apa2 = '[not set]';
+
+      if (data.apaUuiDs[0].component_uuid !== '') {
+        const apa = await Components.retrieve(data.apaUuiDs[0].component_uuid);
+        name_apa1 = apa.data.componentName.substring(4);
+      }
+
+      if (data.apaUuiDs[1].component_uuid !== '') {
+        const apa = await Components.retrieve(data.apaUuiDs[1].component_uuid);
+        name_apa2 = apa.data.componentName.substring(4);
+      }
+
+      const componentName = `Assembled APA Shipment (${name_apa1} + ${name_apa2})`;
+
+      const componentUuid = component.componentUuid;
+      let match_condition = { componentUuid };
+
+      if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
+
+      match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
+
+      let resultInner = await db.collection('components')
+        .updateMany(
+          match_condition,
+          [
+            {
+              $set: { 'data.componentName': componentName }
+            },
+          ]
+        )
+
+      if (resultInner.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to update Assembled APA Shipment component names!`);
+
+      let update = { '$set': {} };
+      update['$set']['path.' + 0 + '.formName'] = newTypeFormName;
+
+      resultInner = await db.collection('workflows')
+        .updateMany(
+          { workflowId: new ObjectId(component.workflowId) },
+          update,
+        )
+
+      if (resultInner.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form name in the workflow records!`);
+    }
+  }
 
   return newTypeFormId;
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -204,14 +204,14 @@ async function save(input, req) {
     // ... the only exceptions are the 'batch' types (these still need the location field to exist, but it can be left as an empty string)
     if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'WireBobbin')) {
       newRecord.reception.location = 'daresbury';
-    } else if (newRecord.formId === 'APAShipment') {
-      newRecord.reception.location = newRecord.data.originOfShipment;
     } else if (newRecord.formId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
     } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
     } else if (newRecord.formId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
+    } else if (newRecord.formId === 'AssembledAPAShipment') {
+      newRecord.reception.location = newRecord.data.originOfShipment;
     } else if ((newRecord.formId === 'CEAdapterBoard') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'CRBoard') || (newRecord.formId === 'CRBoardShipment') || (newRecord.formId === 'CableHarness') || (newRecord.formId === 'CableHarnessShipment') || (newRecord.formId === 'GBiasBoard') || (newRecord.formId === 'GBiasBoardShipment') || (newRecord.formId === 'SHVBoard') || (newRecord.formId === 'SHVBoardShipment') || (newRecord.formId === 'Yoke')) {
       newRecord.reception.location = 'wisconsin';
     } else if ((newRecord.formId === 'DWA') || (newRecord.formId === 'DWAPDB')) {
@@ -234,21 +234,21 @@ async function save(input, req) {
   if (newRecord.formId === 'APAFrameShipment') {
     newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.frameUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'APAShipment') {
+  } else if (newRecord.formId === 'AssembledAPAShipment') {
     let name_apa1 = '[not set]';
     let name_apa2 = '[not set]';
 
     if (newRecord.data.apaUuiDs[0].component_uuid !== '') {
       const apa = await retrieve(newRecord.data.apaUuiDs[0].component_uuid);
-      name_apa1 = apa.data.componentName;
+      name_apa1 = apa.data.componentName.substring(4);
     }
 
     if (newRecord.data.apaUuiDs[1].component_uuid !== '') {
       const apa = await retrieve(newRecord.data.apaUuiDs[1].component_uuid);
-      name_apa2 = apa.data.componentName;
+      name_apa2 = apa.data.componentName.substring(4);
     }
 
-    newRecord.data.componentName = `${newRecord.formName} (${name_apa1} and ${name_apa2})`;
+    newRecord.data.componentName = `${newRecord.formName} (${name_apa1} + ${name_apa2})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'CEAdapterBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
@@ -266,13 +266,13 @@ async function save(input, req) {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GeometryBoardShipment') {
-    newRecord.data.componentName = `Geometry ${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'GroundingMeshPanelShipment') {
-    newRecord.data.componentName = `Grounding Mesh Panel Shipment (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'PopulatedBoardShipment') {
-    newRecord.data.componentName = `Multi-Type Populated Board Shipment ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.formId === 'SHVBoardShipment') {
     newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
@@ -293,19 +293,19 @@ async function save(input, req) {
   if (!result.acknowledged) throw new Error(`Components::save() - failed to insert a new component record into the database!`);
 
   // Once the component record has been successfully saved, deal with the reception information for any related components:
-  // - for an 'APA Shipment', update the reception information of the underlying 'Assembled APA' and 'ASF' components to be the same as the shipment
+  // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
+  // - for an 'Assembled APA Shipment', update the reception information of the underlying 'Assembled APA' and 'ASF' components to be the same as the shipment
   //    (they should already be at the same location as the shipment, but this is a double-check on that)
   // - for other types of shipment, update the reception information of the various sub-components to indicate that they are in transit
-  // - for an 'Assembled APA', update the reception information of the underlying 'APA Frame' to indicate that it is now being used
   // - for a 'Populated Board Shipment', update the reception information of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
   // - for a 'Return Geometry Board Batch', update the reception information of the individual geometry board sub-components to indicate they are at Lancaster (where the batch is put together)
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
-  if (newRecord.formId === 'APAShipment') {
-    const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
+  } else if (newRecord.formId === 'AssembledAPAShipment') {
+    const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.formId === 'ReturnedGeometryBoardBatch') {
     for (const board of newRecord.data.boardUuids) {
       const result = await updateLocation(board.component_uuid, 'lancaster', (new Date()).toISOString().slice(0, 10), '');
@@ -411,7 +411,7 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     for (const frame of shipment.data.frameUuiDs) {
       const result = await updateLocation(frame.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'APAShipment') {
+  } else if (shipment.formId === 'AssembledAPAShipment') {
     // Extract the UUID and update the location information of each assembled APA and the ASF in a shipment of APAs
     for (const apa of shipment.data.apaUuiDs) {
       const result = await updateLocation(apa.component_uuid, location, date, '');

--- a/app/pug/action_listTypes.pug
+++ b/app/pug/action_listTypes.pug
@@ -47,7 +47,7 @@ block content
           - const collapseId = `avail_actionTypeGroup_${index}`;
           - let startingDisplay = 'show';
 
-          if actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'APA Frame' || actionFormsGroup._id.componentType === 'APA Shipment'
+          if actionFormsGroup._id.componentType === 'APA Frame' || actionFormsGroup._id.componentType === 'Assembled APA' || actionFormsGroup._id.componentType === 'Assembled APA Shipment'
             - startingDisplay = ''
 
           .panel.panel-default

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -543,21 +543,21 @@ block content
     .vert-space-x1
       .row
         .col-sm-6
-          if component.formId === 'AssembledAPA'
-            h4 Action History (Non-Workflow Actions Only)
-
-            .vert-space-x1
-              p <b>Existing workflow actions can be accessed through this component's 
-                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
-                | workflow</b>
-          else if component.formId === 'APAFrame'
+          if component.formId === 'APAFrame'
             h4 Action History (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>Existing workflow actions can be accessed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
-          else if component.formId === 'APAShipment'
+          else if component.formId === 'AssembledAPA'
+            h4 Action History (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>Existing workflow actions can be accessed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
+                | workflow</b>
+          else if component.formId === 'AssembledAPAShipment'
             h4 Action History (Non-Workflow Actions Only)
 
             .vert-space-x1
@@ -596,21 +596,21 @@ block content
                         +dateTimeFormat(action.lastEditDate)
 
         .col-sm-6
-          if component.formId === 'AssembledAPA'
-            h4 Select an Action Type to Perform (Non-Workflow Actions Only)
-
-            .vert-space-x1
-              p <b>New workflow actions must be performed through this component's 
-                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
-                | workflow</b>
-          else if component.formId === 'APAFrame'
+          if component.formId === 'APAFrame'
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>New workflow actions must be performed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
-          else if component.formId === 'APAShipment'
+          else if component.formId === 'AssembledAPA'
+            h4 Select an Action Type to Perform (Non-Workflow Actions Only)
+
+            .vert-space-x1
+              p <b>New workflow actions must be performed through this component's 
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
+                | workflow</b>
+          else if component.formId === 'AssembledAPAShipment'
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -31,7 +31,7 @@ block content
               th.col-md-2 Installed on APA
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_listTypes.pug
+++ b/app/pug/component_listTypes.pug
@@ -59,7 +59,7 @@ block content
                   td 0
 
                 td
-                  if (typeFormId === 'AssembledAPA' || typeFormId === 'APAFrame' || typeFormId === 'APAShipment')
+                  if (typeFormId === 'APAFrame' || typeFormId === 'AssembledAPA' || typeFormId === 'AssembledAPAShipment')
                     a.btn-sm.btn-secondary.disabled(href = '')
                       img.small-icon(src = '/images/run_icon.svg')
                       | &nbsp; Create New Components of This Type via Workflows

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAFrameShipment') || (component.formId === 'APAShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.formId === 'APAFrameShipment') || (component.formId === 'AssembledAPAShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -131,7 +131,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only a handful of workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
-    const list_workflowComponents = ['AssembledAPA', 'APAFrame', 'APAShipment'];
+    const list_workflowComponents = ['APAFrame', 'AssembledAPA', 'AssembledAPAShipment'];
     const workflowComponent = list_workflowComponents.includes(component.formId);
 
     // If the specified component type is one that is the subject of a workflow, filter out any action types that should be performed through the workflow
@@ -144,11 +144,11 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     if (workflowComponent) {
       let workflowTypeForm = null;
 
-      if (component.formId === 'AssembledAPA') {
-        workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
-      } else if (component.formId === 'APAFrame') {
+      if (component.formId === 'APAFrame') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'FrameAssembly');
-      } else if (component.formId === 'APAShipment') {
+      } else if (component.formId === 'AssembledAPA') {
+        workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
+      } else if (component.formId === 'AssembledAPAShipment') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_PostProduction');
       }
 
@@ -844,7 +844,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only a small number of workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
-    const list_workflowComponents = ['AssembledAPA', 'APAFrame', 'APAShipment'];
+    const list_workflowComponents = ['APAFrame', 'AssembledAPA', 'AssembledAPAShipment'];
     const workflowComponent = list_workflowComponents.includes(req.params.typeFormId);
 
     // For certain component types, it is useful to display some extra information ... either directly about the component itself, or about a related component or action
@@ -863,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAFrameShipment', 'APAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.reception != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.reception.location]; }
         else { shipment.additionalInformation = '[reception object missing!]'; }


### PR DESCRIPTION
- continuing with 'APA Shipment' ... renamed to 'Assembled APA Shipment'
- changed all instances of the former to the latter
- additional code in the administrator utility function to change the 'path[0].formName' field in 'APA Post Production' workflows to be the new type form name
- changed code for setting component names at creation to now use the updated type form names (previously, some types were using hardcoded naming because their type form names were different from desired ... not anymore)