### PR TITLE
Flattening component location information (Part 1) ...

### DIFF
--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -10,108 +10,43 @@ const utils = require('./utils');
 const Workflows = require('./Workflows');
 
 
-async function fixFields_allComponents() {
+async function setLocationInfo_allComponents() {
   const result = await db.collection('components')
     .updateMany(
       {},
       [
         {
           $set: {
-            'typeFormId': '$formId',
-            'typeFormName': '$formName',
+            'location': '$reception.location',
+            'dateAtLocation': '$reception.date',
+            'locationDetail': '$reception.detail',
           }
         },
       ]
     )
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::fixFields_allComponents() - failed to add fields to the component record!`);
+  if (result.ok === 0) throw new Error(`Admin_Functions::setLocationInfo_allComponents() - failed to add fields to the component record!`);
 
   return result;
 }
 
 
-async function fixFields_batchComponents() {
-  const result = await db.collection('components')
-    .updateMany(
-      { 'typeFormId': { $in: ['CEAdapterBoardBatch', 'CRBoardBatch', 'GBiasBoardBatch', 'GeometryBoardBatch', 'ReturnedGeometryBoardBatch'] }, },
-      [
-        {
-          $set: {
-            'data.subComponent_typeFormId': '$data.subComponent_formId',
-          }
-        },
-      ]
-    )
-
-  if (result.ok === 0) throw new Error(`Admin_Functions::fixFields_batchComponents() - failed to add fields to the component record!`);
-
-  return result;
-}
-
-
-async function removeFields_allComponents(currentTypeFormId) {
+async function removeReceptionObject_allComponents() {
   const result = await db.collection('components')
     .updateMany(
       {},
       [
-        { $unset: ['formId', 'formName'] },
+        { $unset: ['reception'] },
       ]
     )
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::removeFields_allComponents() - failed to remove fields from the component record!`);
+  if (result.ok === 0) throw new Error(`Admin_Functions::removeReceptionObject_allComponents() - failed to remove object from the component record!`);
 
   return result;
 }
-
-
-async function fixNames_wireBobbins(currentTypeFormId) {
-  let aggregation_stages = [];
-
-  aggregation_stages.push({ $match: { typeFormId: currentTypeFormId } });
-  aggregation_stages.push({ $project: { componentUuid: true } });
-
-  let uuids = await db.collection('components')
-    .aggregate(aggregation_stages)
-    .toArray();
-    
-  for (let uuid of uuids) {
-    const component = await Components.retrieve(uuid.componentUuid);
-    const typeFormName = component.typeFormName;
-    const data = component.data;
-    
-    let componentName = '';
-    
-    if (data.manufacturer !== 'fiskAlloy') {
-      componentName = `${typeFormName} ${data.bobbinId} (${utils.dictionary_wireSpoolManufacturers[data.manufacturer]} - Lot ${data.wireLot})`;
-    } else {
-      componentName = `${typeFormName} ${data.bobbinId} (${utils.dictionary_wireSpoolManufacturers[data.manufacturer]} - RM ${data.wireLot})`;
-    }
-    
-    const componentUuid = component.componentUuid;
-    let match_condition = { componentUuid };
-
-    if (typeof componentUuid === 'object' && !(componentUuid instanceof Binary)) match_condition = componentUuid;
-
-    match_condition.componentUuid = MUUID.from(match_condition.componentUuid);
-
-    const result = await db.collection('components')
-      .updateMany(
-        match_condition,
-        [{ $set: { 'data.componentName': componentName } }]
-      )
-
-    if (result.ok === 0) throw new Error(`Admin_Functions::fixNames_wireBobbins() - failed to fix component name in the component record!`);
-  }
-
-  return currentTypeFormId;
-}
-
-
 
 
 module.exports = {
-  fixFields_allComponents,
-  fixFields_batchComponents,
-  removeFields_allComponents,
-  fixNames_wireBobbins,
+  setLocationInfo_allComponents,
+  removeReceptionObject_allComponents,
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -229,8 +229,16 @@ async function save(input, req) {
     } else {
       newRecord.reception.location = '';
     }
+
+    newRecord.location = newRecord.reception.location;
+    newRecord.dateAtLocation = newRecord.reception.date;
+    newRecord.locationDetail = newRecord.reception.detail;
   } else {
     newRecord.reception = input.reception;
+
+    newRecord.location = input.reception.location;
+    newRecord.dateAtLocation = input.reception.date;
+    newRecord.locationDetail = input.reception.detail;
   }
 
   // If the component name is based on fields that are more likely to be changed by the user, it should be assigned and re-assigned any time the record is edited
@@ -356,6 +364,9 @@ async function updateLocation(componentUuid, location, date, detail) {
               'reception.location': location,
               'reception.date': date,
               'reception.detail': detail,
+              'location': location,
+              'dateAtLocation': date,
+              'locationDetail': detail,
             }
           },
         ]
@@ -393,6 +404,9 @@ async function updateLocation_geoBoardRemoval(componentUuid, location, date, det
             'reception.location': location,
             'reception.date': date,
             'reception.detail': detail,
+            'location': location,
+            'dateAtLocation': date,
+            'locationDetail': detail,
           }
         },
       ]

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -55,8 +55,7 @@ block content
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'ALL_COMPONENTS') All Component Types (Clean Records)
-            option(value = 'WireBobbin') Wire Bobbins (Fix Names)
+            option(value = 'ALL_COMPONENTS') All Component Types (Set Location Info)
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -259,13 +259,7 @@ router.post(['/json/administratorUtility/:inputString', '/api/administratorUtili
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
 
-    let result = null;
-
-    if (req.params.inputString === 'ALL_COMPONENTS') {
-      result = await Admin_Functions.removeFields_allComponents(req.params.inputString);    // Change as appropriate for the required utility
-    } else {
-      result = await Admin_Functions.fixNames_wireBobbins(req.params.inputString);
-    }
+    let result = await Admin_Functions.setLocationInfo_allComponents();    // Change as appropriate for the required utility
 
     return res.status(201).json(result);
   } catch (err) {


### PR DESCRIPTION
- there is no longer any need to have a specific 'reception' object to hold component location information - most component types aren't even received anywhere, so the current setup is also a bit misleading
- additionally, having the location information stored within an object instead of as top-level fields makes it needlessly complicated to access (the object has to be checked first, then the fields, etc.)
- new components will now have location information saved directly into the top level of the record (currently alongside the reception object)
- new admin utility to copy existing reception information into the same top level fields

Changes have been tested on Staging.