### PR TITLE
Recent Requested Changes from Staging

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -13,7 +13,7 @@ const utils = require('./utils');
 const transport_typeFormIDs = ['APAShipmentTransport', 'CEAdapterBoardTransport'];
 
 // Declare a list of the available 'reception' related action type forms
-const reception_typeFormIDs = ['APAShipmentReception', 'BoardReception', 'CEAdapterBoardReception', 'DWAComponentShipmentReception', 'FrameShipmentReception', 'GroundingMeshShipmentReception', 'PopulatedBoardKitReception', 'YokeShipmentReception'];
+const reception_typeFormIDs = ['APAShipmentReception', 'BoardReception', 'CEAdapterBoardReception', 'DWAComponentShipmentReception', 'FrameShipmentReception', 'GroundingMeshShipmentReception', 'InstallationHardwareShipmentReception', 'PopulatedBoardKitReception'];
 
 // Declare a list of the available 'board installation' and 'mesh installation' action type forms
 const installation_typeFormIDs = ['x_boards', 'v_boards', 'u_boards', 'g_boards', 'prep_mesh_panel_install'];

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -208,7 +208,7 @@ async function save(input, req) {
       newRecord.location = 'daresbury';
     } else if (newRecord.typeFormId === 'APAShippingFrame') {
       newRecord.location = newRecord.data.asfLocation;
-    } else if ((newRecord.typeFormId === 'APAFrameShipment') || (newRecord.typeFormId === 'DWAComponentShipment') || (newRecord.typeFormId === 'GeometryBoardShipment') || (newRecord.typeFormId === 'GroundingMeshPanelShipment') || (newRecord.typeFormId === 'PopulatedBoardShipment') || (newRecord.typeFormId === 'YokeShipment')) {
+    } else if ((newRecord.typeFormId === 'APAFrameShipment') || (newRecord.typeFormId === 'DWAComponentShipment') || (newRecord.typeFormId === 'GeometryBoardShipment') || (newRecord.typeFormId === 'GroundingMeshPanelShipment') || (newRecord.typeFormId === 'InstallationHardwareShipment') || (newRecord.typeFormId === 'PopulatedBoardShipment')) {
       newRecord.location = 'in_transit';
     } else if (newRecord.typeFormId === 'AssembledAPA') {
       newRecord.location = newRecord.data.apaAssemblyLocation;
@@ -278,14 +278,14 @@ async function save(input, req) {
   } else if (newRecord.typeFormId === 'GroundingMeshPanelShipment') {
     newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.apaUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
+  } else if (newRecord.typeFormId === 'InstallationHardwareShipment') {
+    newRecord.data.componentName = `${newRecord.typeFormName} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
+    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'PopulatedBoardShipment') {
     newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'SHVBoardShipment') {
     newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
-    newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
-  } else if (newRecord.typeFormId === 'YokeShipment') {
-    newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.yokeUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   }
 
@@ -307,7 +307,7 @@ async function save(input, req) {
   // - for a 'Populated Board Shipment', update the locations of the various sub-components to indicate that they are at Wisconsin (where the kit is put together)
   // - for a 'Return Geometry Board Batch', update the locations of the individual geometry board sub-components to indicate they are at Lancaster (where the batch is put together)
   // In all cases, if successful, the updating function returns 'result = 1' in all cases, but we don't actually use this value anywhere
-  if ((newRecord.typeFormId === 'APAFrameShipment') || (newRecord.typeFormId === 'DWAComponentShipment') || (newRecord.typeFormId === 'GeometryBoardShipment') || (newRecord.typeFormId === 'GroundingMeshPanelShipment') || (newRecord.typeFormId === 'PopulatedBoardShipment') || (newRecord.typeFormId === 'YokeShipment')) {
+  if ((newRecord.typeFormId === 'APAFrameShipment') || (newRecord.typeFormId === 'DWAComponentShipment') || (newRecord.typeFormId === 'GeometryBoardShipment') || (newRecord.typeFormId === 'GroundingMeshPanelShipment') || (newRecord.typeFormId === 'InstallationHardwareShipment') || (newRecord.typeFormId === 'PopulatedBoardShipment')) {
     const result = await updateLocations_inShipment(newRecord.componentUuid, 'in_transit', (new Date()).toISOString().slice(0, 10));
   } else if (newRecord.typeFormId === 'AssembledAPA') {
     const result = await updateLocation(newRecord.data.frameUuid, 'installed_on_APA', (new Date()).toISOString().slice(0, 10), newRecord.componentUuid);
@@ -440,6 +440,11 @@ async function updateLocations_inShipment(componentUuid, location, date) {
     for (const mesh of shipment.data.apaUuiDs) {
       const result = await updateLocation(mesh.component_uuid, location, date, '');
     }
+  } else if (shipment.typeFormId === 'InstallationHardwareShipment') {
+    // Extract the UUID and update the location information of each yoke in a shipment of installation hardware components
+    for (const yoke of shipment.data.yokeUuiDs) {
+      const result = await updateLocation(yoke.component_uuid, location, date, '');
+    }
   } else if (shipment.typeFormId === 'PopulatedBoardShipment') {
     // Extract the UUID and update the location information of each shipment in a multi-type populated board shipment
     for (const crBoardShipment of shipment.data.crBoardKitUuiDs) {
@@ -464,11 +469,6 @@ async function updateLocations_inShipment(componentUuid, location, date) {
       if (cableHarnessShipment.component_uuid !== '') {
         const result = await updateLocations_inShipment(cableHarnessShipment.component_uuid, location, date);
       }
-    }
-  } else if (shipment.typeFormId === 'YokeShipment') {
-    // Extract the UUID and update the location information of each yoke in a shipment of yokes
-    for (const yoke of shipment.data.yokeUuiDs) {
-      const result = await updateLocation(yoke.component_uuid, location, date, '');
     }
   }
 

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -322,6 +322,50 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
 }
 
 
+/// Retrieve a list of assembled APA shipments that reference a single Assembled APA or ASF component, specified by its UUID
+async function apaShipmentsByAPAorASFUUID(componentUUID) {
+  let aggregation_stages = [];
+
+  // Match against the type form ID to get records of all 'Assembled APA Shipment' components
+  aggregation_stages.push({ $match: { 'typeFormId': 'AssembledAPAShipment' } });
+
+  // Select the latest version of each record, and pass through only the fields required for later use
+  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({
+    $group: {
+      _id: { componentUuid: '$componentUuid' },
+      componentUuid: { '$first': '$componentUuid' },
+      workflowId: { '$first': '$workflowId' },
+      data: { '$first': '$data' },
+    },
+  });
+
+  // Match against the specified component UUID
+  // Since the Assembled APA UUIDs are stored as an ARRAY in the shipment record, this requires first unwinding the array (to temporarily produce a single record per array entry)
+  aggregation_stages.push({ $unwind: '$data.apaUuiDs' });
+
+  aggregation_stages.push({
+    $match: {
+      $or: [
+        { 'data.apaUuiDs.component_uuid': MUUID.from(componentUUID).toString() },
+        { 'data.asfUuid': MUUID.from(componentUUID).toString() },
+      ]
+    }
+  });
+
+  // Re-sort the records by last edit date ... most recent first
+  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+
+  // Query the 'components' records collection using the aggregation stages defined above
+  let shipments = await db.collection('components')
+    .aggregate(aggregation_stages)
+    .toArray();
+
+  // Return the list of shipments
+  return shipments;
+}
+
+
 /// Retrieve a list of components that match the specified DUNE PID
 async function componentsByDUNEPID(dunePID) {
   let aggregation_stages = [];
@@ -815,6 +859,7 @@ module.exports = {
   geoBoardShipmentsByBoardUUID,
   apasByProductionLocationAndNumber,
   apasByProductionLocationAndAssemblyStep,
+  apaShipmentsByAPAorASFUUID,
   componentsByDUNEPID,
   componentsByTypeAndNumber,
   componentsByTypeAndLocation,

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -242,9 +242,9 @@ module.exports = {
     joeMunski: 'Joe Munski',
   },
 
-  // Personnel who are authorised to signoff on hardware installation at UW [not currently used, but keep for the future]
-  dictionary_uwInstallationSignoff: {
-    joeMunski: 'Joe Munski',
+  // Personnel who are authorised to signoff on populated board shipments ('CE Adapter Board' and 'Multi-Type Populated Board' shipment components)
+  dictionary_populatedBoardShipmentSignoff: {
+    pamMarrLaundrie: 'Pam Marr-Laundrie',
   },
 
   // Personnel from the CERN Compliance Office ('APA Shipment Signoff and Transport' APA Post Production workflow actions)

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -45,13 +45,13 @@ block content
             option(value = 'GeometryBoardShipment') Geometry Board Shipment 
             option(value = 'GroundingMeshPanel') Grounding Mesh Panel
             option(value = 'GroundingMeshPanelShipment') Grounding Mesh Panel Shipment 
+            option(value = 'InstallationHardwareShipment') Installation Hardware Shipment
             option(value = 'PopulatedBoardShipment') Multi-Type Populated Board Shipment
             option(value = 'ReturnedGeometryBoardBatch') Returned Geometry Board Batch
             option(value = 'SHVBoard') SHV Board
             option(value = 'SHVBoardShipment') SHV Board Kit
             option(value = 'WireBobbin') Wire Bobbin
             option(value = 'Yoke') Yoke
-            option(value = 'YokeShipment') Yoke Shipment
 
           select.form-control#inputStringSelection
             option(value = '')

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -163,6 +163,11 @@ block content
               a.btn.btn-primary(href = `/component/${component.componentUuid}/execSummary`)
                 img.small-icon(src = '/images/checklist_icon.svg')
                 | &nbsp; View and print this APA's Executive Summary
+          else if component.typeFormId == 'InstallationHardwareShipment'
+            .vert-space-x1 
+              a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
+                img.small-icon(src = '/images/checklist_icon.svg')
+                | &nbsp; Print all Yoke QR codes
 
           .vert-space-x2
             hr
@@ -437,37 +442,6 @@ block content
 
                   td #{info[1]}
                   td #{`${base_url}/c/${info[2]}`}
-    else if component.typeFormId === 'YokeShipment'
-      .vert-space-x1.border-success.border.rounded.p-2
-        dt Origin Location
-        dd #{dictionary_locations[component.data.originOfShipment]}
-
-        dt Destination Location
-        dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-        dt Yokes in Shipment
-        dd
-          table.table 
-            thead 
-              tr 
-                th.col-md-2 UUID 
-                th.col-md-1 Number
-                th.col-md-1 Load Test Status
-                th.col-md-3 QR Code Link 
-
-            tbody 
-              each info in collectionDetails
-                tr
-                  td
-                    a(href = `/component/${info[0]}`, target = '_blank') #{info[0]}
-
-                  td #{info[1]}
-                  td #{info[2]}
-                  td #{`${base_url}/c/${info[3]}`}
-
-        a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
-          img.small-icon(src = '/images/checklist_icon.svg')
-          | &nbsp; Print all sub-component QR codes
     else
       .vert-space-x1.border-success.border.rounded.p-2
         #typeform

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -16,6 +16,7 @@ block extrascripts
     const base_url = '!{base_url}';
     const dictionary_queries = !{JSON.stringify(dictionary_queries, null, 4)};
     const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
+    const dictionary_populatedBoardShipmentSignoff = = !{JSON.stringify(dictionary_populatedBoardShipmentSignoff, null, 4)};
 
   block workscripts
     script(src = '/pages/component.js')
@@ -251,6 +252,11 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
+
+        if component.typeFormId === 'CEAdapterBoardShipment'
+          .vert-space-x1 
+            dt Engineering Release 
+            dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
     else if component.typeFormId === 'DWAComponentShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
@@ -373,6 +379,10 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
+
+        .vert-space-x1 
+          dt Engineering Release 
+          dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
 
         .vert-space-x1 
           dt Comments 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -9,6 +9,7 @@ block extrascripts
     const collectionDetails = !{JSON.stringify(collectionDetails, null, 4)};
     const installedGeometryBoards = !{JSON.stringify(installedGeometryBoards, null, 4)};
     const installedGeometryBoardsCount = !{JSON.stringify(installedGeometryBoardsCount, null, 4)};
+    const apaPostProductionWorkflowId = !{JSON.stringify(apaPostProductionWorkflowId, null, 4)};
     const actions = !{JSON.stringify(actions, null, 4)};
     const mostRecentAction = !{JSON.stringify(mostRecentAction, null, 4)};
     const actionTypeForms = !{JSON.stringify(actionTypeForms, null, 4)};
@@ -61,10 +62,36 @@ block content
                   +dateFormat(component.dateAtLocation)
                   | )
 
-            if component.workflowId
+            if component.typeFormId === 'APAFrame'
               dt Part of Workflow:
               dd
                 a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                |  (Frame Assembly)
+            else if component.typeFormId === 'APAShippingFrame'
+              if apaPostProductionWorkflowId
+                dt Part of Workflow:
+                dd
+                  a(href = `/workflow/${apaPostProductionWorkflowId}`, target = '_blank') #{apaPostProductionWorkflowId}
+                  |  (APA Post Production)
+            else if component.typeFormId === 'AssembledAPA'
+              dt Part of Workflow:
+
+              if !apaPostProductionWorkflowId
+                dd
+                  a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                  |  (APA Assembly)
+              else 
+                dd
+                  a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                  |  (APA Assembly)
+                  br
+                  a(href = `/workflow/${apaPostProductionWorkflowId}`, target = '_blank') #{apaPostProductionWorkflowId}
+                  |  (APA Post Production)
+            else if component.typeFormId === 'AssembledAPAShipment'
+              dt Part of Workflow:
+              dd
+                a(href = `/workflow/${component.workflowId}`, target = '_blank') #{component.workflowId}
+                |  (APA Post Production)
 
             if component.data.fromBatch
               dt Part of Batch:

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -253,10 +253,14 @@ block content
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
 
-        if component.typeFormId === 'CEAdapterBoardShipment'
-          .vert-space-x1 
-            dt Engineering Release 
-            dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
+        .vert-space-x1 
+          dt Engineering Release 
+          dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
+
+        .vert-space-x1 
+          dt Comments 
+          dd 
+            textarea.form-control#comments(rows = 5)
     else if component.typeFormId === 'DWAComponentShipment'
       .vert-space-x1.border-success.border.rounded.p-2
         dt Origin Location
@@ -379,10 +383,6 @@ block content
         a.btn.btn-secondary(href = `/component/${component.componentUuid}/batchQRCodes`, target = '_blank')
           img.small-icon(src = '/images/checklist_icon.svg')
           | &nbsp; Print all sub-component QR codes
-
-        .vert-space-x1 
-          dt Engineering Release 
-          dd #{dictionary_populatedBoardShipmentSignoff[component.data.engineeringRelease]}
 
         .vert-space-x1 
           dt Comments 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -16,7 +16,7 @@ block extrascripts
     const base_url = '!{base_url}';
     const dictionary_queries = !{JSON.stringify(dictionary_queries, null, 4)};
     const dictionary_locations = !{JSON.stringify(dictionary_locations, null, 4)};
-    const dictionary_populatedBoardShipmentSignoff = = !{JSON.stringify(dictionary_populatedBoardShipmentSignoff, null, 4)};
+    const dictionary_populatedBoardShipmentSignoff = !{JSON.stringify(dictionary_populatedBoardShipmentSignoff, null, 4)};
 
   block workscripts
     script(src = '/pages/component.js')

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -36,7 +36,7 @@ block content
               th.col-md-3 Assembled APA Shipment
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
-            else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
+            else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'InstallationHardwareShipment', 'PopulatedBoardShipment', 'SHVBoardShipment'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location
             else if (['CEAdapterBoard', 'CRBoard', 'CableHarness', 'DWA', 'DWAPDB', 'GBiasBoard', 'GeometryBoard', 'GroundingMeshPanel', 'SHVBoard'].includes(componentTypeForm.formId))
               th.col-md-2 Current Location

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -25,10 +25,15 @@ block content
       table.table
         thead
           tr
-            th.col-md-3 Component Name
+            if componentTypeForm.formId == 'APAShippingFrame'
+              th.col-md-2 Component Name
+            else 
+              th.col-md-3 Component Name
 
             if componentTypeForm.formId == 'APAFrame'
               th.col-md-2 Installed on APA
+            else if componentTypeForm.formId == 'APAShippingFrame'
+              th.col-md-3 Assembled APA Shipment
             else if componentTypeForm.formId == 'AssembledAPA'
               th.col-md-2 APA Frame
             else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId))
@@ -56,6 +61,9 @@ block content
                 if (component.typeFormId == 'APAFrame') && (component.additionalInformation[0] != '[')
                   td 
                     a(href = `/component/${component.locationDetail}`, target = '_blank') #{component.additionalInformation}
+                else if (component.typeFormId == 'APAShippingFrame') && (component.additionalInformation[0] != '[')
+                  td 
+                    a(href = `/component/${component.evenMoreInformation}`, target = '_blank') #{component.additionalInformation}
                 else if (component.typeFormId == 'AssembledAPA') && (component.additionalInformation[0] != '[')
                   td
                     a(href = `/component/${component.data.frameUuid}`, target = '_blank') #{component.additionalInformation}

--- a/app/pug/component_qrCodes.pug
+++ b/app/pug/component_qrCodes.pug
@@ -21,10 +21,13 @@ block allbody
   .vert-space-x2
     .container.fluid
       - const qrCodeURL = `${base_url}/c/${component.shortUuid.toString()}`;
-      - const qrCodeLabelLine1 = component.data.componentName;
+      - let qrCodeLabelLine1 = component.data.componentName;
       - const qrCodeLabelLine2 = component.componentUuid;
 
-      if (component.typeFormId === 'APAFrameShipment') || (component.typeFormId === 'AssembledAPAShipment') || (component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'DWAComponentShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'GeometryBoardShipment') || (component.typeFormId === 'GroundingMeshPanelShipment') || (component.typeFormId === 'PopulatedBoardShipment') || (component.typeFormId === 'SHVBoardShipment') || (component.typeFormId === 'YokeShipment')
+      if (component.typeFormId === 'APAFrameShipment') || (component.typeFormId === 'AssembledAPAShipment') || (component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'DWAComponentShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'GeometryBoardShipment') || (component.typeFormId === 'GroundingMeshPanelShipment') || (component.typeFormId === 'InstallationHardwareShipment') || (component.typeFormId === 'PopulatedBoardShipment') || (component.typeFormId === 'SHVBoardShipment')
+        if (component.typeFormId === 'InstallationHardwareShipment')
+          - qrCodeLabelLine1 = `InstallHardwShip. ${component.data.componentName.substring(31)}`;
+
         .row.qr-row
           .col-sm-6.qr-col
             +qr-panel-topLabel(qrCodeURL, qrCodeLabelLine1, qrCodeLabelLine2)

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -222,29 +222,6 @@ block allbody
                       td #{component.data.subComponent_typeRecordNumbers[index]}
                     else
                       td (not retrievable)
-      else if component.typeFormId === 'YokeShipment'
-        .vert-space-x1.border-success.border.rounded.p-2
-          dt Origin Location
-          dd #{dictionary_locations[component.data.originOfShipment]}
-
-          dt Destination Location
-          dd #{dictionary_locations[component.data.destinationOfShipment]}
-
-          dt Yokes in Shipment
-          dd
-            table.table 
-              thead 
-                tr 
-                  th.col-sm-1 UUID 
-                  th.col-sm-1 Number
-                  th.col-sm-1 Load Test Status 
-
-              tbody 
-                each info in collectionDetails
-                  tr
-                    td #{info[0]}
-                    td #{info[1]}
-                    td #{info[2]}
       else
         .vert-space-x1.border-success.border.rounded.p-2
           #componenttypeform

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -306,6 +306,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       actionTypeForms,
       dictionary_queries: req.query,
       dictionary_locations: utils.dictionary_locations,
+      dictionary_populatedBoardShipmentSignoff: utils.dictionary_populatedBoardShipmentSignoff,
       workflowComponent,
     });
   } catch (err) {

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -272,16 +272,6 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    if (component.typeFormId === 'YokeShipment') {
-      for (const info of component.data.yokeUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, dict_yokeLoadTestResults[componentRecord.data.loadTestStatus], componentRecord.shortUuid]);
-        }
-      }
-    }
-
     // If the specified component is an 'APA Shipping Frame' type, retrieve some more detailed information about any assembled APA shipments that contain it
     // If the specified component is an 'Assembled APA' type, also retrieve the same information, plus that about any geometry boards that have been installed on it
     let installedGeometryBoards = [];
@@ -439,6 +429,16 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       }
     }
 
+    if (component.typeFormId === 'InstallationHardwareShipment') {
+      for (const info of component.data.yokeUuiDs) {
+        if (info.component_uuid !== '') {
+          const componentRecord = await Components.retrieve(info.component_uuid);
+
+          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
+        }
+      }
+    }
+
     if (component.typeFormId === 'PopulatedBoardShipment') {
       for (const info of component.data.crBoardKitUuiDs) {
         if (info.component_uuid !== '') {
@@ -477,16 +477,6 @@ router.get('/component/:uuid/batchQRCodes', permissions.checkPermission('compone
       for (const uuid of component.data.subComponent_fullUuids) {
         if (uuid !== '') {
           const componentRecord = await Components.retrieve(uuid);
-
-          if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
-        }
-      }
-    }
-
-    if (component.typeFormId === 'YokeShipment') {
-      for (const info of component.data.yokeUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) shortUUIDs.push([componentRecord.data.componentName, componentRecord.componentUuid, componentRecord.shortUuid]);
         }
@@ -643,16 +633,6 @@ router.get('/component/:uuid/summary', permissions.checkPermission('components:v
           const componentRecord = await Components.retrieve(info.component_uuid);
 
           if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.componentName]);
-        }
-      }
-    }
-
-    if (component.typeFormId === 'YokeShipment') {
-      for (const info of component.data.yokeUuiDs) {
-        if (info.component_uuid !== '') {
-          const componentRecord = await Components.retrieve(info.component_uuid);
-
-          if (componentRecord) collectionDetails.push([componentRecord.componentUuid, componentRecord.data.typeRecordNumber, dict_yokeLoadTestResults[componentRecord.data.loadTestStatus]]);
         }
       }
     }
@@ -883,7 +863,7 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
         if (apaFrame) { assembledAPA.additionalInformation = apaFrame.data.componentName; }
         else { assembledAPA.additionalInformation = '[No APA Frame UUID Found!]'; }
       }
-    } else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'PopulatedBoardShipment', 'SHVBoardShipment', 'YokeShipment'].includes(componentTypeForm.formId)) {
+    } else if (['APAFrameShipment', 'AssembledAPAShipment', 'CEAdapterBoardShipment', 'CRBoardShipment', 'CableHarnessShipment', 'DWAComponentShipment', 'GBiasBoardShipment', 'GeometryBoardShipment', 'GroundingMeshPanelShipment', 'InstallationHardwareShipment', 'PopulatedBoardShipment', 'SHVBoardShipment'].includes(componentTypeForm.formId)) {
       for (let shipment of components) {
         if (shipment.location != null) { shipment.additionalInformation = utils.dictionary_locations[shipment.location]; }
         else { shipment.additionalInformation = '[location field missing!]'; }

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -282,16 +282,24 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       }
     }
 
-    // If the specified component is an 'Assembled APA' type, retrieve some more detailed information about any geometry boards that have been installed on it
+    // If the specified component is an 'APA Shipping Frame' type, retrieve some more detailed information about any assembled APA shipments that contain it
+    // If the specified component is an 'Assembled APA' type, also retrieve the same information, plus that about any geometry boards that have been installed on it
     let installedGeometryBoards = [];
     let installedGeometryBoardsCount = 0;
+    let apaPostProductionWorkflowId = null;
 
-    if (component.typeFormId === 'AssembledAPA') {
+    if (component.typeFormId === 'APAShippingFrame') {
+      const assembledAPAShipments = await Search_OtherComponents.apaShipmentsByAPAorASFUUID(req.params.uuid);
+      apaPostProductionWorkflowId = (assembledAPAShipments.length > 0) ? assembledAPAShipments[0].workflowId : null;
+    } else if (component.typeFormId === 'AssembledAPA') {
       installedGeometryBoards = await Search_GeoBoards.boardsByAPA(req.params.uuid);
 
       for (const boardGroup of installedGeometryBoards) {
         installedGeometryBoardsCount += boardGroup.componentUuids.length;
       }
+
+      const assembledAPAShipments = await Search_OtherComponents.apaShipmentsByAPAorASFUUID(req.params.uuid);
+      apaPostProductionWorkflowId = (assembledAPAShipments.length > 0) ? assembledAPAShipments[0].workflowId : null;
     }
 
     // Render the interface page
@@ -302,6 +310,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       collectionDetails,
       installedGeometryBoards,
       installedGeometryBoardsCount,
+      apaPostProductionWorkflowId,
       actions: nonWorkflowActions,
       mostRecentAction,
       actionTypeForms,
@@ -855,6 +864,17 @@ router.get('/components/:typeFormId/list', permissions.checkPermission('componen
 
         if (assembledAPA) { apaFrame.additionalInformation = assembledAPA.data.componentName; }
         else { apaFrame.additionalInformation = '[Not Currently in Use on an APA!]'; }
+      }
+    } else if (componentTypeForm.formId === 'APAShippingFrame') {
+      for (let asf of components) {
+        const assembledAPAShipments = await Search_OtherComponents.apaShipmentsByAPAorASFUUID(asf.componentUuid);
+
+        if (assembledAPAShipments.length > 0) {
+          asf.additionalInformation = assembledAPAShipments[0].data.componentName;
+          asf.evenMoreInformation = assembledAPAShipments[0].componentUuid;
+        } else {
+          asf.additionalInformation = '[Not Currently in Use on a Shipment!]';
+        }
       }
     } else if (componentTypeForm.formId === 'AssembledAPA') {
       for (let assembledAPA of components) {

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -202,10 +202,10 @@ router.get(['/json/yokeSignoff.json', '/api/yokeSignoff.json'], async function (
 });
 
 
-/// List personnel who are authorised to signoff on hardware installation at UW
-router.get(['/json/uwInstallationSignoff.json', '/api/uwInstallationSignoff.json'], async function (req, res, next) {
+/// List personnel who are authorised to signoff on populated board shipments
+router.get(['/json/populatedBoardShipmentSignoff.json', '/api/populatedBoardShipmentSignoff.json'], async function (req, res, next) {
   try {
-    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_uwInstallationSignoff));
+    return res.status(200).json(ConvertDictionaryToList(utils.dictionary_populatedBoardShipmentSignoff));
   } catch (err) {
     logger.info({ route: req.route.path }, err.message);
     res.status(500).json({ error: err.toString() });

--- a/app/static/pages/component.js
+++ b/app/static/pages/component.js
@@ -5,7 +5,7 @@ window.addEventListener('load', populateTypeForm);
 // Function to run when the page is loaded
 async function populateTypeForm() {
   if (component.typeFormId !== 'ReturnedGeometryBoardBatch') {
-    if (component.typeFormId === 'PopulatedBoardShipment') {
+    if ((component.typeFormId === 'CEAdapterBoardShipment') || (component.typeFormId === 'CRBoardShipment') || (component.typeFormId === 'CableHarnessShipment') || (component.typeFormId === 'GBiasBoardShipment') || (component.typeFormId === 'PopulatedBoardShipment') || (component.typeFormId === 'SHVBoardShipment')) {
       // Fill the value of the 'comments' page element (defined as a Bootstrap text area in the .pug file) from the component record
       $('#comments').val(component.data.comments);
     } else {


### PR DESCRIPTION
Improving connections between APAs, ASFs and APA Shipments
- each Assembled APA component info page will now show a link to the APA Post Production workflow whose APA Shipment component includes the APA in question (if the APA is not yet associated with a shipment component, no link will be shown)
- similarly, each ASF component info page will now show a link to the APA Post Production workflow whose APA Shipment component includes the ASF in question (and again, if the ASF is not yet associated with a shipment component, no link will be shown)
- the component listing page for ASFs will now show which APA Shipment it is associated with (or a message indicating otherwise, if the ASF is not yet in use)

New personnel list for populated board shipment signoff
- reusing currently unused 'UW Installation Signoff' personnel list for convenience

Replacing yoke shipments with general installation hardware shipments
- installation hardware includes more than just the yokes, so we need a shipment type that covers everything in one go
- previous 'YokeShipment' type component has been replaced with a new 'InstallationHardwareShipment' one, and similarly with their reception actions
- new shipment type should be displayed fully on the component info and summary pages (instead of a condensed version like other shipment-like components)
- when displaying QR codes for the new component type, use a shortened component name (otherwise it's too long, and the UUID gets pushed out)

Adding new inputs to populated board kit information pages
- populated board kits and shipments now include an Engineering Release input, plus a comments box (mainly to show who submitted them if creating via M2M)
- added these inputs to the bespoke component information pages for these component types (they don't show the entire type form, but instead use a reduced version tailored to each component type)

All changes have been tested on Staging.