### PR TITLE
Fixing Component Record formId and formName fields (Part 2) ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -493,7 +493,7 @@ async function boardRejectionCounts_byPartNumberAndLocation() {
   // Match against the component type form ID and reception location to get records of all 'Geometry Board' components with a current reception location of 'rejected'
   aggregation_stages.push({
     $match: {
-      'formId': 'GeometryBoard',
+      'typeFormId': 'GeometryBoard',
       'reception.location': 'rejected',
     }
   });

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -10,12 +10,10 @@ const utils = require('./utils');
 const Workflows = require('./Workflows');
 
 
-async function fixComponentFields(currentFormId) {
-  const matchCondition = (currentFormId === 'ALL_COMPONENTS') ? {} : { formId: currentFormId };
-
+async function fixFields_allComponents() {
   const result = await db.collection('components')
     .updateMany(
-      matchCondition,
+      {},
       [
         {
           $set: {
@@ -26,12 +24,32 @@ async function fixComponentFields(currentFormId) {
       ]
     )
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::fixComponentFields() - failed to add fields to the component record!`);
+  if (result.ok === 0) throw new Error(`Admin_Functions::fixFields_allComponents() - failed to add fields to the component record!`);
 
-  return currentFormId;
+  return result;
+}
+
+
+async function fixFields_batchComponents() {
+  const result = await db.collection('components')
+    .updateMany(
+      { 'typeFormId': { $in: ['CEAdapterBoardBatch', 'CRBoardBatch', 'GBiasBoardBatch', 'GeometryBoardBatch', 'ReturnedGeometryBoardBatch'] }, },
+      [
+        {
+          $set: {
+            'data.subComponent_typeFormId': '$data.subComponent_formId',
+          }
+        },
+      ]
+    )
+
+  if (result.ok === 0) throw new Error(`Admin_Functions::fixFields_batchComponents() - failed to add fields to the component record!`);
+
+  return result;
 }
 
 
 module.exports = {
-  fixComponentFields,
+  fixFields_allComponents,
+  fixFields_batchComponents,
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -37,15 +37,15 @@ async function save(input, req) {
   //   - user-provided data (this may be an empty object, but must still exist)
   if (!(input instanceof Object)) throw new Error(`Components::save() - the 'input' object has not been specified!`);
   if (!input.hasOwnProperty('componentUuid')) throw new Error(`Components::save() - the 'input.componentUuid' has not been specified!`);
-  if (!input.hasOwnProperty('formId')) throw new Error(`Components::save() - the 'input.formId' has not been specified!`);
+  if (!input.hasOwnProperty('typeFormId')) throw new Error(`Components::save() - the 'input.typeFormId' has not been specified!`);
   if (!input.hasOwnProperty('data')) throw new Error(`Components::save() - the 'input.data' has not been specified!`);
 
   // Check that there is an existing type form corresponding to the the provided type form ID, and that the type form is not currently 'trashed'
   const typeFormsList = await Forms.list('componentForms');
-  const typeForm = typeFormsList[input.formId];
+  const typeForm = typeFormsList[input.typeFormId];
 
-  if (!typeForm) throw new Error(`Components:save() - the specified 'input.formId' (${input.formId}) does not match a known component type form!`);
-  if (typeForm.tags.includes('Trash')) throw new Error(`Components:save() - the specified component type form (${input.formId}) is currently trashed, and cannot be used!`);
+  if (!typeForm) throw new Error(`Components:save() - the specified 'input.typeFormId' (${input.typeFormId}) does not match a known component type form!`);
+  if (typeForm.tags.includes('Trash')) throw new Error(`Components:save() - the specified component type form (${input.typeFormId}) is currently trashed, and cannot be used!`);
 
   // Set up a new record object, and immediately add some information, either directly or inherited from the 'input' object
   let newRecord = {};
@@ -53,8 +53,6 @@ async function save(input, req) {
   newRecord.recordType = 'component';
   newRecord.componentUuid = MUUID.from(input.componentUuid);
   newRecord.shortUuid = ShortUUID().fromUUID(input.componentUuid);
-  newRecord.formId = input.formId;
-  newRecord.formName = typeForm.formName;
   newRecord.typeFormId = typeForm.formId;
   newRecord.typeFormName = typeForm.formName;
   newRecord.data = input.data;
@@ -80,8 +78,8 @@ async function save(input, req) {
     const componentCounts_byType = await counts_byType();
     let numberOfExistingComponents = 0;
 
-    if (componentCounts_byType[input.formId].count) numberOfExistingComponents = componentCounts_byType[input.formId].count;
-    if (input.formId === 'GeometryBoard') numberOfExistingComponents += 5000;
+    if (componentCounts_byType[input.typeFormId].count) numberOfExistingComponents = componentCounts_byType[input.typeFormId].count;
+    if (input.typeFormId === 'GeometryBoard') numberOfExistingComponents += 5000;
 
     // If the 'input.data' object does NOT contain a 'Type Record Number' field, add the component count to the new record's 'data' object under a new field
     // The field will exist only when creating new records for individual sub-components in a batch, since in this situation the sub-component type record numbers are determined on the client side
@@ -92,7 +90,7 @@ async function save(input, req) {
     // The format of the name is dependent on the component type ... some are simply a combination of the type form name and type record number, whereas others have more information included
     const typeRecordNumber = String(newRecord.data.typeRecordNumber).padStart(5, '0');
 
-    if (newRecord.formId === 'APAFrame') {
+    if (newRecord.typeFormId === 'APAFrame') {
       let pidSuffix = '';
 
       if (newRecord.data.frameProductionLocation === 'dsm') {
@@ -104,7 +102,7 @@ async function save(input, req) {
       }
 
       newRecord.data.dunePid = `D00300200001-${typeRecordNumber}-${pidSuffix}`;
-    } else if (newRecord.formId === 'APAShippingFrame') {
+    } else if (newRecord.typeFormId === 'APAShippingFrame') {
       let pidSuffix = '';
 
       if (newRecord.data.asfLocation === 'chicago') {
@@ -119,7 +117,7 @@ async function save(input, req) {
       }
 
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-${pidSuffix}`;
-    } else if (newRecord.formId === 'AssembledAPA') {
+    } else if (newRecord.typeFormId === 'AssembledAPA') {
       let pidPrefix = '';
       let pidSuffix = '';
 
@@ -141,58 +139,58 @@ async function save(input, req) {
       }
 
       newRecord.data.dunePid = `${pidPrefix}-${typeRecordNumber}-${pidSuffix}`;
-    } else if (newRecord.formId === 'CEAdapterBoard') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+    } else if (newRecord.typeFormId === 'CEAdapterBoard') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300400003-${typeRecordNumber}-US200-010000`;
-    } else if (newRecord.formId === 'CEAdapterBoardBatch') {
-      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    } else if (newRecord.typeFormId === 'CEAdapterBoardBatch') {
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (newRecord.formId === 'CRBoard') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+    } else if (newRecord.typeFormId === 'CRBoard') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300400001-${typeRecordNumber}-US200-010000`;
-    } else if (newRecord.formId === 'CRBoardBatch') {
-      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    } else if (newRecord.typeFormId === 'CRBoardBatch') {
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (newRecord.formId === 'CableHarness') {
+    } else if (newRecord.typeFormId === 'CableHarness') {
       if (newRecord.data.cableHarnessSide === 'a') {
-        newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (Side A)`;
+        newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (Side A)`;
         newRecord.data.dunePid = `D00300500002-${typeRecordNumber}-US200-010000`;
       } else if (newRecord.data.cableHarnessSide === 'b') {
-        newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (Side B)`;
+        newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (Side B)`;
         newRecord.data.dunePid = `D00300500003-${typeRecordNumber}-US200-010000`;
       }
-    } else if (newRecord.formId === 'DWA') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+    } else if (newRecord.typeFormId === 'DWA') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300800001-${typeRecordNumber}-US136-010000`;
-    } else if (newRecord.formId === 'DWAPDB') {
+    } else if (newRecord.typeFormId === 'DWAPDB') {
       newRecord.data.componentName = `DWA PDB ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300800002-${typeRecordNumber}-US136-010000`;
-    } else if (newRecord.formId === 'GBiasBoard') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+    } else if (newRecord.typeFormId === 'GBiasBoard') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300400002-${typeRecordNumber}-US200-010000`;
-    } else if (newRecord.formId === 'GBiasBoardBatch') {
-      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    } else if (newRecord.typeFormId === 'GBiasBoardBatch') {
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (newRecord.formId === 'GeometryBoard') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.partString})`;
+    } else if (newRecord.typeFormId === 'GeometryBoard') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.partString})`;
       newRecord.data.dunePid = `D003003${utils.dictionary_geometryBoardPIDs[newRecord.data.partNumber]}-${typeRecordNumber}-UK109-010000`;
-    } else if (newRecord.formId === 'GeometryBoardBatch') {
-      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.PN${newRecord.data.subComponent_partNumber}.ON${newRecord.data.orderNumber})`;
+    } else if (newRecord.typeFormId === 'GeometryBoardBatch') {
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.PN${newRecord.data.subComponent_partNumber}.ON${newRecord.data.orderNumber})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (newRecord.formId === 'GroundingMeshPanel') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+    } else if (newRecord.typeFormId === 'GroundingMeshPanel') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300200004-${typeRecordNumber}-UK106-010000`;
-    } else if (newRecord.formId === 'ReturnedGeometryBoardBatch') {
-      newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.subComponent_count}.PN${newRecord.data.subComponent_partNumber}.ON${newRecord.data.orderNumber})`;
+    } else if (newRecord.typeFormId === 'ReturnedGeometryBoardBatch') {
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.PN${newRecord.data.subComponent_partNumber}.ON${newRecord.data.orderNumber})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (newRecord.formId === 'SHVBoard') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+    } else if (newRecord.typeFormId === 'SHVBoard') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300500001-${typeRecordNumber}-US200-010000`;
-    } else if (newRecord.formId === 'WireBobbin') {
-      newRecord.data.componentName = `${newRecord.formName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
+    } else if (newRecord.typeFormId === 'WireBobbin') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-    } else if (newRecord.formId === 'Yoke') {
-      newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber}`;
+    } else if (newRecord.typeFormId === 'Yoke') {
+      newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00301000001-${typeRecordNumber}-US200-010000`;
     }
 
@@ -205,23 +203,23 @@ async function save(input, req) {
 
     // Almost all component types will always start at specific fixed locations ...
     // ... the only exceptions are the 'batch' types (these still need the location field to exist, but it can be left as an empty string)
-    if ((newRecord.formId === 'APAFrame') || (newRecord.formId === 'WireBobbin')) {
+    if ((newRecord.typeFormId === 'APAFrame') || (newRecord.typeFormId === 'WireBobbin')) {
       newRecord.reception.location = 'daresbury';
-    } else if (newRecord.formId === 'APAShippingFrame') {
+    } else if (newRecord.typeFormId === 'APAShippingFrame') {
       newRecord.reception.location = newRecord.data.asfLocation;
-    } else if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+    } else if ((newRecord.typeFormId === 'APAFrameShipment') || (newRecord.typeFormId === 'DWAComponentShipment') || (newRecord.typeFormId === 'GeometryBoardShipment') || (newRecord.typeFormId === 'GroundingMeshPanelShipment') || (newRecord.typeFormId === 'PopulatedBoardShipment') || (newRecord.typeFormId === 'YokeShipment')) {
       newRecord.reception.location = 'in_transit';
-    } else if (newRecord.formId === 'AssembledAPA') {
+    } else if (newRecord.typeFormId === 'AssembledAPA') {
       newRecord.reception.location = newRecord.data.apaAssemblyLocation;
-    } else if (newRecord.formId === 'AssembledAPAShipment') {
+    } else if (newRecord.typeFormId === 'AssembledAPAShipment') {
       newRecord.reception.location = newRecord.data.originOfShipment;
-    } else if ((newRecord.formId === 'CEAdapterBoard') || (newRecord.formId === 'CEAdapterBoardShipment') || (newRecord.formId === 'CRBoard') || (newRecord.formId === 'CRBoardShipment') || (newRecord.formId === 'CableHarness') || (newRecord.formId === 'CableHarnessShipment') || (newRecord.formId === 'GBiasBoard') || (newRecord.formId === 'GBiasBoardShipment') || (newRecord.formId === 'SHVBoard') || (newRecord.formId === 'SHVBoardShipment') || (newRecord.formId === 'Yoke')) {
+    } else if ((newRecord.typeFormId === 'CEAdapterBoard') || (newRecord.typeFormId === 'CEAdapterBoardShipment') || (newRecord.typeFormId === 'CRBoard') || (newRecord.typeFormId === 'CRBoardShipment') || (newRecord.typeFormId === 'CableHarness') || (newRecord.typeFormId === 'CableHarnessShipment') || (newRecord.typeFormId === 'GBiasBoard') || (newRecord.typeFormId === 'GBiasBoardShipment') || (newRecord.typeFormId === 'SHVBoard') || (newRecord.typeFormId === 'SHVBoardShipment') || (newRecord.typeFormId === 'Yoke')) {
       newRecord.reception.location = 'wisconsin';
-    } else if ((newRecord.formId === 'DWA') || (newRecord.formId === 'DWAPDB')) {
+    } else if ((newRecord.typeFormId === 'DWA') || (newRecord.typeFormId === 'DWAPDB')) {
       newRecord.reception.location = newRecord.data.productionLocation;
-    } else if (newRecord.formId === 'GeometryBoard') {
+    } else if (newRecord.typeFormId === 'GeometryBoard') {
       newRecord.reception.location = 'lancaster';
-    } else if (newRecord.formId === 'GroundingMeshPanel') {
+    } else if (newRecord.typeFormId === 'GroundingMeshPanel') {
       newRecord.reception.location = 'ukWarehouse';
     } else {
       newRecord.reception.location = '';
@@ -234,10 +232,10 @@ async function save(input, req) {
   // The DUNE PID of such components should technically be fixed at creation, but it is simpler code-wise to assign and re-assign that here as well
   const typeRecordNumber = String(newRecord.data.typeRecordNumber).padStart(5, '0');
 
-  if (newRecord.formId === 'APAFrameShipment') {
-    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.frameUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+  if (newRecord.typeFormId === 'APAFrameShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.frameUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'AssembledAPAShipment') {
+  } else if (newRecord.typeFormId === 'AssembledAPAShipment') {
     let name_apa1 = '[not set]';
     let name_apa2 = '[not set]';
 
@@ -251,37 +249,37 @@ async function save(input, req) {
       name_apa2 = apa.data.componentName.substring(4);
     }
 
-    newRecord.data.componentName = `${newRecord.formName} (${name_apa1} + ${name_apa2})`;
+    newRecord.data.componentName = `${newRecord.typeFormName} (${name_apa1} + ${name_apa2})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'CEAdapterBoardShipment') {
-    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+  } else if (newRecord.typeFormId === 'CEAdapterBoardShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'CRBoardShipment') {
-    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+  } else if (newRecord.typeFormId === 'CRBoardShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'CableHarnessShipment') {
-    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+  } else if (newRecord.typeFormId === 'CableHarnessShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'DWAComponentShipment') {
-    newRecord.data.componentName = `${newRecord.formName} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+  } else if (newRecord.typeFormId === 'DWAComponentShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'GBiasBoardShipment') {
-    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+  } else if (newRecord.typeFormId === 'GBiasBoardShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'GeometryBoardShipment') {
-    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+  } else if (newRecord.typeFormId === 'GeometryBoardShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'GroundingMeshPanelShipment') {
-    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+  } else if (newRecord.typeFormId === 'GroundingMeshPanelShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'PopulatedBoardShipment') {
-    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+  } else if (newRecord.typeFormId === 'PopulatedBoardShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'SHVBoardShipment') {
-    newRecord.data.componentName = `${newRecord.formName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+  } else if (newRecord.typeFormId === 'SHVBoardShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.formId === 'YokeShipment') {
-    newRecord.data.componentName = `${newRecord.formName} (${newRecord.data.yokeUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+  } else if (newRecord.typeFormId === 'YokeShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.yokeUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   }
 
@@ -303,13 +301,13 @@ async function save(input, req) {
   // - for a 'Populated Board Shipment', update the reception information of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
   // - for a 'Return Geometry Board Batch', update the reception information of the individual geometry board sub-components to indicate they are at Lancaster (where the batch is put together)
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
-  if ((newRecord.formId === 'APAFrameShipment') || (newRecord.formId === 'DWAComponentShipment') || (newRecord.formId === 'GeometryBoardShipment') || (newRecord.formId === 'GroundingMeshPanelShipment') || (newRecord.formId === 'PopulatedBoardShipment') || (newRecord.formId === 'YokeShipment')) {
+  if ((newRecord.typeFormId === 'APAFrameShipment') || (newRecord.typeFormId === 'DWAComponentShipment') || (newRecord.typeFormId === 'GeometryBoardShipment') || (newRecord.typeFormId === 'GroundingMeshPanelShipment') || (newRecord.typeFormId === 'PopulatedBoardShipment') || (newRecord.typeFormId === 'YokeShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
-  } else if (newRecord.formId === 'AssembledAPA') {
+  } else if (newRecord.typeFormId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
-  } else if (newRecord.formId === 'AssembledAPAShipment') {
+  } else if (newRecord.typeFormId === 'AssembledAPAShipment') {
     const result = await updateLocations_inShipment(newRecord.componentUuid, newRecord.reception.location, (new Date()).toISOString().slice(0, 10));
-  } else if (newRecord.formId === 'ReturnedGeometryBoardBatch') {
+  } else if (newRecord.typeFormId === 'ReturnedGeometryBoardBatch') {
     for (const board of newRecord.data.boardUuids) {
       const result = await updateLocation(board.component_uuid, 'lancaster', (new Date()).toISOString().slice(0, 10), '');
     }
@@ -409,34 +407,34 @@ async function updateLocations_inShipment(componentUuid, location, date) {
 
   // Loop over all sub-components in the shipment, and update each one's location information appropriately for the shipment type and contents
   // In all cases, if successful, the updating function returns 'result = 1', but we don't actually use this value anywhere
-  if (shipment.formId === 'APAFrameShipment') {
+  if (shipment.typeFormId === 'APAFrameShipment') {
     // Extract the UUID and update the location information of each APA frame in a shipment of frames
     for (const frame of shipment.data.frameUuiDs) {
       const result = await updateLocation(frame.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'AssembledAPAShipment') {
+  } else if (shipment.typeFormId === 'AssembledAPAShipment') {
     // Extract the UUID and update the location information of each assembled APA and the ASF in a shipment of APAs
     for (const apa of shipment.data.apaUuiDs) {
       const result = await updateLocation(apa.component_uuid, location, date, '');
     }
 
     const result = await updateLocation(shipment.data.asfUuid, location, date, '');
-  } else if ((shipment.formId === 'CEAdapterBoardShipment') || (shipment.formId === 'CRBoardShipment') || (shipment.formId === 'CableHarnessShipment') || (shipment.formId === 'GBiasBoardShipment') || (shipment.formId === 'GeometryBoardShipment') || (shipment.formId === 'SHVBoardShipment')) {
+  } else if ((shipment.typeFormId === 'CEAdapterBoardShipment') || (shipment.typeFormId === 'CRBoardShipment') || (shipment.typeFormId === 'CableHarnessShipment') || (shipment.typeFormId === 'GBiasBoardShipment') || (shipment.typeFormId === 'GeometryBoardShipment') || (shipment.typeFormId === 'SHVBoardShipment')) {
     // Extract the UUID and update the location information of each board in a shipment of (single type) boards
     for (const board of shipment.data.boardUuiDs) {
       const result = await updateLocation(board.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'DWAComponentShipment') {
+  } else if (shipment.typeFormId === 'DWAComponentShipment') {
     // Extract the UUID and update the location information of each component in a (combined) shipment of DWAs and DWAPDBs
     for (const dwa of shipment.data.componentUUIDs) {
       const result = await updateLocation(dwa.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'GroundingMeshPanelShipment') {
+  } else if (shipment.typeFormId === 'GroundingMeshPanelShipment') {
     // Extract the UUID and update the location information of each mesh in a shipment of meshes
     for (const mesh of shipment.data.apaUuiDs) {
       const result = await updateLocation(mesh.component_uuid, location, date, '');
     }
-  } else if (shipment.formId === 'PopulatedBoardShipment') {
+  } else if (shipment.typeFormId === 'PopulatedBoardShipment') {
     // Extract the UUID and update the location information of each shipment in a multi-type populated board shipment
     for (const crBoardShipment of shipment.data.crBoardKitUuiDs) {
       if (crBoardShipment.component_uuid !== '') {
@@ -461,7 +459,7 @@ async function updateLocations_inShipment(componentUuid, location, date) {
         const result = await updateLocations_inShipment(cableHarnessShipment.component_uuid, location, date);
       }
     }
-  } else if (shipment.formId === 'YokeShipment') {
+  } else if (shipment.typeFormId === 'YokeShipment') {
     // Extract the UUID and update the location information of each yoke in a shipment of yokes
     for (const yoke of shipment.data.yokeUuiDs) {
       const result = await updateLocation(yoke.component_uuid, location, date, '');
@@ -565,8 +563,8 @@ async function list(match_condition, options) {
   aggregation_stages.push({
     $project: {
       componentUuid: true,
-      formId: true,
-      formName: true,
+      typeFormId: true,
+      typeFormName: true,
       data: true,
       validity: true,
       reception: true,
@@ -582,8 +580,8 @@ async function list(match_condition, options) {
     $group: {
       _id: { componentUuid: '$componentUuid' },
       componentUuid: { '$first': '$componentUuid' },
-      typeFormId: { '$first': '$formId' },
-      typeFormName: { '$first': '$formName' },
+      typeFormId: { '$first': '$typeFormId' },
+      typeFormName: { '$first': '$typeFormName' },
       data: { '$first': '$data' },
       componentName: { '$first': '$data.componentName' },
       lastEditDate: { '$first': '$validity.startDate' },
@@ -592,7 +590,7 @@ async function list(match_condition, options) {
   });
 
   // Re-sort the records ... by (alphanumerical) component name for APA Frames, ASFs and Assembled APAs, or by last edit date (most recent first) for other component types
-  if ((match_condition) && (match_condition.formId) && (['APAFrame', 'APAShippingFrame', 'AssembledAPA'].includes(match_condition.formId))) {
+  if ((match_condition) && (match_condition.typeFormId) && (['APAFrame', 'APAShippingFrame', 'AssembledAPA'].includes(match_condition.typeFormId))) {
     aggregation_stages.push({ $sort: { componentName: -1 } });
   } else {
     aggregation_stages.push({ $sort: { lastEditDate: -1 } });
@@ -627,7 +625,7 @@ async function counts_byType() {
   aggregation_stages.push({
     $group: {
       _id: {
-        formId: '$formId',
+        typeFormId: '$typeFormId',
         componentUuid: '$componentUuid',
       },
     },
@@ -637,15 +635,15 @@ async function counts_byType() {
   // Then determine the 'count' - i.e. how many records are in each group
   aggregation_stages.push({
     $group: {
-      _id: '$_id.formId',
+      _id: '$_id.typeFormId',
       count: { $sum: 1 },
     },
   });
 
-  // Flatten the returned groups by projecting the 'formId' group ID directly (along with the 'count'), and not projecting the group ID object
+  // Flatten the returned groups by projecting the 'typeFormId' group ID directly (along with the 'count'), and not projecting the group ID object
   aggregation_stages.push({
     $project: {
-      formId: '$_id',
+      typeFormId: '$_id',
       count: true,
       _id: false,
     },
@@ -660,15 +658,15 @@ async function counts_byType() {
   let keyedRecords = {};
 
   for (const record of records) {
-    keyedRecords[record.formId] = record;
+    keyedRecords[record.typeFormId] = record;
   }
 
   // Retrieve an object containing all component type forms, with each entry keyed by the type form ID
   // Then, for each type form, copy the component count from the entry in the results object (if it exists) into the corresponding entry in the type forms object
   let typeFormsList = await Forms.list('componentForms');
 
-  for (const formId of Object.keys(typeFormsList)) {
-    if (keyedRecords.hasOwnProperty(formId)) typeFormsList[formId].count = keyedRecords[formId].count;
+  for (const typeFormId of Object.keys(typeFormsList)) {
+    if (keyedRecords.hasOwnProperty(typeFormId)) typeFormsList[typeFormId].count = keyedRecords[typeFormId].count;
   }
 
   // Return the type forms object
@@ -682,7 +680,7 @@ async function boardCounts_byPartNumberAndLocation() {
   let aggregation_stages = [];
 
   // Match against the type form ID to get records of all components of the single specified component type
-  aggregation_stages.push({ $match: { formId: 'GeometryBoard' } });
+  aggregation_stages.push({ $match: { typeFormId: 'GeometryBoard' } });
 
   // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
   aggregation_stages.push({
@@ -772,7 +770,7 @@ async function autoCompleteUuid(inputString, limit = 10) {
     $group: {
       _id: { componentUuid: '$componentUuid' },
       componentUuid: { '$first': '$componentUuid' },
-      typeFormName: { '$first': '$formName' },
+      typeFormName: { '$first': '$typeFormName' },
       componentName: { '$first': '$data.componentName' },
       lastEditDate: { '$first': '$validity.startDate' },
     },

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -753,7 +753,7 @@ async function forHWDB(componentUUID) {
     return { error: `There is no component record with component UUID = ${componentUUID}` }
   }
 
-  const componentTypeFormId = componentRecord.formId;
+  const componentTypeFormId = componentRecord.typeFormId;
   const componentDUNEPID = componentRecord.data.dunePid;
 
   // Set up the top-level information object that will hold the component information in the format required by the HWDB

--- a/app/lib/Search_GeoBoards.js
+++ b/app/lib/Search_GeoBoards.js
@@ -63,7 +63,7 @@ async function boardsByVisualInspection(disposition, issue) {
   // Match against the type form ID and component UUID to get records of all 'Geometry Board' components that the previously found 'Visual Inspection' actions were performed on
   comp_aggregation_stages.push({
     $match: {
-      'formId': 'GeometryBoard',
+      'typeFormId': 'GeometryBoard',
       'componentUuid': { $in: componentUUIDs }
     }
   });
@@ -157,7 +157,7 @@ async function boardsByVisualInspection(disposition, issue) {
         let perBoard_comp_aggregation_stages = [];
 
         perBoard_comp_aggregation_stages.push({
-          $match: { 'formId': 'ReturnedGeometryBoardBatch' }
+          $match: { 'typeFormId': 'ReturnedGeometryBoardBatch' }
         });
 
         perBoard_comp_aggregation_stages.push({ $unwind: '$data.boardUuids' });
@@ -199,7 +199,7 @@ async function boardsByOrderNumber(orderNumber) {
   // Match against the type form ID to get records of all 'Geometry Board Batch' and 'Returned Geometry Board Batch' components
   comp_aggregation_stages.push({
     $match: {
-      'formId': { $in: ['GeometryBoardBatch', 'ReturnedGeometryBoardBatch'] },
+      'typeFormId': { $in: ['GeometryBoardBatch', 'ReturnedGeometryBoardBatch'] },
     }
   });
 
@@ -210,7 +210,7 @@ async function boardsByOrderNumber(orderNumber) {
   comp_aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
-      typeFormId: { '$first': '$formId' },
+      typeFormId: { '$first': '$typeFormId' },
       orderNumber: { '$first': '$data.orderNumber' },
       boardUuids_batch: { '$first': '$data.subComponent_fullUuids' },
       boardUuids_returnedBatch: { '$first': '$data.boardUuids' },
@@ -346,7 +346,7 @@ async function boardsByAPA(apaUUID) {
   // Match against the type form ID to get records of all 'Geometry Board' components
   aggregation_stages.push({
     $match: {
-      'formId': 'GeometryBoard',
+      'typeFormId': 'GeometryBoard',
     }
   });
 

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -17,7 +17,7 @@ async function geoBoardShipmentsByReceptionDetails(status, origin, destination, 
   // Match against the type form ID and both locations to get records of all 'Geometry Board Shipment' components that were supposed to travel between the specified locations
   comp_aggregation_stages.push({
     $match: {
-      'formId': 'GeometryBoardShipment',
+      'typeFormId': 'GeometryBoardShipment',
       'data.originOfShipment': originString,
       'data.destinationOfShipment': destinationString,
     }
@@ -149,7 +149,7 @@ async function geoBoardShipmentsByBoardUUID(componentUUID) {
   let aggregation_stages = [];
 
   // Match against the type form ID to get records of all 'Geometry Board Shipment' components
-  aggregation_stages.push({ $match: { 'formId': 'GeometryBoardShipment' } });
+  aggregation_stages.push({ $match: { 'typeFormId': 'GeometryBoardShipment' } });
 
   // Select the latest version of each record, and pass through only the fields required for later use
   aggregation_stages.push({ $sort: { 'validity.version': -1 } });
@@ -157,8 +157,8 @@ async function geoBoardShipmentsByBoardUUID(componentUUID) {
     $group: {
       _id: { componentUuid: '$componentUuid' },
       componentUuid: { '$first': '$componentUuid' },
-      typeFormId: { '$first': '$formId' },
-      typeFormName: { '$first': '$formName' },
+      typeFormId: { '$first': '$typeFormId' },
+      typeFormName: { '$first': '$typeFormName' },
       data: { '$first': '$data' },
       reception: { '$first': '$reception' },
       lastEditDate: { '$first': '$validity.startDate' },
@@ -190,7 +190,7 @@ async function apasByProductionLocationAndNumber(location, number) {
   // Match against the type form ID to get records of all 'Assembled APA' components
   aggregation_stages.push({
     $match: {
-      'formId': 'AssembledAPA',
+      'typeFormId': 'AssembledAPA',
     }
   });
 
@@ -289,7 +289,7 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
   // Match against the type form ID, component UUID and production location to get records of all 'Assembled APA' components that have a UUID that is NOT in the previously constructed list
   comp_aggregation_stages.push({
     $match: {
-      'formId': 'AssembledAPA',
+      'typeFormId': 'AssembledAPA',
       'componentUuid': { $nin: uuids_apasCompletedToStep_atLocation },
       'data.apaAssemblyLocation': location,
     }
@@ -356,7 +356,7 @@ async function componentsByTypeAndNumber(typeFormId, typeRecordNumber) {
   // Match against the type form ID and type record number to get records of all components that have the same type and number as the specified ones
   aggregation_stages.push({
     $match: {
-      'formId': typeFormId,
+      'typeFormId': typeFormId,
       'data.typeRecordNumber': parseInt(typeRecordNumber, 10),
     }
   });
@@ -369,7 +369,7 @@ async function componentsByTypeAndNumber(typeFormId, typeRecordNumber) {
       componentUuid: { '$first': '$componentUuid' },
       componentName: { '$first': '$data.componentName' },
       typeRecordNumber: { '$first': '$data.typeRecordNumber' },
-      formName: { '$first': '$formName' },
+      typeFormName: { '$first': '$typeFormName' },
       shortUuid: { '$first': '$shortUuid' },
       data: { '$first': '$data' },
     },
@@ -398,7 +398,7 @@ async function componentsByTypeAndLocation(typeFormId, location, toothStripStatu
   // Match against the type form ID and location to get records of all components of the specified type at the specified location
   aggregation_stages.push({
     $match: {
-      'formId': typeFormId,
+      'typeFormId': typeFormId,
       'reception.location': location,
     }
   });
@@ -652,7 +652,7 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
   // For geometry boards, also match against the reception location if the specified 'acceptanceStatus' is 'rejected'
   if (typeFormId === 'GeometryBoard') {
     let matchConditions = {
-      'formId': typeFormId,
+      'typeFormId': typeFormId,
       'data.partNumber': partNumber,
     }
 
@@ -666,7 +666,7 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
   } else if (typeFormId === 'GroundingMeshPanel') {
     aggregation_stages.push({
       $match: {
-        'formId': typeFormId,
+        'typeFormId': typeFormId,
         'data.meshPanelPartNumber': partNumber,
       }
     });

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -56,7 +56,7 @@ block content
           select.form-control#inputStringSelection
             option(value = '')
             option(value = 'ALL_COMPONENTS') All Component Types 
-            option(value = 'GroundingMeshPanelShipment') Grounding Mesh Panel Shipment 
+            option(value = 'BATCH_COMPONENTS') Batch Components Only
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -131,7 +131,7 @@ block content
               img.small-icon(src = '/images/checklist_icon.svg')
               | &nbsp; View and print the component's summary
 
-          if component.formId == 'AssembledAPA'
+          if component.typeFormId == 'AssembledAPA'
             .vert-space-x1
               a.btn.btn-primary(href = `/component/${component.componentUuid}/execSummary`)
                 img.small-icon(src = '/images/checklist_icon.svg')
@@ -146,7 +146,7 @@ block content
                   img.small-icon(src = '/images/run_icon.svg')
                   | &nbsp; Create New Components of This Type via Workflows
               else
-                a.btn.btn-primary(href = `/component/${component.formId}/new`)
+                a.btn.btn-primary(href = `/component/${component.typeFormId}/new`)
                   img.small-icon(src = '/images/run_icon.svg')
                   | &nbsp; Create New Component of This Type
 
@@ -156,7 +156,7 @@ block content
 
           p.small.text-center #{base_url}/c/#{component.shortUuid.toString()}
 
-    if component.formId === 'APAFrameShipment'
+    if component.typeFormId === 'APAFrameShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
         dd #{dictionary_locations[component.data.originOfShipment]}
@@ -187,9 +187,9 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
+    else if component.typeFormId === 'CEAdapterBoardShipment' || component.typeFormId === 'CRBoardShipment' || component.typeFormId === 'CableHarnessShipment' || component.typeFormId === 'GBiasBoardShipment' || component.typeFormId === 'SHVBoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
-        if component.formId === 'CEAdapterBoardShipment'
+        if component.typeFormId === 'CEAdapterBoardShipment'
           dt Origin Location 
           dd #{dictionary_locations[component.data.originOfShipment]}
 
@@ -219,7 +219,7 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'DWAComponentShipment'
+    else if component.typeFormId === 'DWAComponentShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
         dd #{dictionary_locations[component.data.originOfShipment]}
@@ -250,7 +250,7 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'GeometryBoardShipment'
+    else if component.typeFormId === 'GeometryBoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location 
         dd #{dictionary_locations[component.data.originOfShipment]}
@@ -281,7 +281,7 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'GroundingMeshPanelShipment'
+    else if component.typeFormId === 'GroundingMeshPanelShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
         dd #{dictionary_locations[component.data.originOfShipment]}
@@ -312,7 +312,7 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-    else if component.formId === 'PopulatedBoardShipment'
+    else if component.typeFormId === 'PopulatedBoardShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
         dd #{dictionary_locations[component.data.originOfShipment]}
@@ -346,14 +346,14 @@ block content
           dt Comments 
           dd 
             textarea.form-control#comments(rows = 5)
-    else if component.formId === 'CEAdapterBoardBatch' || component.formId === 'CRBoardBatch' || component.formId === 'GBiasBoardBatch' || component.formId === 'GeometryBoardBatch'
-      if component.formId === 'GeometryBoardBatch'
+    else if component.typeFormId === 'CEAdapterBoardBatch' || component.typeFormId === 'CRBoardBatch' || component.typeFormId === 'GBiasBoardBatch' || component.typeFormId === 'GeometryBoardBatch'
+      if component.typeFormId === 'GeometryBoardBatch'
         .vert-space-x1.border-success.border.rounded.p-2
           #typeform
 
       - let columnHeader = ''
 
-      if component.data.subComponent_formId == 'CEAdapterBoard' || component.data.subComponent_formId == 'CRBoard' || component.data.subComponent_formId == 'GBiasBoard'
+      if component.data.subComponent_typeFormId == 'CEAdapterBoard' || component.data.subComponent_typeFormId == 'CRBoard' || component.data.subComponent_typeFormId == 'GBiasBoard'
         - columnHeader = 'UW ID'
       else 
         - columnHeader = 'UK ID'
@@ -388,7 +388,7 @@ block content
 
           .hori-space-x2 
             a.btn.btn-secondary#download_links(onclick = 'DownloadLinks(component.data.subComponent_shortUuids)', download = `links_${component.data.orderNumber}.txt`, href = '') Download List of Links
-    else if component.formId === 'ReturnedGeometryBoardBatch'
+    else if component.typeFormId === 'ReturnedGeometryBoardBatch'
       .vert-space-x1.border-success.border.rounded.p-2
         #typeform
 
@@ -410,7 +410,7 @@ block content
 
                   td #{info[1]}
                   td #{`${base_url}/c/${info[2]}`}
-    else if component.formId === 'YokeShipment'
+    else if component.typeFormId === 'YokeShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
         dd #{dictionary_locations[component.data.originOfShipment]}
@@ -445,7 +445,7 @@ block content
       .vert-space-x1.border-success.border.rounded.p-2
         #typeform
 
-    if component.formId === 'GeometryBoard'
+    if component.typeFormId === 'GeometryBoard'
       .vert-space-x2.border-success.border.rounded.p-2
         dt Geometry Board History
         dd 
@@ -492,7 +492,7 @@ block content
                   else 
                     td #{entry.data.checksPassed}
 
-    if component.formId === 'AssembledAPA'
+    if component.typeFormId === 'AssembledAPA'
       .vert-space-x2.border-success.border.rounded.p-2
         dt Installed Geometry Boards (#{installedGeometryBoardsCount})
         dd
@@ -543,21 +543,21 @@ block content
     .vert-space-x1
       .row
         .col-sm-6
-          if component.formId === 'APAFrame'
+          if component.typeFormId === 'APAFrame'
             h4 Action History (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>Existing workflow actions can be accessed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
-          else if component.formId === 'AssembledAPA'
+          else if component.typeFormId === 'AssembledAPA'
             h4 Action History (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>Existing workflow actions can be accessed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
                 | workflow</b>
-          else if component.formId === 'AssembledAPAShipment'
+          else if component.typeFormId === 'AssembledAPAShipment'
             h4 Action History (Non-Workflow Actions Only)
 
             .vert-space-x1
@@ -567,7 +567,7 @@ block content
           else
             h4 Action History
 
-            if component.formId === 'GeometryBoard'
+            if component.typeFormId === 'GeometryBoard'
               .vert-space-x1
                 p <b> Please see the table above for the action history of geometry boards</b>
 
@@ -576,7 +576,7 @@ block content
           if !actions || actions.length == 0
             p None
           else
-            if component.formId !== 'GeometryBoard'
+            if component.typeFormId !== 'GeometryBoard'
               table.table
                 thead
                   tr
@@ -596,21 +596,21 @@ block content
                         +dateTimeFormat(action.lastEditDate)
 
         .col-sm-6
-          if component.formId === 'APAFrame'
+          if component.typeFormId === 'APAFrame'
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>New workflow actions must be performed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') Frame Assembly 
                 | workflow</b>
-          else if component.formId === 'AssembledAPA'
+          else if component.typeFormId === 'AssembledAPA'
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1
               p <b>New workflow actions must be performed through this component's 
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') APA Assembly 
                 | workflow</b>
-          else if component.formId === 'AssembledAPAShipment'
+          else if component.typeFormId === 'AssembledAPAShipment'
             h4 Select an Action Type to Perform (Non-Workflow Actions Only)
 
             .vert-space-x1
@@ -623,7 +623,7 @@ block content
           hr
 
           each typeForm in actionTypeForms
-            if typeForm.componentTypes.includes(component.formName) && !typeForm.tags.includes('Trash')
+            if typeForm.componentTypes.includes(component.typeFormName) && !typeForm.tags.includes('Trash')
               a.actionbutton.btn.btn-success(href = `/action/${typeForm.formId}/spec/${component.componentUuid}`) #{typeForm.formName}
 
     .vert-space-x2

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -24,7 +24,7 @@ block allbody
       - const qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.formId === 'APAFrameShipment') || (component.formId === 'AssembledAPAShipment') || (component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'DWAComponentShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'GroundingMeshPanelShipment') || (component.formId === 'PopulatedBoardShipment') || (component.formId === 'SHVBoardShipment') || (component.formId === 'YokeShipment')
+      if (component.typeFormId === 'APAFrameShipment') || (component.typeFormId === 'AssembledAPAShipment') || (component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'DWAComponentShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'GeometryBoardShipment') || (component.typeFormId === 'GroundingMeshPanelShipment') || (component.typeFormId === 'PopulatedBoardShipment') || (component.typeFormId === 'SHVBoardShipment') || (component.typeFormId === 'YokeShipment')
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -41,7 +41,7 @@ block allbody
               dt Component UUID
               dd #{component.componentUuid}
 
-              if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId == 'GeometryBoardShipment' || component.formId === 'SHVBoardShipment'
+              if component.typeFormId === 'CEAdapterBoardShipment' || component.typeFormId === 'CRBoardShipment' || component.typeFormId === 'CableHarnessShipment' || component.typeFormId === 'GBiasBoardShipment' || component.typeFormId == 'GeometryBoardShipment' || component.typeFormId === 'SHVBoardShipment'
                 dt Number of Boards in Shipment
                 dd #{component.data.boardUuiDs.length}
 
@@ -62,7 +62,7 @@ block allbody
             if component.insertion.user
               |  by !{' '} #{component.insertion.user.displayName}
 
-      if component.formId === 'APAFrameShipment'
+      if component.typeFormId === 'APAFrameShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location
           dd #{dictionary_locations[component.data.originOfShipment]}
@@ -85,7 +85,7 @@ block allbody
                     td #{info[0]}
                     td #{info[1]}
                     td #{info[2]}
-      else if component.formId === 'CEAdapterBoardShipment' || component.formId === 'CRBoardShipment' || component.formId === 'CableHarnessShipment' || component.formId === 'GBiasBoardShipment' || component.formId === 'SHVBoardShipment'
+      else if component.typeFormId === 'CEAdapterBoardShipment' || component.typeFormId === 'CRBoardShipment' || component.typeFormId === 'CableHarnessShipment' || component.typeFormId === 'GBiasBoardShipment' || component.typeFormId === 'SHVBoardShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Boards in Shipment / Kit
           dd
@@ -102,7 +102,7 @@ block allbody
                     td #{info[0]}
                     td #{info[2]}
                     td #{info[1]}
-      else if component.formId === 'DWAComponentShipment'
+      else if component.typeFormId === 'DWAComponentShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location
           dd #{dictionary_locations[component.data.originOfShipment]}
@@ -125,7 +125,7 @@ block allbody
                     td #{info[0]}
                     td #{info[2]}
                     td #{info[1]}
-      else if component.formId === 'GeometryBoardShipment'
+      else if component.typeFormId === 'GeometryBoardShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location 
           dd #{dictionary_locations[component.data.originOfShipment]}
@@ -148,7 +148,7 @@ block allbody
                     td #{info[0]}
                     td #{info[1]}
                     td #{info[2]}
-      else if component.formId === 'GroundingMeshPanelShipment'
+      else if component.typeFormId === 'GroundingMeshPanelShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location
           dd #{dictionary_locations[component.data.originOfShipment]}
@@ -171,7 +171,7 @@ block allbody
                     td #{info[0]}
                     td #{info[1]}
                     td #{info[2]}
-      else if component.formId === 'PopulatedBoardShipment'
+      else if component.typeFormId === 'PopulatedBoardShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location
           dd #{dictionary_locations[component.data.originOfShipment]}
@@ -192,14 +192,14 @@ block allbody
                   tr
                     td #{info[0]}
                     td #{info[1]}
-      else if component.formId === 'CEAdapterBoardBatch' || component.formId === 'CRBoardBatch' || component.formId === 'GBiasBoardBatch' || component.formId === 'GeometryBoardBatch'
-        if component.formId === 'GeometryBoardBatch'
+      else if component.typeFormId === 'CEAdapterBoardBatch' || component.typeFormId === 'CRBoardBatch' || component.typeFormId === 'GBiasBoardBatch' || component.typeFormId === 'GeometryBoardBatch'
+        if component.typeFormId === 'GeometryBoardBatch'
           .vert-space-x1.border-success.border.rounded.p-2
             #typeform
 
         - let columnHeader = ''
 
-        if component.data.subComponent_formId == 'CEAdapterBoard' || component.data.subComponent_formId == 'CRBoard' || component.data.subComponent_formId == 'GBiasBoard'
+        if component.data.subComponent_typeFormId == 'CEAdapterBoard' || component.data.subComponent_typeFormId == 'CRBoard' || component.data.subComponent_typeFormId == 'GBiasBoard'
           - columnHeader = 'UW ID'
         else 
           - columnHeader = 'UK ID'
@@ -222,7 +222,7 @@ block allbody
                       td #{component.data.subComponent_typeRecordNumbers[index]}
                     else
                       td (not retrievable)
-      else if component.formId === 'YokeShipment'
+      else if component.typeFormId === 'YokeShipment'
         .vert-space-x1.border-success.border.rounded.p-2
           dt Origin Location
           dd #{dictionary_locations[component.data.originOfShipment]}
@@ -253,7 +253,7 @@ block allbody
 
       each action in nonConformActions
         .section.actionSection
-          .section-side.formName #{action.typeFormName}
+          .section-side.typeFormName #{action.typeFormName}
 
           .vert-space-x1
             dl
@@ -282,7 +282,7 @@ block allbody
 
       each action in workflowActions
         .section.actionSection
-          .section-side.formName (workflow) #{action.typeFormName}
+          .section-side.typeFormName (workflow) #{action.typeFormName}
 
           .vert-space-x1
             dl
@@ -311,7 +311,7 @@ block allbody
 
       each action in otherActions
         .section.actionSection
-          .section-side.formName (other) #{action.typeFormName}
+          .section-side.typeFormName (other) #{action.typeFormName}
 
           .vert-space-x1
             dl

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -41,12 +41,12 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     //  - records of all actions that have already been performed on this component
     //  - all currently available action type forms
     let [componentTypeForm, actions, actionTypeForms] = await Promise.all([
-      Forms.retrieve('componentForms', component.formId),
+      Forms.retrieve('componentForms', component.typeFormId),
       Actions.list({ componentUuid: req.params.uuid }),
       Forms.list('actionForms'),
     ]);
 
-    if (!componentTypeForm) return res.status(404).send(`There is no component type form with form ID = ${component.formId}`);
+    if (!componentTypeForm) return res.status(404).send(`There is no component type form with form ID = ${component.typeFormId}`);
 
     // Extract the most recently performed / edited action from the list of all actions above
     // This should be done explicitly here, since that list could be modified below depending on the component's type
@@ -55,7 +55,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // If the specified component is a 'Geometry Board' type, retrieve some more detailed information about any shipments that the board has been part of
     // Add this information to the previously retrieved list of actions performed on the board, and make sure that all of the action entries contain the same (or equivalent) fields
     // Add an entry for the board itself (again, containing the same fields as the action entries), and finally sort all entries in the combined array by the 'lastEditDate' field
-    if (component.formId === 'GeometryBoard') {
+    if (component.typeFormId === 'GeometryBoard') {
       geoBoardShipments = await Search_OtherComponents.geoBoardShipmentsByBoardUUID(req.params.uuid);
       actions = actions.concat(geoBoardShipments);
 
@@ -132,7 +132,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // First set up a list of component type form IDs for all components that are the subject of any workflow (there are only a handful of workflow types, so we can do this explicitly)
     // Then check to see if the list of component type form IDs includes the type form ID of the component type being specified
     const list_workflowComponents = ['APAFrame', 'AssembledAPA', 'AssembledAPAShipment'];
-    const workflowComponent = list_workflowComponents.includes(component.formId);
+    const workflowComponent = list_workflowComponents.includes(component.typeFormId);
 
     // If the specified component type is one that is the subject of a workflow, filter out any action types that should be performed through the workflow
     // First, retrieve the workflow type form, and then build an array of the workflow's action type form names from its path steps
@@ -144,11 +144,11 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     if (workflowComponent) {
       let workflowTypeForm = null;
 
-      if (component.formId === 'APAFrame') {
+      if (component.typeFormId === 'APAFrame') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'FrameAssembly');
-      } else if (component.formId === 'AssembledAPA') {
+      } else if (component.typeFormId === 'AssembledAPA') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_Assembly');
-      } else if (component.formId === 'AssembledAPAShipment') {
+      } else if (component.typeFormId === 'AssembledAPAShipment') {
         workflowTypeForm = await Forms.retrieve('workflowForms', 'APA_PostProduction');
       }
 
@@ -178,7 +178,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // For the other shipment and batch component types, set up an array containing more detailed information about each sub-component
     let collectionDetails = [];
 
-    if (component.formId === 'APAFrameShipment') {
+    if (component.typeFormId === 'APAFrameShipment') {
       for (const info of component.data.frameUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -188,27 +188,27 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
+    if ((component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
 
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.typeFormName, componentRecord.shortUuid]);
         }
       }
     }
 
-    if (component.formId === 'DWAComponentShipment') {
+    if (component.typeFormId === 'DWAComponentShipment') {
       for (const info of component.data.componentUUIDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
 
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName, componentRecord.shortUuid]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.typeFormName, componentRecord.shortUuid]);
         }
       }
     }
 
-    if (component.formId === 'GeometryBoardShipment') {
+    if (component.typeFormId === 'GeometryBoardShipment') {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -218,7 +218,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'GroundingMeshPanelShipment') {
+    if (component.typeFormId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -228,7 +228,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'PopulatedBoardShipment') {
+    if (component.typeFormId === 'PopulatedBoardShipment') {
       for (const info of component.data.crBoardKitUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -262,7 +262,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'ReturnedGeometryBoardBatch') {
+    if (component.typeFormId === 'ReturnedGeometryBoardBatch') {
       for (const info of component.data.boardUuids) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -272,7 +272,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.formId === 'YokeShipment') {
+    if (component.typeFormId === 'YokeShipment') {
       for (const info of component.data.yokeUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -286,7 +286,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     let installedGeometryBoards = [];
     let installedGeometryBoardsCount = 0;
 
-    if (component.formId === 'AssembledAPA') {
+    if (component.typeFormId === 'AssembledAPA') {
       installedGeometryBoards = await Search_GeoBoards.boardsByAPA(req.params.uuid);
 
       for (const boardGroup of installedGeometryBoards) {
@@ -340,9 +340,9 @@ router.get('/component/:uuid/edit', permissions.checkPermission('components:edit
     if (!component) return res.status(404).send(`There is no component record with component UUID = ${req.params.uuid}`);
 
     // Retrieve the component type form corresponding to the type form ID in the component record, and throw an error if there is no such type form
-    const componentTypeForm = await Forms.retrieve('componentForms', component.formId);
+    const componentTypeForm = await Forms.retrieve('componentForms', component.typeFormId);
 
-    if (!componentTypeForm) return res.status(404).send(`There is no component type form with form ID = ${component.formId}`);
+    if (!componentTypeForm) return res.status(404).send(`There is no component type form with form ID = ${component.typeFormId}`);
 
     // Render the interface page
     res.render('component_edit.pug', {
@@ -390,7 +390,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
     // ... but for batch-type components, they are already saved in the batch component's own record, so the individual sub-component records are not needed
     let shortUUIDs = [];
 
-    if (component.formId === 'APAFrameShipment') {
+    if (component.typeFormId === 'APAFrameShipment') {
       for (const info of component.data.frameUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -400,7 +400,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'GeometryBoardShipment') || (component.formId === 'SHVBoardShipment')) {
+    if ((component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'GeometryBoardShipment') || (component.typeFormId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -410,7 +410,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if (component.formId === 'DWAComponentShipment') {
+    if (component.typeFormId === 'DWAComponentShipment') {
       for (const info of component.data.componentUUIDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -420,7 +420,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if (component.formId === 'GroundingMeshPanelShipment') {
+    if (component.typeFormId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -430,7 +430,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if (component.formId === 'PopulatedBoardShipment') {
+    if (component.typeFormId === 'PopulatedBoardShipment') {
       for (const info of component.data.crBoardKitUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -464,7 +464,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if (component.formId === 'CEAdapterBoardBatch' || component.formId === 'CRBoardBatch' || component.formId === 'GBiasBoardBatch' || component.formId === 'GeometryBoardBatch') {
+    if (component.typeFormId === 'CEAdapterBoardBatch' || component.typeFormId === 'CRBoardBatch' || component.typeFormId === 'GBiasBoardBatch' || component.typeFormId === 'GeometryBoardBatch') {
       for (const uuid of component.data.subComponent_fullUuids) {
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
@@ -474,7 +474,7 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
-    if (component.formId === 'YokeShipment') {
+    if (component.typeFormId === 'YokeShipment') {
       for (const info of component.data.yokeUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -505,11 +505,11 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
     //  - the component type form corresponding to the type form ID in the component record (and throw an error if there is no such type form)
     //  - records of all actions that have already been performed on this component
     const [componentTypeForm, actions] = await Promise.all([
-      Forms.retrieve('componentForms', component.formId),
+      Forms.retrieve('componentForms', component.typeFormId),
       Actions.list({ componentUuid: req.params.uuid }),
     ]);
 
-    if (!componentTypeForm) return res.status(404).send(`There is no component type form with form ID = ${component.formId}`);
+    if (!componentTypeForm) return res.status(404).send(`There is no component type form with form ID = ${component.typeFormId}`);
 
     // We would like the actions to be ordered in a specific way in the summary document, to make it easier to find any given action (particularly when there are a lot of actions):
     //   - first, all non-conformance actions in chronological order (earliest to latest)
@@ -554,7 +554,7 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
     // For specific shipment and batch component types, set up an array containing more detailed information about each sub-component
     let collectionDetails = [];
 
-    if (component.formId === 'APAFrameShipment') {
+    if (component.typeFormId === 'APAFrameShipment') {
       for (const info of component.data.frameUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -564,27 +564,27 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if ((component.formId === 'CEAdapterBoardShipment') || (component.formId === 'CRBoardShipment') || (component.formId === 'CableHarnessShipment') || (component.formId === 'GBiasBoardShipment') || (component.formId === 'SHVBoardShipment')) {
+    if ((component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'SHVBoardShipment')) {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
 
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.typeFormName]);
         }
       }
     }
 
-    if (component.formId === 'DWAComponentShipment') {
+    if (component.typeFormId === 'DWAComponentShipment') {
       for (const info of component.data.componentUUIDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
 
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.formName]);
+          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, componentRecord.typeFormName]);
         }
       }
     }
 
-    if (component.formId === 'GeometryBoardShipment') {
+    if (component.typeFormId === 'GeometryBoardShipment') {
       for (const info of component.data.boardUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -594,7 +594,7 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if (component.formId === 'GroundingMeshPanelShipment') {
+    if (component.typeFormId === 'GroundingMeshPanelShipment') {
       for (const info of component.data.apaUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -604,7 +604,7 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if (component.formId === 'PopulatedBoardShipment') {
+    if (component.typeFormId === 'PopulatedBoardShipment') {
       for (const info of component.data.crBoardKitUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -638,7 +638,7 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
       }
     }
 
-    if (component.formId === 'YokeShipment') {
+    if (component.typeFormId === 'YokeShipment') {
       for (const info of component.data.yokeUuiDs) {
         if (info.component_uuid !== '') {
           const componentRecord = await Components.retrieve(info.component_uuid);
@@ -833,7 +833,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
   try {
     // Retrieve records of all components with the specified component type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const components = await Components.list({ formId: req.params.typeFormId }, { limit: 500 });
+    const components = await Components.list({ typeFormId: req.params.typeFormId }, { limit: 500 });
 
     // Retrieve the component type form corresponding to the specified type form ID
     const componentTypeForm = await Forms.retrieve('componentForms', req.params.typeFormId);
@@ -1065,7 +1065,7 @@ router.get(['/json/components/:typeFormId/list', '/api/components/:typeFormId/li
   try {
     // Retrieve records of all components with the specified component type
     // The first argument should be an object consisting of the match condition, i.e. the type form ID to match to
-    const components = await Components.list({ formId: req.params.typeFormId }, { limit: 500 });
+    const components = await Components.list({ typeFormId: req.params.typeFormId }, { limit: 500 });
 
     // Extract only the UUID field (in string format) from each component record, and save it into a list to be returned
     let componentUUIDs = [];

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -247,7 +247,13 @@ router.get('/administratorUtility', async function (req, res, next) {
 router.post(['/json/administratorUtility/:inputString', '/api/administratorUtility/:inputString'], async function (req, res, next) {
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
-    let result = await Admin_Functions.fixComponentFields(req.params.inputString);    // Change as appropriate for the required utility
+    let result = null;
+
+    if (req.params.inputString === 'ALL_COMPONENTS') {
+      result = await Admin_Functions.fixFields_allComponents();    // Change as appropriate for the required utility
+    } else {
+      result = await Admin_Functions.fixFields_batchComponents();
+    }
 
     return res.status(201).json(result);
   } catch (err) {

--- a/app/static/formio/ComponentUUID.js
+++ b/app/static/formio/ComponentUUID.js
@@ -295,7 +295,7 @@ class ComponentUUID extends TextFieldComponent {
                                              // ... meaning that it cannot find the 'component' variable in time, and throws an error as a result
                                              // It does eventually catch up if given enough time, but the box messages are purely for displaying information ...
                                              // ... it won't affect any record submission if they don't load fast enough
-            if (component.formId === 'APAFrame') {
+            if (component.typeFormId === 'APAFrame') {
               $.ajax({
                 contentType: 'application/json',
                 method: 'GET',
@@ -321,7 +321,7 @@ class ComponentUUID extends TextFieldComponent {
                   }
                 },
               }).fail();
-            } else if (component.formId === 'GroundingMeshPanel') {
+            } else if (component.typeFormId === 'GroundingMeshPanel') {
               $.ajax({
                 contentType: 'application/json',
                 method: 'GET',
@@ -347,13 +347,13 @@ class ComponentUUID extends TextFieldComponent {
                   }
                 },
               }).fail();
-            } else if (component.formId === 'WireBobbin') {
+            } else if (component.typeFormId === 'WireBobbin') {
               if (component.data.meanBreakStrength >= 24.0) {
                 info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - ready for use`);
               } else {
                 info_target.text(`\xa0 [Click for Component Info] ${component.data.componentName} - mean break strength is less than 24.0 N!`);
               }
