### PR TITLE
Fixing Component Record formId and formName fields (Part 1) ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -79,7 +79,7 @@ async function save(input, req) {
 
   newRecord.recordType = 'action';
   newRecord.actionId = new ObjectId(input.actionId);
-  newRecord.typeFormId = input.typeFormId;
+  newRecord.typeFormId = typeForm.formId;
   newRecord.typeFormName = typeForm.formName;
   newRecord.componentUuid = MUUID.from(input.componentUuid);
 
@@ -87,8 +87,8 @@ async function save(input, req) {
 
   if (componentRecord) {
     newRecord.componentName = componentRecord.data.componentName;
-    newRecord.componentTypeFormId = componentRecord.formId;
-    newRecord.componentTypeFormName = componentRecord.formName;
+    newRecord.componentTypeFormId = componentRecord.typeFormId;
+    newRecord.componentTypeFormName = componentRecord.typeFormName;
   } else {
     newRecord.componentName = '[no component record found!]';
     newRecord.componentTypeFormId = '[no component record found!]';

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -10,67 +10,28 @@ const utils = require('./utils');
 const Workflows = require('./Workflows');
 
 
-async function cleanComponentTypeFormIds(typeFormId) {
-  let newTypeFormId = null;
-  let newTypeFormName = null;
+async function fixComponentFields(currentFormId) {
+  const matchCondition = (currentFormId === 'ALL_COMPONENTS') ? {} : { formId: currentFormId };
 
-  if (typeFormId === 'wire_bobbin') {
-    newTypeFormId = 'WireBobbin';
-    newTypeFormName = 'Wire Bobbin';
-  } else if (typeFormId === 'BoardShipment') {
-    newTypeFormId = 'GeometryBoardShipment';
-    newTypeFormName = 'Geometry Board Shipment';
-  }
+  const result = await db.collection('components')
+    .updateMany(
+      matchCondition,
+      [
+        {
+          $set: {
+            'typeFormId': '$formId',
+            'typeFormName': '$formName',
+          }
+        },
+      ]
+    )
 
-  let aggregation_stages = [];
-  aggregation_stages.push({ $match: { formId: typeFormId } });
-  aggregation_stages.push({ $project: { componentUuid: true } });
+  if (result.ok === 0) throw new Error(`Admin_Functions::fixComponentFields() - failed to add fields to the component record!`);
 
-  let uuids = await db.collection('components')
-    .aggregate(aggregation_stages)
-    .toArray();
-
-  for (let uuid of uuids) {
-    const component = await Components.retrieve(uuid.componentUuid);
-    const data = component.data;
-    const typeRecordNumber = String(data.typeRecordNumber).padStart(5, '0');
-
-    let componentName = '';
-    let dunePid = '';
-
-    if (typeFormId === 'BoardShipment') {
-      componentName = `${newTypeFormName} (${data.boardUuiDs.length}.${utils.dictionary_locations[data.originOfShipment]}.${utils.dictionary_locations[data.destinationOfShipment]})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (typeFormId === 'wire_bobbin') {
-      componentName = `${newTypeFormName} ${data.bobbinId} (Lot ${data.wireLot})`;
-      dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    }
-
-    const componentUuid = component.componentUuid;
-    let match_condition = { componentUuid };
-
-    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
-    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
-
-    const result = await db.collection('components')
-      .updateMany(
-        match_condition,
-        [
-          {
-            $set: {
-              'formId': newTypeFormId,
-              'formName': newTypeFormName,
-              'data.componentName': componentName,
-              'data.dunePid': dunePid,
-            }
-          },
-        ]
-      )
-    if (result.ok === 0) throw new Error(`Admin_Functions::cleanComponentTypeFormIds() - failed to change fields in the component record!`);
-  }
+  return currentFormId;
 }
 
 
 module.exports = {
-  cleanComponentTypeFormIds,
+  fixComponentFields,
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -55,6 +55,8 @@ async function save(input, req) {
   newRecord.shortUuid = ShortUUID().fromUUID(input.componentUuid);
   newRecord.formId = input.formId;
   newRecord.formName = typeForm.formName;
+  newRecord.typeFormId = typeForm.formId;
+  newRecord.typeFormName = typeForm.formName;
   newRecord.data = input.data;
 
   if (input.workflowId) newRecord.workflowId = input.workflowId;

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -49,7 +49,7 @@ async function save(input, req) {
 
   newRecord.recordType = 'workflow';
   newRecord.workflowId = new ObjectId(input.workflowId);
-  newRecord.typeFormId = input.typeFormId;
+  newRecord.typeFormId = typeForm.formId;
   newRecord.typeFormName = typeForm.formName;
   newRecord.data = input.data;
   newRecord.path = input.path;

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -44,7 +44,7 @@ block content
             option(value = 'GeometryBoardBatch') Geometry Board Batch
             option(value = 'GeometryBoardShipment') Geometry Board Shipment 
             option(value = 'GroundingMeshPanel') Grounding Mesh Panel
-            option(value = 'GroundingMeshPanelShipment') Grounding Mesh Shipment 
+            option(value = 'GroundingMeshPanelShipment') Grounding Mesh Panel Shipment 
             option(value = 'PopulatedBoardShipment') Multi-Type Populated Board Shipment
             option(value = 'ReturnedGeometryBoardBatch') Returned Geometry Board Batch
             option(value = 'SHVBoard') SHV Board
@@ -55,9 +55,8 @@ block content
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'BoardShipment') Board Shipment 
-            option(value = 'wire_bobbin') Wire Bobbin
-            
+            option(value = 'ALL_COMPONENTS') All Component Types 
+            option(value = 'GroundingMeshPanelShipment') Grounding Mesh Panel Shipment 
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -247,7 +247,7 @@ router.get('/administratorUtility', async function (req, res, next) {
 router.post(['/json/administratorUtility/:inputString', '/api/administratorUtility/:inputString'], async function (req, res, next) {
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
-    let result = await Admin_Functions.cleanComponentTypeFormIds(req.params.inputString);    // Change as appropriate for the required utility
+    let result = await Admin_Functions.fixComponentFields(req.params.inputString);    // Change as appropriate for the required utility
 
     return res.status(201).json(result);
   } catch (err) {

--- a/app/static/pages/administratorUtility.js
+++ b/app/static/pages/administratorUtility.js
@@ -27,7 +27,11 @@ async function renderInputForm() {
 
 
 function postSuccess(result) {    // Change as appropriate for the required utility
-  window.location.href = `/components/${result}/list`;
+  if (result === 'ALL_COMPONENTS') {
+    window.location.href = `/componentTypes/list`;
+  } else {
+    window.location.href = `/components/${result}/list`;
+  }
 }
 
 

--- a/app/static/pages/component_edit.js
+++ b/app/static/pages/component_edit.js
@@ -46,6 +46,7 @@ async function onPageLoad() {
     // Add the other required information, inheriting from the variables that were passed through the route to this page
     submission.componentUuid = component.componentUuid;
     submission.formId = componentTypeForm.formId;
+    submission.typeFormId = componentTypeForm.formId;
 
     // If the component originates from a workflow (and therefore a non-empty workflow ID has been provided), save the workflow ID into the 'submission' object
     if (!(workflowId === '')) submission.workflowId = workflowId;
@@ -67,8 +68,8 @@ async function onPageLoad() {
       // If the component is a 'Geometry Board' type, offset the count, to account for an unknown number of boards that might have been manufactured before the database was up and running
       let numberOfExistingSubComponents = 0;
 
-      if (componentCounts_byType[submission.data.subComponent_formId].count) numberOfExistingSubComponents = componentCounts_byType[submission.data.subComponent_formId].count;
-      if (submission.data.subComponent_formId === 'GeometryBoard') numberOfExistingSubComponents += 5000;
+      if (componentCounts_byType[submission.data.subComponent_typeFormId].count) numberOfExistingSubComponents = componentCounts_byType[submission.data.subComponent_typeFormId].count;
+      if (submission.data.subComponent_typeFormId === 'GeometryBoard') numberOfExistingSubComponents += 5000;
 
       // Set up an array to hold the sub-component type record numbers and submission objects (these will be populated in the sub-component loop below)
       let subComponent_typeRecordNumbers = [];
@@ -80,7 +81,8 @@ async function onPageLoad() {
         let sub_submission = Object.create(submission);
 
         sub_submission.componentUuid = slice_fullUuids[s];
-        sub_submission.formId = submission.data.subComponent_formId;
+        sub_submission.formId = submission.data.subComponent_typeFormId;
+        sub_submission.typeFormId = submission.data.subComponent_typeFormId;
         sub_submission.data = Object.create(submission.data);
 
         // Add information to the sub-component's 'data' field indicating the fields and values that are inherited from the batch component
@@ -94,7 +96,7 @@ async function onPageLoad() {
         subComponent_typeRecordNumbers.push(numberOfExistingSubComponents + s + 1);
 
         // Add any other information to the sub-component's 'data' field that might be specific to certain component types
-        if (['CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes(submission.data.subComponent_formId)) {
+        if (['CEAdapterBoard', 'CRBoard', 'GBiasBoard', 'SHVBoard'].includes(submission.data.subComponent_typeFormId)) {
           sub_submission.data.boardIsConformant = 'yes';
         }
 


### PR DESCRIPTION
- component records have had 'formId' and 'formName' fields from the very start of the APA DB, whereas the same fields in action and workflow records have always been called 'typeFormId' and 'typeFormName'
- absolutely no reason why these fields should be different depending on entity type ... they mean the same thing, and are assigned in the same way - literally the only difference is the field name
- new administrator utility function to add 'typeFormId' and 'typeFormName' fields to all component records, with values copied from the existing 'formId' and 'formName' fields respectively
- new components will now have the 'typeFormId' and 'typeFormName' fields added, in addition to the 'formId' and 'formName' ones
- changed action and workflow records to pull the type form ID directly from the type form itself, instead of the submitted input ... keeps them consistent with (new) component records, and is more reliable in case the submitted input is malformed

Changes have been tested on Staging.

REMINDER - all 'batch' type component type forms will need to have 'subComponent_formId' changed to 'subComponent_typeFormId' in the interface.