### PR TITLE
Changes to Admin Utility to Fix Incorrect Records

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -11,67 +11,15 @@ const Workflows = require('./Workflows');
 
 
 async function cleanComponentTypeFormIds(typeFormId) {
-  let typeFormName = null;
-  let actionTypeFormIDs = null;
-
-  if (typeFormId === 'AssembledAPAShipment') {
-    typeFormName = 'Assembled APA Shipment';
-    actionTypeFormIDs = ['APAShipmentReception', 'APAShipmentTransport', 'ASFCloseUp'];
-  }
-
-  for (const actionTypeFormID of actionTypeFormIDs) {
-    let aggregation_stages = [];
-
-    aggregation_stages.push({ $match: { typeFormId: actionTypeFormID } });
-    aggregation_stages.push({
-      $project: {
-        actionId: true,
-        componentUuid: true,
-      }
-    });
-
-    let actions = await db.collection('actions')
-      .aggregate(aggregation_stages)
-      .toArray();
-
-    for (let action of actions) {
-      const component = await Components.retrieve(action.componentUuid);
-      
-      const result = await db.collection('actions')
-        .updateMany(
-          { actionId: action.actionId },
-          [
-            {
-              $set: {
-                'componentName': component.data.componentName,
-                'componentTypeFormId': typeFormId,
-                'componentTypeFormName': typeFormName,
-              }
-            },
-          ]
-        )
-
-      if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
-    }
-  }
-
-
-/*
   let newTypeFormId = null;
   let newTypeFormName = null;
 
-  if (typeFormId === 'GroundingMeshShipment') {
-    newTypeFormId = 'GroundingMeshPanelShipment';
-    newTypeFormName = 'Grounding Mesh Panel Shipment';
-  } else if (typeFormId === 'wire_bobbin') {
+  if (typeFormId === 'wire_bobbin') {
     newTypeFormId = 'WireBobbin';
     newTypeFormName = 'Wire Bobbin';
   } else if (typeFormId === 'BoardShipment') {
     newTypeFormId = 'GeometryBoardShipment';
     newTypeFormName = 'Geometry Board Shipment';
-  } else if (typeFormId === 'APAShipment') {
-    newTypeFormId = 'AssembledAPAShipment';
-    newTypeFormName = 'Assembled APA Shipment';
   }
 
   const result = await db.collection('components')
@@ -89,67 +37,6 @@ async function cleanComponentTypeFormIds(typeFormId) {
 
   if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
 
-  if (typeFormId === 'APAShipment') {
-    let aggregation_stages = [];
-
-    aggregation_stages.push({ $match: { formId: newTypeFormId } });
-    aggregation_stages.push({ $project: { componentUuid: true } });
-
-    let uuids = await db.collection('components')
-      .aggregate(aggregation_stages)
-      .toArray();
-
-    for (let uuid of uuids) {
-      const component = await Components.retrieve(uuid.componentUuid);
-      const data = component.data;
-
-      let name_apa1 = '[not set]';
-      let name_apa2 = '[not set]';
-
-      if (data.apaUuiDs[0].component_uuid !== '') {
-        const apa = await Components.retrieve(data.apaUuiDs[0].component_uuid);
-        name_apa1 = apa.data.componentName.substring(4);
-      }
-
-      if (data.apaUuiDs[1].component_uuid !== '') {
-        const apa = await Components.retrieve(data.apaUuiDs[1].component_uuid);
-        name_apa2 = apa.data.componentName.substring(4);
-      }
-
-      const componentName = `Assembled APA Shipment (${name_apa1} + ${name_apa2})`;
-
-      const componentUuid = component.componentUuid;
-      let match_condition = { componentUuid };
-
-      if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
-
-      match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
-
-      let resultInner = await db.collection('components')
-        .updateMany(
-          match_condition,
-          [
-            {
-              $set: { 'data.componentName': componentName }
-            },
-          ]
-        )
-
-      if (resultInner.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to update Assembled APA Shipment component names!`);
-
-      let update = { '$set': {} };
-      update['$set']['path.' + 0 + '.formName'] = newTypeFormName;
-
-      resultInner = await db.collection('workflows')
-        .updateMany(
-          { workflowId: new ObjectId(component.workflowId) },
-          update,
-        )
-
-      if (resultInner.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form name in the workflow records!`);
-    }
-  }
-*/
   return typeFormId;
 }
 

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -22,22 +22,52 @@ async function cleanComponentTypeFormIds(typeFormId) {
     newTypeFormName = 'Geometry Board Shipment';
   }
 
-  const result = await db.collection('components')
-    .updateMany(
-      { formId: typeFormId },
-      [
-        {
-          $set: {
-            'formId': newTypeFormId,
-            'formName': newTypeFormName,
-          }
-        },
-      ]
-    )
+  let aggregation_stages = [];
+  aggregation_stages.push({ $match: { formId: typeFormId } });
+  aggregation_stages.push({ $project: { componentUuid: true } });
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change type form ID in the component records!`);
+  let uuids = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
 
-  return typeFormId;
+  for (let uuid of uuids) {
+    const component = await Components.retrieve(uuid.componentUuid);
+    const data = component.data;
+    const typeRecordNumber = String(data.typeRecordNumber).padStart(5, '0');
+
+    let componentName = '';
+    let dunePid = '';
+
+    if (typeFormId === 'BoardShipment') {
+      componentName = `${newTypeFormName} (${data.boardUuiDs.length}.${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    } else if (typeFormId === 'wire_bobbin') {
+      componentName = `${newTypeFormName} ${data.bobbinId} (Lot ${data.wireLot})`;
+      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+    }
+
+    const componentUuid = component.componentUuid;
+    let match_condition = { componentUuid };
+
+    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
+    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
+
+    const result = await db.collection('components')
+      .updateMany(
+        match_condition,
+        [
+          {
+            $set: {
+              'formId': newTypeFormId,
+              'formName': newTypeFormName,
+              'data.componentName': componentName,
+              'data.dunePid': dunePid,
+            }
+          },
+        ]
+      )
+    if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change fields in the component record!`);
+  }
 }
 
 

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -55,7 +55,8 @@ block content
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'AssembledAPAShipment') Assembled APA Shipment 
+            option(value = 'BoardShipment') Board Shipment 
+            option(value = 'wire_bobbin') Wire Bobbin
             
 
           .vert-space-x2 


### PR DESCRIPTION
Some geometry board shipment and wire bobbin component records have been recently created using the old component type forms ... the former due to an un-updated M2M script, and the latter due to the old form not being trashed.

The administrator utility has been reverted to an older function in order to change the records' type form IDs and names, and fill in the currently missing component names and DUNE PIDs.

Changes have been tested on Staging.
