### PR TITLE
Miscellaneous Small Tweaks and Changes

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -33,11 +33,12 @@ async function save(input, req) {
   if (!input.hasOwnProperty('componentUuid')) throw new Error(`Actions::save() - the 'input.componentUuid' has not been specified!`);
   if (!input.hasOwnProperty('data')) throw new Error(`Actions::save() - the 'input.data' has not been specified!`);
 
-  // Check that there is an existing type form corresponding to the the provided type form ID
+  // Check that there is an existing type form corresponding to the the provided type form ID, and that the type form is not currently 'trashed'
   const typeFormsList = await Forms.list('actionForms');
   const typeForm = typeFormsList[input.typeFormId];
 
   if (!typeForm) throw new Error(`Actions:save() - the specified 'input.typeFormId' (${input.typeFormId}) does not match a known action type form!`);
+  if (typeForm.tags.includes('Trash')) throw new Error(`Actions:save() - the specified action type form (${input.typeFormId}) is currently trashed, and cannot be used!`);
 
   // Some action types should be submitted only by the APA Factory Leads or other top-level personnel - these are typically the most important and/or highest level QA checks and signoffs
   // Check that the submitter (i.e. the currently logged-in user) is the same as the person who's name is being used for the final signoff ... if not, do not allow the action to be submitted

--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -40,24 +40,29 @@ async function save(input, req) {
   if (!typeForm) throw new Error(`Actions:save() - the specified 'input.typeFormId' (${input.typeFormId}) does not match a known action type form!`);
   if (typeForm.tags.includes('Trash')) throw new Error(`Actions:save() - the specified action type form (${input.typeFormId}) is currently trashed, and cannot be used!`);
 
-  // Some action types should be submitted only by the APA Factory Leads or other top-level personnel - these are typically the most important and/or highest level QA checks and signoffs
-  // Check that the submitter (i.e. the currently logged-in user) is the same as the person who's name is being used for the final signoff ... if not, do not allow the action to be submitted
-  // This check should restrict such actions to only be submittable by leads / top-level personnel WHEN LOGGED IN AS THEMSELVES
+  // Some action types - typically the highest level QA signoffs - should only be submittable by top-level personnel (i.e. the APA Factory Leads or equivalent)
+  // When submitting such actions, make sure that a) the required signoff has actually been entered, and b) the submitter is the same person as the person signing off
+  // This is intended to prevent users from completing these actions on behalf of someone else, i.e. putting someone else's name in for the signoff and then submitting it themselves
+  // Note that this check only applies if the action is being submitted as 'complete' ... if not, it should still be editable by any user with the appropriate permissions
+  if (input.typeFormId === 'prep_mesh_panel_install') {
+    if ((input.data.actionComplete) && (req.user.displayName !== utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy])) {
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off and complete this action on behalf of someone else (${utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]}) - this is not permitted!`);
+    }
+  }
+
   if (input.typeFormId === 'AssembledAPAQACheck') {
-    if (req.user.displayName !== utils.dictionary_apaFactoryLeads[input.data.personSigningOff]) {
-      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off this action on behalf of someone else (${utils.dictionary_apaFactoryLeads[input.data.personSigningOff]}) - this is not permitted!`);
+    if ((input.data.actionComplete) && (req.user.displayName !== utils.dictionary_apaFactoryLeads[input.data.personSigningOff])) {
+      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off and complete this action on behalf of someone else (${utils.dictionary_apaFactoryLeads[input.data.personSigningOff]}) - this is not permitted!`);
     }
   }
 
   if (input.typeFormId === 'CompletedAPAQCChecklist') {
-    if ((req.user.displayName !== utils.dictionary_fdhdTechCoordSignoff[input.data.fdhdTechCoordSigningOff]) && (input.data.actionComplete)) {
-      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off and complete this action on behalf of someone else (${utils.dictionary_fdhdTechCoordSignoff[input.data.fdhdTechCoordSigningOff]}) - this is not permitted!`);
-    }
-  }
-
-  if (input.typeFormId === 'prep_mesh_panel_install') {
-    if ((req.user.displayName !== utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]) && (input.data.actionComplete)) {
-      throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off and complete this action on behalf of someone else (${utils.dictionary_dBandFramePrep[input.data.meshPanelQCBy]}) - this is not permitted!`);
+    if (input.data.actionComplete) {
+      if (input.data.fdhdTechCoordSigningOff === '') {
+        throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to complete this action without a signoff from the FDHD Technical Coordinator - this is not permitted!`);
+      } else if (req.user.displayName !== utils.dictionary_fdhdTechCoordSignoff[input.data.fdhdTechCoordSigningOff]) {
+        throw new Error(`Actions:save() - the current user (${req.user.displayName}) is attempting to sign off and complete this action on behalf of someone else (${utils.dictionary_fdhdTechCoordSignoff[input.data.fdhdTechCoordSigningOff]}) - this is not permitted!`);
+      }
     }
   }
 

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -40,11 +40,12 @@ async function save(input, req) {
   if (!input.hasOwnProperty('formId')) throw new Error(`Components::save() - the 'input.formId' has not been specified!`);
   if (!input.hasOwnProperty('data')) throw new Error(`Components::save() - the 'input.data' has not been specified!`);
 
-  // Check that there is an existing type form corresponding to the the provided type form ID
+  // Check that there is an existing type form corresponding to the the provided type form ID, and that the type form is not currently 'trashed'
   const typeFormsList = await Forms.list('componentForms');
   const typeForm = typeFormsList[input.formId];
 
   if (!typeForm) throw new Error(`Components:save() - the specified 'input.formId' (${input.formId}) does not match a known component type form!`);
+  if (typeForm.tags.includes('Trash')) throw new Error(`Components:save() - the specified component type form (${input.formId}) is currently trashed, and cannot be used!`);
 
   // Set up a new record object, and immediately add some information, either directly or inherited from the 'input' object
   let newRecord = {};

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -154,6 +154,7 @@ async function forExecSummary(componentUUID) {
     signoff_actionID: '[no record found]',
     signoff_name: '[no information found]',
     signoff_date: '',
+    signoff_fdhd: '[no information found]',
   };
 
   collatedInfo.ncrs_useAsIs_withWires = [];
@@ -475,6 +476,7 @@ async function forExecSummary(componentUUID) {
       name: { '$first': '$data.personSigningOff' },
       date: { '$first': '$validity.startDate' },
       actionId: { '$first': '$actionId' },
+      fdhd: { '$first': '$data.fdhdTechCoordSigningOff' },
     },
   });
 
