### PR TITLE
Improving connections between APAs, ASFs and APA Shipments ...

### DIFF
--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -322,6 +322,50 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
 }
 
 
+/// Retrieve a list of assembled APA shipments that reference a single Assembled APA or ASF component, specified by its UUID
+async function apaShipmentsByAPAorASFUUID(componentUUID) {
+  let aggregation_stages = [];
+
+  // Match against the type form ID to get records of all 'Assembled APA Shipment' components
+  aggregation_stages.push({ $match: { 'typeFormId': 'AssembledAPAShipment' } });
+
+  // Select the latest version of each record, and pass through only the fields required for later use
+  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({
+    $group: {
+      _id: { componentUuid: '$componentUuid' },
+      componentUuid: { '$first': '$componentUuid' },
+      workflowId: { '$first': '$workflowId' },
+      data: { '$first': '$data' },
+    },
+  });
+
+  // Match against the specified component UUID
+  // Since the Assembled APA UUIDs are stored as an ARRAY in the shipment record, this requires first unwinding the array (to temporarily produce a single record per array entry)
+  aggregation_stages.push({ $unwind: '$data.apaUuiDs' });
+
+  aggregation_stages.push({
+    $match: {
+      $or: [
+        { 'data.apaUuiDs.component_uuid': MUUID.from(componentUUID).toString() },
+        { 'data.asfUuid': MUUID.from(componentUUID).toString() },
+      ]
+    }
+  });
+
+  // Re-sort the records by last edit date ... most recent first
+  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+
+  // Query the 'components' records collection using the aggregation stages defined above
+  let shipments = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
+
+  // Return the list of shipments
+  return shipments;
+}
+
+
 /// Retrieve a list of components that match the specified DUNE PID
 async function componentsByDUNEPID(dunePID) {
   let aggregation_stages = [];
@@ -815,6 +859,7 @@ module.exports = {
   geoBoardShipmentsByBoardUUID,
   apasByProductionLocationAndNumber,
   apasByProductionLocationAndAssemblyStep,
+  apaShipmentsByAPAorASFUUID,
   componentsByDUNEPID,
   componentsByTypeAndNumber,
   componentsByTypeAndLocation,

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -9,6 +9,7 @@ block extrascripts
     const collectionDetails = !{JSON.stringify(collectionDetails, null, 4)};
     const installedGeometryBoards = !{JSON.stringify(installedGeometryBoards, null, 4)};
     const installedGeometryBoardsCount = !{JSON.stringify(installedGeometryBoardsCount, null, 4)};
+    const apaPostProductionWorkflowId = !{JSON.stringify(apaPostProductionWorkflowId, null, 4)};
     const actions = !{JSON.stringify(actions, null, 4)};
     const mostRecentAction = !{JSON.stringify(mostRecentAction, null, 4)};
     const actionTypeForms = !{JSON.stringify(actionTypeForms, null, 4)};
@@ -61,10 +62,36 @@ block content
                   +dateFormat(component.dateAtLocation)
                   | )
 
-            if component.workflowId
+            if component.typeFormId === 'APAFrame'
               dt Part of Workflow:
               dd
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                |  (Frame Assembly)
+            else if component.typeFormId === 'APAShippingFrame'
+              if apaPostProductionWorkflowId
+                dt Part of Workflow:
+                dd
+                  a(href = `/workflow/${apaPostProductionWorkflowId}`, target = '_blank') #{apaPostProductionWorkflowId}
+                  |  (APA Post Production)
+            else if component.typeFormId === 'AssembledAPA'
+              dt Part of Workflow:
+
+              if !apaPostProductionWorkflowId
+                dd
+                  a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                  |  (APA Assembly)
+              else 
+                dd
+                  a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                  |  (APA Assembly)
+                  br
+                  a(href = `/workflow/${apaPostProductionWorkflowId}`, target = '_blank') #{apaPostProductionWorkflowId}
+                  |  (APA Post Production)
+            else if component.typeFormId === 'AssembledAPAShipment'
+              dt Part of Workflow:
+              dd
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                |  (APA Post Production)
 
             if component.data.fromBatch
               dt Part of Batch:

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -25,10 +25,15 @@ block content
       table.table
         thead
           tr
-            th.col-md-3 Component Name
+            if componentTypeForm.formId == 'APAShippingFrame'
+              th.col-md-2 Component Name
+            else 
+              th.col-md-3 Component Name
 
             if componentTypeForm.formId == 'APAFrame'
               th.col-md-2 Installed on APA
+            else if componentTypeForm.formId == 'APAShippingFrame'
+              th.col-md-3 Assembled APA Shipment
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
             else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
@@ -56,6 +61,9 @@ block content
                 if (component.typeFormId == 'APAFrame') && (component.additionalInformation[0] != '[')
                   td 
                     a(href = `/component/${component.locationDetail}`, target = '_blank') #{component.additionalInformation}
+                else if (component.typeFormId == 'APAShippingFrame') && (component.additionalInformation[0] != '[')
+                  td 
+                    a(href = `/component/${component.evenMoreInformation}`, target = '_blank') #{component.additionalInformation}
                 else if (component.typeFormId == 'AssembledAPA') && (component.additionalInformation[0] != '[')
                   td
                     a(href = `/component/${component.data.frameUuid}`, target = '_blank') #{component.additionalInformation}

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -282,16 +282,24 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    // If the specified component is an 'Assembled APA' type, retrieve some more detailed information about any geometry boards that have been installed on it
+    // If the specified component is an 'APA Shipping Frame' type, retrieve some more detailed information about any assembled APA shipments that contain it
+    // If the specified component is an 'Assembled APA' type, also retrieve the same information, plus that about any geometry boards that have been installed on it
     let installedGeometryBoards = [];
     let installedGeometryBoardsCount = 0;
+    let apaPostProductionWorkflowId = null;
 
-    if (component.typeFormId === 'AssembledAPA') {
+    if (component.typeFormId === 'APAShippingFrame') {
+      const assembledAPAShipments = await Search_OtherComponents.apaShipmentsByAPAorASFUUID(req.params.uuid);
+      apaPostProductionWorkflowId = (assembledAPAShipments.length > 0) ? assembledAPAShipments[0].workflowId : null;
+    } else if (component.typeFormId === 'AssembledAPA') {
       installedGeometryBoards = await Search_GeoBoards.boardsByAPA(req.params.uuid);
 
       for (const boardGroup of installedGeometryBoards) {
         installedGeometryBoardsCount += boardGroup.componentUuids.length;
       }
+
+      const assembledAPAShipments = await Search_OtherComponents.apaShipmentsByAPAorASFUUID(req.params.uuid);
+      apaPostProductionWorkflowId = (assembledAPAShipments.length > 0) ? assembledAPAShipments[0].workflowId : null;
     }
 
     // Render the interface page
@@ -302,6 +310,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       collectionDetails,
       installedGeometryBoards,
       installedGeometryBoardsCount,
+      apaPostProductionWorkflowId,
       actions: nonWorkflowActions,
       mostRecentAction,
       actionTypeForms,
@@ -855,6 +864,17 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
 
         if (assembledAPA) { apaFrame.additionalInformation = assembledAPA.data.componentName; }
         else { apaFrame.additionalInformation = '[Not Currently in Use on an APA!]'; }
+      }
+    } else if (componentTypeForm.formId === 'APAShippingFrame') {
+      for (let asf of components) {
+        const assembledAPAShipments = await Search_OtherComponents.apaShipmentsByAPAorASFUUID(asf.componentUuid);
+
+        if (assembledAPAShipments.length > 0) {
+          asf.additionalInformation = assembledAPAShipments[0].data.componentName;
+          asf.evenMoreInformation = assembledAPAShipments[0].componentUuid;
+        } else {
+          asf.additionalInformation = '[Not Currently in Use on a Shipment!]';
+        }
       }
     } else if (componentTypeForm.formId === 'AssembledAPA') {
       for (let assembledAPA of components) {


### PR DESCRIPTION
- each Assembled APA component info page will now show a link to the APA Post Production workflow whose APA Shipment component includes the APA in question (if the APA is not yet associated with a shipment component, no link will be shown)
- similarly, each ASF component info page will now show a link to the APA Post Production workflow whose APA Shipment component includes the ASF in question (and again, if the ASF is not yet associated with a shipment component, no link will be shown)
- the component listing page for ASFs will now show which APA Shipment it is associated with (or a message indicating otherwise, if the ASF is not yet in use)