### PR TITLE
Flattening validity and insertion objects (Part 1) ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -28,10 +28,13 @@ async function save(input, req) {
   //   - the action type form ID
   //   - the UUID of the component on which the action has been performed
   //   - user-provided data (may be empty of content, but must still exist)
+  //   - the submitting user's profile information
   if (!(input instanceof Object)) throw new Error(`Actions::save() - the 'input' object has not been specified!`);
   if (!input.hasOwnProperty('typeFormId')) throw new Error(`Actions::save() - the 'input.typeFormId' has not been specified!`);
   if (!input.hasOwnProperty('componentUuid')) throw new Error(`Actions::save() - the 'input.componentUuid' has not been specified!`);
   if (!input.hasOwnProperty('data')) throw new Error(`Actions::save() - the 'input.data' has not been specified!`);
+  if (!(req instanceof Object)) throw new Error(`Components::save() - the 'req' object has not been specified!`);
+  if (!req.hasOwnProperty('user')) throw new Error(`Components::save() - the 'req.user' has not been specified!`);
 
   // Check that there is an existing type form corresponding to the the provided type form ID, and that the type form is not currently 'trashed'
   const typeFormsList = await Forms.list('actionForms');
@@ -74,13 +77,19 @@ async function save(input, req) {
     }
   }
 
+  // Check if a record with the same action ID as the specified one already exists
+  // If so (i.e. the returned object is not 'null'), this indicates that we are editing an existing action, and if not (the returned object is 'null'), this is a new action
+  let oldRecord = (input.actionId) ? await retrieve(input.actionId) : null;
+
   // Set up a new record object, and immediately add information, either directly or inherited from the 'input' object
   let newRecord = {};
 
   newRecord.recordType = 'action';
-  newRecord.actionId = new ObjectId(input.actionId);
+  newRecord.recordDate = new Date();
+  newRecord.recordVersion = (oldRecord === null) ? 1 : parseInt(oldRecord.recordVersion) + 1;
   newRecord.typeFormId = typeForm.formId;
   newRecord.typeFormName = typeForm.formName;
+  newRecord.actionId = new ObjectId(input.actionId);
   newRecord.componentUuid = MUUID.from(input.componentUuid);
 
   const componentRecord = await Components.retrieve(newRecord.componentUuid);
@@ -95,9 +104,24 @@ async function save(input, req) {
     newRecord.componentTypeFormName = '[no component record found!]';
   }
 
+  if (input.workflowId) newRecord.workflowId = input.workflowId;
+
+  newRecord.userId = req.user.user_id;
+  newRecord.userName = req.user.displayName;
+  newRecord.userEmail = req.user.emails[0].value;
+
+  ///////////////////////////////
+  ////// DELETE THIS STUFF //////
+  // Generate and add an 'insertion' field to the new record
+  newRecord.insertion = commonSchema.insertion(req);
+
+  // Generate and add a 'validity' field to the new record, either from scratch (for a new record), or via incrementing that of the existing record (if editing)
+  newRecord.validity = commonSchema.validity(oldRecord);
+  newRecord.validity.ancestor_id = input._id;
+  ///////////////////////////////
+
   newRecord.data = input.data;
 
-  if (input.workflowId) newRecord.workflowId = input.workflowId;
   if (input.images) newRecord.images = input.images;
 
   // Winding and soldering actions each always contain an array of replaced wires or bad solder joints respectively ...
@@ -160,18 +184,6 @@ async function save(input, req) {
       }
     }
   }
-
-  // Generate and add an 'insertion' field to the new record
-  newRecord.insertion = commonSchema.insertion(req);
-
-  // Attempt to retrieve an existing record with the same action ID as the specified one (relevant if we are editing an existing record)
-  let oldRecord = null;
-
-  if (input.actionId) oldRecord = await retrieve(input.actionId);
-
-  // Generate and add a 'validity' field to the new record, either from scratch (for a new record), or via incrementing that of the existing record (if editing)
-  newRecord.validity = commonSchema.validity(oldRecord);
-  newRecord.validity.ancestor_id = input._id;
 
   // Insert the new record into the 'actions' records collection, and throw an error if the insertion fails
   let _lock = await dbLock(`saveAction_${newRecord.actionId}`, 1000);

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -10,43 +10,49 @@ const utils = require('./utils');
 const Workflows = require('./Workflows');
 
 