@@ -486,6 +488,7 @@ async function forExecSummary(componentUUID) {
     collatedInfo.completedAPA.signoff_actionID = results[0].actionId;
     collatedInfo.completedAPA.signoff_name = utils.dictionary_apaFactoryLeads[results[0].name];
     collatedInfo.completedAPA.signoff_date = results[0].date;
+    collatedInfo.completedAPA.signoff_fdhd = utils.dictionary_fdhdTechCoordSignoff[results[0].fdhd];
   }
 
   ////////////////////////////////////////////

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -24,11 +24,12 @@ async function save(input, req) {
   if (!input.hasOwnProperty('data')) throw new Error(`Workflows::save() - the 'input.data' has not been specified!`);
   if (!input.hasOwnProperty('path')) throw new Error(`Workflows::save() - the 'input.path' has not been specified!`);
 
-  // Check that there is an existing type form corresponding to the the provided type form ID
+  // Check that there is an existing type form corresponding to the the provided type form ID, and that the type form is not currently 'trashed'
   const typeFormsList = await Forms.list('workflowForms');
   const typeForm = typeFormsList[input.typeFormId];
 
   if (!typeForm) throw new Error(`Workflows:save() - the specified 'input.typeFormId' (${input.typeFormId}) does not match a known workflow type form!`);
+  if (typeForm.tags.includes('Trash')) throw new Error(`Workflows:save() - the specified workflow type form (${input.typeFormId}) is currently trashed, and cannot be used!`);
 
   // Check that each step of the workflow path has the minimum required information:
   //   - the type of the step (named as 'type', and taking either 'component' or 'action' as value)

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -251,6 +251,7 @@ module.exports = {
     danielSalisbury: 'Daniel Salisbury',
     stephenSumner: 'Stephen Sumner',
     niklasTempleton: 'Niklas Templeton',
+    annaVikhoreva: 'Anna Vikhoreva',
     sotirisVlachos: 'Sotiris Vlachos',
   },
 

--- a/app/pug/workflow_listTypes.pug
+++ b/app/pug/workflow_listTypes.pug
@@ -40,7 +40,7 @@ block content
         thead
           tr
             th.col-md-2 Type Name
-            th.col-md-3 Recommended Component Type
+            th.col-md-3 Associated Component Type
             th.col-md-2
             th.col-md-2
 
@@ -83,7 +83,7 @@ block content
           thead
             tr
               th.col-md-2 Type Name
-              th.col-md-3 Recommended Component Type
+              th.col-md-3 Associated Component Type
               th.col-md-2
               th.col-md-2
 

--- a/app/static/pages/component_execSummary.js
+++ b/app/static/pages/component_execSummary.js
@@ -1431,7 +1431,109 @@ function SetEntry_qcSignoffs(frameConstruction, framePreparation, x, v, u, g, co
                   "type": "columns",
                   "input": false,
                   "tableView": false
-                }
+                },
+                {
+                  "label": "Columns",
+                  "columns": [
+                    {
+                      "components": [
+                        {
+                          "label": "Text Field",
+                          "placeholder": "FDHD Technical Coordinator",
+                          "hideLabel": true,
+                          "disabled": true,
+                          "tableView": true,
+                          "key": "completedAPA_labelFDHD",
+                          "type": "textfield",
+                          "input": true
+                        }
+                      ],
+                      "width": 2,
+                      "offset": 0,
+                      "push": 0,
+                      "pull": 0,
+                      "size": "sm",
+                      "currentWidth": 2
+                    },
+                    {
+                      "components": [
+                        {
+                          "label": "Text Field",
+                          "hideLabel": true,
+                          "disabled": true,
+                          "tableView": true,
+                          "key": "completedAPA_signoffFDHD",
+                          "type": "textfield",
+                          "input": true,
+                          "defaultValue": completedAPA.signoff_fdhd
+                        }
+                      ],
+                      "width": 2,
+                      "offset": 0,
+                      "push": 0,
+                      "pull": 0,
+                      "size": "sm",
+                      "currentWidth": 2
+                    },
+                    {
+                      "components": [
+                        {
+                          "label": "Date / Time",
+                          "hideLabel": true,
+                          "disabled": true,
+                          "tableView": false,
+                          "enableMinDateInput": false,
+                          "datePicker": {
+                            "disableWeekends": false,
+                            "disableWeekdays": false
+                          },
+                          "enableMaxDateInput": false,
+                          "key": "completedAPA_date",
+                          "type": "datetime",
+                          "input": true,
+                          "defaultValue": completedAPA.signoff_date,
+                          "widget": {
+                            "type": "calendar",
+                            "displayInTimezone": "viewer",
+                            "locale": "en",
+                            "useLocaleSettings": false,
+                            "allowInput": true,
+                            "mode": "single",
+                            "enableTime": true,
+                            "noCalendar": false,
+                            "format": "yyyy-MM-dd hh:mm a",
+                            "hourIncrement": 1,
+                            "minuteIncrement": 1,
+                            "time_24hr": false,
+                            "minDate": null,
+                            "disableWeekends": false,
+                            "disableWeekdays": false,
+                            "maxDate": null
+                          }
+                        }
+                      ],
+                      "size": "sm",
+                      "width": 3,
+                      "offset": 0,
+                      "push": 0,
+                      "pull": 0,
+                      "currentWidth": 3
+                    },
+                    {
+                      "components": [],
+                      "size": "sm",
+                      "width": 5,
+                      "offset": 0,
+                      "push": 0,
+                      "pull": 0,
+                      "currentWidth": 5
+                    },
+                  ],
+                  "key": "columns12",
+                  "type": "columns",
+                  "input": false,
+                  "tableView": false
+                },
               ]
             }
           ]


### PR DESCRIPTION
- adding FDHD Signoff to APA Executive Summaries
- changed 'recommended component type' to 'associated component type' in the column header on the Workflow Types listing page ... it's not a recommendation!
- when attempting to save a record (new or existing), a check will now be made to see if the type form is currently trashed ... submission will be rejected if so (applies to components, actions and workflows)
- adding new Daresbury QA tech to personnel list
- added additional safeguard against submitting 'Completed APA QA Checklist' actions with no FDHD technical coordinator signoff (the existing comparison between currently logged-in user and signoff name remains the same)