### PR TITLE
Miscellaneous Changes and Fixes from Staging

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -39,24 +39,24 @@ async function save(input, req) {
 
   if (!typeForm) throw new Error(`Actions:save() - the specified 'input.typeFormId' (${input.typeFormId}) does not match a known action type form!`);
 
-  // Some action types should be submitted only by the APA Factory Leads - these are typically the most important and/or highest level QA checks and signoffs
-  // Check that the submitter (i.e. the currently logged-in user) is the same as the person who's name is being used for the QA signoff ... if not, do not allow the action to be submitted
-  // Since the list of personnel for QA signoffs is always only the APA Factory Leads, this check should restrict such actions to only be submittable by leads WHEN LOGGED IN AS THEMSELVES
+  // Some action types should be submitted only by the APA Factory Leads or other top-level personnel - these are typically the most important and/or highest level QA checks and signoffs
+  // Check that the submitter (i.e. the currently logged-in user) is the same as the person who's name is being used for the final signoff ... if not, do not allow the action to be submitted
+  // This check should restrict such actions to only be submittable by leads / top-level personnel WHEN LOGGED IN AS THEMSELVES
   if (input.typeFormId === 'AssembledAPAQACheck') {
     if (req.user.displayName !== utils.dictionary_apaFactoryLeads[input.data.personSigningOff]) {
-      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off the QA Checks on behalf of someone else (${utils.dictionary_apaFactoryLeads[input.data.personSigningOff]}) - this is not permitted!`);
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off this action on behalf of someone else (${utils.dictionary_apaFactoryLeads[input.data.personSigningOff]}) - this is not permitted!`);
     }
   }
 
   if (input.typeFormId === 'CompletedAPAQCChecklist') {
-    if (req.user.displayName !== utils.dictionary_apaFactoryLeads[input.data.personSigningOff]) {
-      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off the APA Final Assembly on behalf of someone else (${utils.dictionary_apaFactoryLeads[input.data.personSigningOff]}) - this is not permitted!`);
+    if ((req.user.displayName !== utils.dictionary_fdhdTechCoordSignoff[input.data.fdhdTechCoordSigningOff]) && (input.data.actionComplete)) {
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off and complete this action on behalf of someone else (${utils.dictionary_fdhdTechCoordSignoff[input.data.fdhdTechCoordSigningOff]}) - this is not permitted!`);
     }
   }
 
   if (input.typeFormId === 'prep_mesh_panel_install') {
     if ((req.user.displayName !== utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]) && (input.data.actionComplete)) {
-      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off the Installation QA and complete this action on behalf of someone else (${utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]}) - this is not permitted!`);
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off and complete this action on behalf of someone else (${utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]}) - this is not permitted!`);
     }
   }
 
