### PR TITLE
Additional change for the previous commit ...

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -22,22 +22,52 @@ async function cleanComponentTypeFormIds(typeFormId) {
     newTypeFormName = 'Geometry Board Shipment';
   }
 
-  const result = await db.collection('components')
-    .updateMany(
-      { formId: typeFormId },
-      [
-        {
-          $set: {
-            'formId': newTypeFormId,
-            'formName': newTypeFormName,
-          }
-        },
-      ]
-    )
+  let aggregation_stages = [];
+  aggregation_stages.push({ $match: { formId: typeFormId } });
+  aggregation_stages.push({ $project: { componentUuid: true } });
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
+  let uuids = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
 
-  return typeFormId;
+  for (let uuid of uuids) {
+    const component = await Components.retrieve(uuid.componentUuid);
+    const data = component.data;
+    const typeRecordNumber = String(data.typeRecordNumber).padStart(5, '0');
+
+    let componentName = '';
+    let dunePid = '';
+
+    if (typeFormId === 'BoardShipment') {
+      componentName = `${newTypeFormName} (${data.boardUuiDs.length}.${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'wire_bobbin') {
+      componentName = `${newTypeFormName} ${data.bobbinId} (Lot ${data.wireLot})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    }
+
+    const componentUuid = component.componentUuid;
+    let match_condition = { componentUuid };
+
+    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
+    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
+
+    const result = await db.collection('components')
+      .updateMany(
+        match_condition,
+        [
+          {
+            $set: {
+              'formId': newTypeFormId,
+              'formName': newTypeFormName,
+              'data.componentName': componentName,
+              'data.dunePid': dunePid,
+            }
+          },
+        ]
+      )
+    if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change fields in the component record!`);
+  }
 }
 
 


### PR DESCRIPTION
- forgot to change the component names and DUNE PIDs
- since those are unique to each component, had to take the admin utility back even further to the function that was previously used to set the individual component names ... now also sets the correct type form names and IDs