### PR TITLE
Adding new inputs to populated board kit information pages ...

### DIFF
--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -253,10 +253,14 @@ block content
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
 
-        if component.typeFormId === 'CEAdapterBoardShipment'
-          .vert-space-x1 
-            dt Engineering Release 
-            dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
+        .vert-space-x1 
+          dt Engineering Release 
+          dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
+
+        .vert-space-x1 
+          dt Comments 
+          dd 
+            textarea.form-control#comments(rows = 5)
     else if component.typeFormId === 'DWAComponentShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
@@ -379,10 +383,6 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-
-        .vert-space-x1 
-          dt Engineering Release 
-          dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
 
         .vert-space-x1 
           dt Comments 

--- a/app/static/pages/component.js
+++ b/app/static/pages/component.js
@@ -5,7 +5,7 @@ window.addEventListener('load', populateTypeForm);
 // Function to run when the page is loaded
 async function populateTypeForm() {
   if (component.typeFormId !== 'ReturnedGeometryBoardBatch') {
-    if (component.typeFormId === 'PopulatedBoardShipment') {
+    if ((component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'PopulatedBoardShipment') || (component.typeFormId === 'SHVBoardShipment')) {
       // Fill the value of the 'comments' page element (defined as a Bootstrap text area in the .pug file) from the component record
       $('#comments').val(component.data.comments);
     } else {


### PR DESCRIPTION
- populated board kits and shipments now include an Engineering Release input, plus a comments box (mainly to show who submitted them if creating via M2M)
- added these inputs to the bespoke component information pages for these component types (they don't show the entire type form, but instead use a reduced version tailored to each component type)