@@ -64,7 +64,7 @@ async function save(input, req) {
   // This is designed to stop users from performing and 'completing' blank actions in order to skip ahead in workflows, but this way it does not require any fields to be 'required' in the type form
   if (input.data.actionComplete) {
     if ((input.typeFormId === 'x_tension_testing') && (input.data.measuredTensions_sideA.length === 0) && (input.data.measuredTensions_sideB.length === 0)) {
-      throw new Error(`Actions:save() - this action does not contain any tension measurements, but has been set as 'complete' ... please uncheck the 'Action Complete' box to submit!`);
+      throw new Error(`Actions:save() - you are attempting to complete this action,  but it does not yet contain any tension measurements ... please uncheck the 'Action Complete' box to submit!`);
     }
   }
 

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -11,6 +11,52 @@ const Workflows = require('./Workflows');
 
 
 async function cleanComponentTypeFormIds(typeFormId) {
+  let typeFormName = null;
+  let actionTypeFormIDs = null;
+
+  if (typeFormId === 'AssembledAPAShipment') {
+    typeFormName = 'Assembled APA Shipment';
+    actionTypeFormIDs = ['APAShipmentReception', 'APAShipmentTransport', 'ASFCloseUp'];
+  }
+
+  for (const actionTypeFormID of actionTypeFormIDs) {
+    let aggregation_stages = [];
+
+    aggregation_stages.push({ $match: { typeFormId: actionTypeFormID } });
+    aggregation_stages.push({
+      $project: {
+        actionId: true,
+        componentUuid: true,
+      }
+    });
+
+    let actions = await db.collection('actions')
+      .aggregate(aggregation_stages)
+      .toArray();
+
+    for (let action of actions) {
+      const component = await Components.retrieve(action.componentUuid);
+      
+      const result = await db.collection('actions')
+        .updateMany(
+          { actionId: action.actionId },
+          [
+            {
+              $set: {
+                'componentName': component.data.componentName,
+                'componentTypeFormId': typeFormId,
+                'componentTypeFormName': typeFormName,
+              }
+            },
+          ]
+        )
+
+      if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
+    }
+  }
+
+
+/*
   let newTypeFormId = null;
   let newTypeFormName = null;
 
@@ -103,8 +149,8 @@ async function cleanComponentTypeFormIds(typeFormId) {
       if (resultInner.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form name in the workflow records!`);
     }
   }
-
-  return newTypeFormId;
+*/
+  return typeFormId;
 }
 
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -150,7 +150,7 @@ module.exports = {
     radosavPantelic: 'Radosav Pantelic',
   },
 
-  // Frame Prep D-band personnel (prep-related APA Assembly workflow actions and 'Final Inspection' Grounding Mesh Panel actions)
+  // Frame Prep D-band personnel ('Frame Prep - ???' APA Assembly workflow actions and 'Final Inspection' Grounding Mesh Panel actions)
   dictionary_dBandFramePrep: {
     edBlucher: 'Ed Blucher',
     wayneGreen: 'Wayne Green',
@@ -210,6 +210,11 @@ module.exports = {
     radosavPantelic: 'Radosav Pantelic',
     danielSalisbury: 'Daniel Salisbury',
     jasonThornhill: 'Jason Thornhill',
+  },
+
+  // FD-HD technical coordinators (final signoff in 'Completed APA QA Checklist' APA Assembly workflow actions)
+  dictionary_fdhdTechCoordSignoff: {
+    ericJames: 'Eric James',
   },
 
   // Yoke load test technicians at UW [not currently used, but keep for the future]

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -55,10 +55,7 @@ block content
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'APAShipment') APA Shipment 
-            option(value = 'BoardShipment') Board Shipment 
-            option(value = 'GroundingMeshShipment') Grounding Mesh Shipment 
-            option(value = 'wire_bobbin') Wire Bobbin
+            option(value = 'AssembledAPAShipment') Assembled APA Shipment 
             
 
           .vert-space-x2 

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -160,10 +160,10 @@ router.get(['/json/dBandPostProduction.json', '/api/dBandPostProduction.json'], 
 });
 
 
-/// List geometry board metrology technicians at Manchester
-router.get(['/json/manchesterTechnicians.json', '/api/manchesterTechnicians.json'], async function (req, res, next) {
+/// List FD-HD technical coordinators
+router.get(['/json/fdhdTechCoordSignoff.json', '/api/fdhdTechCoordSignoff.json'], async function (req, res, next) {
   try {
-    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_manchesterTechnicians));
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_fdhdTechCoordSignoff));
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);
     res.status(500).json({ error: err.toString() });


### PR DESCRIPTION
Changes to FD-HD Technical Coordinator signoffs ...
- after discussion with Brian, realised that the FD-HD technical coordinator signoff is actually the final one for 'Completed APA QA Checklist' actions ... that is the one that should be checked against the submitter
- added new dictionary of FD-HD technical coordinators (just Eric at the moment), and corresponding route
- the 'Completed APA QA Checklist' action type should now use the new dictionary, instead of the built-in list of names
- if attempting to be completed, the action will now check the inputted FD-HD technical coordinator against the new dictionary ... submission rejected if there is no match
- small clean up of displayed errors and unused dictionaries

Fixing outdated component names in actions ...
- actions performed on Assembled APA Shipments still show the old-style component names ('APA Shipment XXX') ... forgot to update these when I updated the other fields in the previous commit
- set up administrator utility to update these component names

Changes have been tested on Staging.