### PR TITLE
Fixing Component Record formId and formName fields (Part 3) ...

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -49,7 +49,69 @@ async function fixFields_batchComponents() {
 }
 
 
+async function removeFields_allComponents(currentTypeFormId) {
+  const result = await db.collection('components')
+    .updateMany(
+      {},
+      [
+        { $unset: ['formId', 'formName'] },
+      ]
+    )
+
+  if (result.ok === 0) throw new Error(`Admin_Functions::removeFields_allComponents() - failed to remove fields from the component record!`);
+
+  return result;
+}
+
+
+async function fixNames_wireBobbins(currentTypeFormId) {
+  let aggregation_stages = [];
+
+  aggregation_stages.push({ $match: { typeFormId: currentTypeFormId } });
+  aggregation_stages.push({ $project: { componentUuid: true } });
+
+  let uuids = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
+    
+  for (let uuid of uuids) {
+    const component = await Components.retrieve(uuid.componentUuid);
+    const typeFormName = component.typeFormName;
+    const data = component.data;
+    
+    let componentName = '';
+    
+    if (data.manufacturer !== 'fiskAlloy') {
+      componentName = `${typeFormName} ${data.bobbinId} (${utils.dictionary_wireSpoolManufacturers[data.manufacturer]} - Lot ${data.wireLot})`;
+    } else {
+      componentName = `${typeFormName} ${data.bobbinId} (${utils.dictionary_wireSpoolManufacturers[data.manufacturer]} - RM ${data.wireLot})`;
+    }
+    
+    const componentUuid = component.componentUuid;
+    let match_condition = { componentUuid };
+
+    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
+
+    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
+
+    const result = await db.collection('components')
+      .updateMany(
+        match_condition,
+        [{ $set: { 'data.componentName': componentName } }]
+      )
+
+    if (result.ok === 0) throw new Error(`Admin_Functions::fixNames_wireBobbins() - failed to fix component name in the component record!`);
+  }
+
+  return currentTypeFormId;
+}
+
+
+
+
 module.exports = {
   fixFields_allComponents,
   fixFields_batchComponents,
+  removeFields_allComponents,
+  fixNames_wireBobbins,
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -187,7 +187,12 @@ async function save(input, req) {
       newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300500001-${typeRecordNumber}-US200-010000`;
     } else if (newRecord.typeFormId === 'WireBobbin') {
-      newRecord.data.componentName = `${newRecord.typeFormName} ${newRecord.data.bobbinId} (Lot ${newRecord.data.wireLot})`;
+      if (newRecord.data.manufacturer !== 'fiskAlloy') {
+        newRecord.data.componentName = `${newRecord.typeFormName} ${newRecord.data.bobbinId} (${utils.dictionary_wireSpoolManufacturers[newRecord.data.manufacturer]} - Lot ${newRecord.data.wireLot})`;
+      } else {
+        newRecord.data.componentName = `${newRecord.typeFormName} ${newRecord.data.bobbinId} (${utils.dictionary_wireSpoolManufacturers[newRecord.data.manufacturer]} - RM ${newRecord.data.wireLot})`;
+      }
+
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     } else if (newRecord.typeFormId === 'Yoke') {
       newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -33,13 +33,6 @@ const dictionary_winderHeads = {
   us1: 'US 2',
 };
 
-const dictionary_bobbinManufacturers = {
-  littleFalls: 'Little Falls',
-  rstLocker: 'RST/Locker',
-  wireAlloyInternational: 'Wire Alloy International',
-  fiskAlloy: 'Fisk Alloy',
-}
-
 const dictionary_tensionSystems = {
   dwa1: 'DWA #1',
   dwa2: 'DWA #2',
@@ -534,7 +527,7 @@ async function forExecSummary(componentUUID) {
 
         const bobbin = await Components.retrieve(MUUID.from(bobbinUuid).toString());
 
-        if (bobbin) bobbinManufacturers += `${dictionary_bobbinManufacturers[bobbin.data.manufacturer]}, `;
+        if (bobbin) bobbinManufacturers += `${utils.dictionary_wireSpoolManufacturers[bobbin.data.manufacturer]}, `;
       }
 
       bobbinManufacturers = bobbinManufacturers.substring(0, bobbinManufacturers.length - 2);

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -13,8 +13,7 @@ module.exports = {
     }
   },
 
-  // A dictionary of locations that are used across all component and action type forms
-  // Using this centralised dictionary allows locations to be consistently displayed in the DB interface
+  // Locations (used in various places by both components and actions)
   dictionary_locations: {
     bnl: 'BNL',
     cambridge: 'Cambridge',
@@ -44,7 +43,7 @@ module.exports = {
     wisconsin: 'Wisconsin',
   },
 
-  // A dictionary of DUNE PID 'component ID' strings for Geometry Boards, related to the board part numbers
+  // DUNE PID 'component ID' strings for Geometry Boards, related to the board part numbers (used for setting the full DUNE PIDs of Geometry Board components at creation)
   // Note that cover boards are not included (even though they do technically have DUNE PIDs), because they are not individually recorded in the DB ... either as components or during installation
   dictionary_geometryBoardPIDs: {
     '8760104': '00001',
@@ -76,6 +75,15 @@ module.exports = {
     '8760121': '00023',
     '8760122': '00024',
     '8760120': '00025',
+  },
+
+  // Wire Spool Manufacturers (used for setting the names of Wire Bobbin components at creation)
+  dictionary_wireSpoolManufacturers: {
+    littleFalls: 'Little Falls',
+    rstLocker: 'RST/Locker',
+    wireAlloyInternational: 'Wire Alloy Intl.',
+    fiskAlloy: 'Fisk Alloy',
+    newLfa: 'Little Falls (NEW)',
   },
 
   // The dictionaries below list various groups of UK and US personnel, whose names should be entered as appropriate in various component and action type forms

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -55,8 +55,8 @@ block content
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'ALL_COMPONENTS') All Component Types 
-            option(value = 'BATCH_COMPONENTS') Batch Components Only
+            option(value = 'ALL_COMPONENTS') All Component Types (Clean Records)
+            option(value = 'WireBobbin') Wire Bobbins (Fix Names)
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -72,6 +72,17 @@ router.get('/user', async function (req, res, next) {
 });
 
 
+/// List wire spool manufacturers
+router.get(['/json/wireSpoolManufacturers.json', '/api/wireSpoolManufacturers.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_wireSpoolManufacturers));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
+
+
 /// List all technicians and other personnel at the UK and US APA factories
 router.get(['/json/technicians.json', '/api/technicians.json'], async function (req, res, next) {
   try {
@@ -247,12 +258,13 @@ router.get('/administratorUtility', async function (req, res, next) {
 router.post(['/json/administratorUtility/:inputString', '/api/administratorUtility/:inputString'], async function (req, res, next) {
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
+
     let result = null;
 
     if (req.params.inputString === 'ALL_COMPONENTS') {
-      result = await Admin_Functions.fixFields_allComponents();    // Change as appropriate for the required utility
+      result = await Admin_Functions.removeFields_allComponents(req.params.inputString);    // Change as appropriate for the required utility
     } else {
-      result = await Admin_Functions.fixFields_batchComponents();
+      result = await Admin_Functions.fixNames_wireBobbins(req.params.inputString);
     }
 
     return res.status(201).json(result);


### PR DESCRIPTION
- set administrator utility to remove the now unused 'formId' and 'formName' fields from all component records
- new administrator utility to update Wire Bobbin component names to include the manufacturer, and display Lot Number vs. RM Tag accordingly (naming format has been agreed with Dan Salisbury at Daresbury)
- updated component naming code to do the same for new Wire Bobbins in the future
- corresponding new common dictionary of wire spool manufacturers, with associated route so it can be used in the Wire Bobbin component type form once deployed, and change APA Exec. Summaries to use the new dictionary

Changes have been tested on Staging.