### PR TITLE
New Personnel List and Frame Name Bug Fix

### DIFF
--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -93,7 +93,7 @@ async function save(input, req) {
     if (newRecord.typeFormId === 'APAFrame') {
       let pidSuffix = '';
 
-      if (newRecord.data.frameProductionLocation === 'dsm') {
+      if ((newRecord.data.frameProductionLocation === 'dsm') || (newRecord.data.frameProductionLocation === 'evt')) {
         newRecord.data.componentName = `APA Frame ${typeRecordNumber}-UK`;
         pidSuffix = 'UK106-010000';
       } else if (newRecord.data.frameProductionLocation === 'wisconsin') {

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -211,9 +211,20 @@ module.exports = {
     stephenSumner: 'Stephen Sumner',
   },
 
-  // Post-Production D-band personnel (post-winding APA Assembly workflow actions and all APA Post Production workflow actions)
+  // Post-Production D-band personnel (post-winding APA Assembly workflow actions except for 'Conduit Insertion', and all APA Post Production workflow actions)
   dictionary_dBandPostProduction: {
     edBlucher: 'Ed Blucher',
+    albertoMarchionni: 'Alberto Marchionni',
+    radosavPantelic: 'Radosav Pantelic',
+    danielSalisbury: 'Daniel Salisbury',
+    jasonThornhill: 'Jason Thornhill',
+  },
+
+  // Personnel who are authorised to signoff on Conduit Insertion checks ('Conduit Insertion' APA Assembly workflow actions)
+  // These are the same personnel as in 'dictionary_dBandPostProduction' above, plus an additional name (Dave Brown) specifically for this action type
+  dictionary_dBandConduitInsertion: {
+    edBlucher: 'Ed Blucher',
+    daveBrown: 'Dave Brown',
     albertoMarchionni: 'Alberto Marchionni',
     radosavPantelic: 'Radosav Pantelic',
     danielSalisbury: 'Daniel Salisbury',

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -22,6 +22,7 @@ module.exports = {
     cincinnati: 'Cincinnati',
     daresbury: 'Daresbury Factory',
     dsm: 'Durham Sheet Metal',
+    evt: 'EGKENN Vacuum Technology',
     fermilab: 'Fermilab',
     harvard: 'Harvard',
     in_transit: 'In Transit',

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -170,6 +170,15 @@ router.get(['/json/dBandPostProduction.json', '/api/dBandPostProduction.json'], 
   }
 });
 
+/// List personnel who are authorised to signoff on Conduit Insertion checks
+router.get(['/json/dBandConduitInsertion.json', '/api/dBandConduitInsertion.json'], async function (req, res, next) {
+  try {
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_dBandConduitInsertion));
+  } catch (err) {
+    logger.info({ route: req.route.path }, err.message);
+    res.status(500).json({ error: err.toString() });
+  }
+});
 
 /// List FD-HD technical coordinators
 router.get(['/json/fdhdTechCoordSignoff.json', '/api/fdhdTechCoordSignoff.json'], async function (req, res, next) {

--- a/app/static/pages/search_componentsByTypeAndPartNumber.js
+++ b/app/static/pages/search_componentsByTypeAndPartNumber.js
@@ -129,7 +129,7 @@ function postSuccess(result) {
         <tr>
           <th style = 'width: 23%'>UKID</th>
           <th style = 'width: 42%'>Date at Location</th>
-          <th style = 'width: 35%'>Rejection info</th>
+          <th style = 'width: 35%'>Rejection Info</th>
         </tr>`;
 
       for (const boardGroup of result.slice(0, (result.length / 3) + 1)) {


### PR DESCRIPTION
New personnel list for Conduit Insertion APA Assembly actions
- Dave Brown is now allowed to sign off on conduit insertion checks
- currently, the insertion checks use the D-Band Post Production personnel list - but so do a number of other checks, which Dave is not supposed to be able to sign off on
- made a new personnel list specifically for conduit insertion checks, which is just the D-Band Post Production one plus Dave

Bug fix for new APA Frame production location
- frame component name will now be correctly set for EVT-produced frames (previously assumed that all UK frames came from DSM)
- added EVT to the global dictionary of locations