-async function setLocationInfo_allComponents() {
-  const result = await db.collection('components')
+async function setSubmissionInfo_singleCollection(collection) {
+  let result = await db.collection(collection)
     .updateMany(
       {},
       [
         {
           $set: {
-            'location': '$reception.location',
-            'dateAtLocation': '$reception.date',
-            'locationDetail': '$reception.detail',
+            'recordDate': '$insertion.insertDate',
+            'recordVersion': '$validity.version',
+            'userId': '$insertion.user.user_id',
+            'userName': '$insertion.user.displayName',
+            'userEmails': { $arrayElemAt: ["$insertion.user.emails", 0] },
           }
         },
       ]
     )
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::setLocationInfo_allComponents() - failed to add fields to the component record!`);
-
-  return result;
-}
-
-
-async function removeReceptionObject_allComponents() {
-  const result = await db.collection('components')
+  result = await db.collection(collection)
     .updateMany(
       {},
       [
-        { $unset: ['reception'] },
+        {
+          $set: {
+            'userEmail': '$userEmails.value',
+          }
+        },
       ]
     )
 
-  if (result.ok === 0) throw new Error(`Admin_Functions::removeReceptionObject_allComponents() - failed to remove object from the component record!`);
+  result = await db.collection(collection)
+    .updateMany(
+      {},
+      [
+        { $unset: ['userEmails'] },
+      ]
+    )
+
+  if (result.ok === 0) throw new Error(`Admin_Functions::setSubmissionInfo_singleCollection() - failed to add fields to the collection records!`);
 
   return result;
 }
 
 
 module.exports = {
-  setLocationInfo_allComponents,
-  removeReceptionObject_allComponents,
+  setSubmissionInfo_singleCollection,
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -35,10 +35,13 @@ async function save(input, req) {
   //   - the component UUID
   //   - the component type form ID
   //   - user-provided data (this may be an empty object, but must still exist)
+  //   - the submitting user's profile information
   if (!(input instanceof Object)) throw new Error(`Components::save() - the 'input' object has not been specified!`);
   if (!input.hasOwnProperty('componentUuid')) throw new Error(`Components::save() - the 'input.componentUuid' has not been specified!`);
   if (!input.hasOwnProperty('typeFormId')) throw new Error(`Components::save() - the 'input.typeFormId' has not been specified!`);
   if (!input.hasOwnProperty('data')) throw new Error(`Components::save() - the 'input.data' has not been specified!`);
+  if (!(req instanceof Object)) throw new Error(`Components::save() - the 'req' object has not been specified!`);
+  if (!req.hasOwnProperty('user')) throw new Error(`Components::save() - the 'req.user' has not been specified!`);
 
   // Check that there is an existing type form corresponding to the the provided type form ID, and that the type form is not currently 'trashed'
   const typeFormsList = await Forms.list('componentForms');
@@ -47,28 +50,38 @@ async function save(input, req) {
   if (!typeForm) throw new Error(`Components:save() - the specified 'input.typeFormId' (${input.typeFormId}) does not match a known component type form!`);
   if (typeForm.tags.includes('Trash')) throw new Error(`Components:save() - the specified component type form (${input.typeFormId}) is currently trashed, and cannot be used!`);
 
-  // Set up a new record object, and immediately add some information, either directly or inherited from the 'input' object
-  let newRecord = {};
-
-  newRecord.recordType = 'component';
-  newRecord.componentUuid = MUUID.from(input.componentUuid);
-  newRecord.shortUuid = ShortUUID().fromUUID(input.componentUuid);
-  newRecord.typeFormId = typeForm.formId;
-  newRecord.typeFormName = typeForm.formName;
-  newRecord.data = input.data;
-
-  if (input.workflowId) newRecord.workflowId = input.workflowId;
-
-  // Generate and add an 'insertion' field to the new record
-  newRecord.insertion = commonSchema.insertion(req);
-
   // Check if a record with the same component UUID as the specified one already exists
   // If so (i.e. the returned object is not 'null'), this indicates that we are editing an existing component, and if not (the returned object is 'null'), this is a new component
   let oldRecord = await retrieve(input.componentUuid);
 
+  // Set up a new record object, and immediately add some information, either directly or inherited from the 'input' object
+  let newRecord = {};
+
+  newRecord.recordType = 'component';
+  newRecord.recordDate = new Date();
+  newRecord.recordVersion = (oldRecord === null) ? 1 : parseInt(oldRecord.recordVersion) + 1;
+  newRecord.typeFormId = typeForm.formId;
+  newRecord.typeFormName = typeForm.formName;
+  newRecord.componentUuid = MUUID.from(input.componentUuid);
+  newRecord.shortUuid = ShortUUID().fromUUID(input.componentUuid);
+
+  if (input.workflowId) newRecord.workflowId = input.workflowId;
+
+  newRecord.userId = req.user.user_id;
+  newRecord.userName = req.user.displayName;
+  newRecord.userEmail = req.user.emails[0].value;
+
+  ///////////////////////////////
+  ////// DELETE THIS STUFF //////
+  // Generate and add an 'insertion' field to the new record
+  newRecord.insertion = commonSchema.insertion(req);
+
   // Generate and add a 'validity' field to the new record, either from scratch for a new component, or via incrementing that from the existing component's record
   newRecord.validity = commonSchema.validity(oldRecord);
   newRecord.validity.ancestor_id = input._id;
+  ///////////////////////////////
+
+  newRecord.data = input.data;
 
   // If saving a new component record, certain objects and fields need to be set up and populated
   // If editing an existing component record, this same information will either already exist (from being included when the 'input.data' object was copied over above) or can be directly copied

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -19,10 +19,13 @@ async function save(input, req) {
   //   - the workflow type form ID
   //   - user-provided data (may be empty of content, but must still exist)
   //   - a workflow path (the path steps will be checked later in this function)
+  //   - the submitting user's profile information
   if (!(input instanceof Object)) throw new Error(`Workflows::save() - the 'input' object has not been specified!`);
   if (!input.hasOwnProperty('typeFormId')) throw new Error(`Workflows::save() - the 'input.typeFormId' has not been specified!`);
   if (!input.hasOwnProperty('data')) throw new Error(`Workflows::save() - the 'input.data' has not been specified!`);
   if (!input.hasOwnProperty('path')) throw new Error(`Workflows::save() - the 'input.path' has not been specified!`);
+  if (!(req instanceof Object)) throw new Error(`Components::save() - the 'req' object has not been specified!`);
+  if (!req.hasOwnProperty('user')) throw new Error(`Components::save() - the 'req.user' has not been specified!`);
 
   // Check that there is an existing type form corresponding to the the provided type form ID, and that the type form is not currently 'trashed'
   const typeFormsList = await Forms.list('workflowForms');
@@ -43,30 +46,38 @@ async function save(input, req) {
   // Check that the first step of the workflow path is 'component' type (since component creation must always be performed first)
   if (!(input.path[0].type === 'component')) throw new Error(`Workflows::save() - the 'step.type' of the first step is not 'component'!`);
 
+  // Check if a record with the same workflow ID as the specified one already exists
+  // If so (i.e. the returned object is not 'null'), this indicates that we are editing an existing workflow, and if not (the returned object is 'null'), this is a new workflow
+  let oldRecord = (input.workflowId) ? await retrieve(input.workflowId) : null;
+
   // Set up a new record object, and immediately add information, either directly or inherited from the 'input' object
-  // If no type form name has been specified in the 'input' object, use the value from the type form instead
   let newRecord = {};
 
   newRecord.recordType = 'workflow';
-  newRecord.workflowId = new ObjectId(input.workflowId);
+  newRecord.recordDate = new Date();
+  newRecord.recordVersion = (oldRecord === null) ? 1 : parseInt(oldRecord.recordVersion) + 1;
   newRecord.typeFormId = typeForm.formId;
   newRecord.typeFormName = typeForm.formName;
-  newRecord.data = input.data;
-  newRecord.path = input.path;
-  newRecord.completionStatus = input.completionStatus;
-  newRecord.firstIncompleteAction = input.firstIncompleteAction;
+  newRecord.workflowId = new ObjectId(input.workflowId);
 
+  newRecord.userId = req.user.user_id;
+  newRecord.userName = req.user.displayName;
+  newRecord.userEmail = req.user.emails[0].value;
+
+  ///////////////////////////////
+  ////// DELETE THIS STUFF //////
   // Generate and add an 'insertion' field to the new record
   newRecord.insertion = commonSchema.insertion(req);
-
-  // Attempt to retrieve an existing record with the same workflow ID as the specified one (relevant if we are editing an existing record)
-  let oldRecord = null;
-
-  if (input.workflowId) oldRecord = await retrieve(input.workflowId);
 
   // Generate and add a 'validity' field to the new record, either from scratch (for a new record), or via incrementing that of the existing record (if editing)
   newRecord.validity = commonSchema.validity(oldRecord);
   newRecord.validity.ancestor_id = input._id;
+  ///////////////////////////////
+
+  newRecord.data = input.data;
+  newRecord.path = input.path;
+  newRecord.completionStatus = input.completionStatus;
+  newRecord.firstIncompleteAction = input.firstIncompleteAction;
 
   // Insert the new record into the 'workflows' records collection, and throw and error if the insertion fails
   let _lock = await dbLock(`saveWorkflow_${newRecord.workflowId}`, 1000);

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -55,7 +55,9 @@ block content
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'ALL_COMPONENTS') All Component Types (Remove Reception Object)
+            option(value = 'components') Components (Add Insertion and Validity Fields)
+            option(value = 'actions') Actions (Add Insertion and Validity Fields)
+            option(value = 'workflows') Workflows (Add Insertion and Validity Fields)
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -268,7 +268,7 @@ router.post(['/json/administratorUtility/:inputString', '/api/administratorUtili
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
 
-    let result = await Admin_Functions.removeReceptionObject_allComponents();    // Change as appropriate for the required utility
+    let result = await Admin_Functions.setSubmissionInfo_singleCollection(req.params.inputString);    // Change as appropriate for the required utility
 
     return res.status(201).json(result);
   } catch (err) {


### PR DESCRIPTION
- of the 6 total fields in the validity and insertion objects, 4 are actually used and 1 of those is a duplicate ... don't really any of them to be nested objects either
- new records will now write only the useful information directly into top-level fields
- changed administrator utility to copy the existing information into new top-level fields in existing records