-            } else if (component.formId === 'GeometryBoard') {
+            } else if (component.typeFormId === 'GeometryBoard') {
               $.ajax({
                 contentType: 'application/json',
                 method: 'GET',
@@ -379,7 +379,7 @@ class ComponentUUID extends TextFieldComponent {
                   }
                 },
               }).fail();
-            } else if (component.formId === 'AssembledAPA') {
+            } else if (component.typeFormId === 'AssembledAPA') {
               $.ajax({
                 contentType: 'application/json',
                 method: 'GET',

--- a/app/static/pages/administratorUtility.js
+++ b/app/static/pages/administratorUtility.js
@@ -27,11 +27,7 @@ async function renderInputForm() {
 
 
 function postSuccess(result) {    // Change as appropriate for the required utility
-  if (result === 'ALL_COMPONENTS') {
-    window.location.href = `/componentTypes/list`;
-  } else {
-    window.location.href = `/components/${result}/list`;
-  }
+  window.location.href = `/componentTypes/list`;
 }
 
 

--- a/app/static/pages/component.js
+++ b/app/static/pages/component.js
@@ -4,8 +4,8 @@ window.addEventListener('load', populateTypeForm);
 
 // Function to run when the page is loaded
 async function populateTypeForm() {
-  if (component.formId !== 'ReturnedGeometryBoardBatch') {
-    if (component.formId === 'PopulatedBoardShipment') {
+  if (component.typeFormId !== 'ReturnedGeometryBoardBatch') {
+    if (component.typeFormId === 'PopulatedBoardShipment') {
       // Fill the value of the 'comments' page element (defined as a Bootstrap text area in the .pug file) from the component record
       $('#comments').val(component.data.comments);
     } else {
@@ -30,7 +30,7 @@ async function populateTypeForm() {
                 "components": [
                   {
                     "label": " Type of Component",
-                    "key": "subComponent_formId",
+                    "key": "subComponent_typeFormId",
                     "type": "textfield",
                     "input": false
                   },

--- a/app/static/pages/component_edit.js
+++ b/app/static/pages/component_edit.js
@@ -45,7 +45,6 @@ async function onPageLoad() {
     // At this point, the 'submission' object contains ONLY the information that has been entered into the type form (i.e. the 'data' object)
     // Add the other required information, inheriting from the variables that were passed through the route to this page
     submission.componentUuid = component.componentUuid;
-    submission.formId = componentTypeForm.formId;
     submission.typeFormId = componentTypeForm.formId;
 
     // If the component originates from a workflow (and therefore a non-empty workflow ID has been provided), save the workflow ID into the 'submission' object
@@ -81,7 +80,6 @@ async function onPageLoad() {
         let sub_submission = Object.create(submission);
 
         sub_submission.componentUuid = slice_fullUuids[s];
-        sub_submission.formId = submission.data.subComponent_typeFormId;
         sub_submission.typeFormId = submission.data.subComponent_typeFormId;
         sub_submission.data = Object.create(submission.data);
 


### PR DESCRIPTION
- changing code to use the new 'typeFormId' and 'typeFormName' component record fields instead of the old 'formId' and 'formName' ones
- removed any places where the latter were still being assigned or set ... all new records from now on will only have the former present
- note that 'formId' and 'formName' are still the relevant field names for the actual type form records themselves ... might change those too in the future, but for now they can stay as they are

Additional Administrator Utility for Batch Components
- added new administrator utility function to change 'subComponent_formId' field name to 'subComponent_typeFormId'
- actually just adds the new field with the same value as the old one, like with 'formId' and 'formName' previously
- field name change was already made to the type forms via the interface, so new batches since the last deployment should be fine - this will only apply to older ones

Changes have been tested on Staging.