### PR TITLE
Flattening validity and insertion objects (Part 2) ...

### DIFF
--- a/app/lib/Actions.js
+++ b/app/lib/Actions.js
@@ -110,16 +110,6 @@ async function save(input, req) {
   newRecord.userName = req.user.displayName;
   newRecord.userEmail = req.user.emails[0].value;
 
-  ///////////////////////////////
-  ////// DELETE THIS STUFF //////
-  // Generate and add an 'insertion' field to the new record
-  newRecord.insertion = commonSchema.insertion(req);
-
-  // Generate and add a 'validity' field to the new record, either from scratch (for a new record), or via incrementing that of the existing record (if editing)
-  newRecord.validity = commonSchema.validity(oldRecord);
-  newRecord.validity.ancestor_id = input._id;
-  ///////////////////////////////
-
   newRecord.data = input.data;
 
   if (input.images) newRecord.images = input.images;
@@ -309,7 +299,7 @@ async function addImageStrings(actionId, imageStringsArray, imageType) {
           $set: { 'data.shocklogPlotsImage': imageStringsArray[0] }
         },
         {
-          sort: { 'validity.version': -1 },
+          sort: { 'recordVersion': -1 },
           returnNewDocument: true,
           includeResultMetadata: true,
         },
@@ -323,7 +313,7 @@ async function addImageStrings(actionId, imageStringsArray, imageType) {
           $push: { 'images': { $each: imageStringsArray } }
         },
         {
-          sort: { 'validity.version': -1 },
+          sort: { 'recordVersion': -1 },
           returnNewDocument: true,
           includeResultMetadata: true,
         },
@@ -358,7 +348,7 @@ async function removeImageString(actionId, imageNumber) {
         $pull: { 'images': imageString }
       },
       {
-        sort: { 'validity.version': -1 },
+        sort: { 'recordVersion': -1 },
         returnNewDocument: true,
         includeResultMetadata: true,
       },
@@ -391,7 +381,7 @@ async function retrieve(actionId, projection) {
   // Then sort any matching records such that the most recent version is first in the list
   let records = await db.collection('actions')
     .find(match_condition, options)
-    .sort({ 'validity.version': -1 })
+    .sort({ 'recordVersion': -1 })
     .toArray();
 
   // If there is at least one matching record ...
@@ -423,7 +413,7 @@ async function versions(actionId) {
   // Then sort any matching records such that the most recent version is first in the list
   let records = await db.collection('actions')
     .find(match_condition)
-    .sort({ 'validity.version': -1 })
+    .sort({ 'recordVersion': -1 })
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display
@@ -451,38 +441,39 @@ async function list(match_condition) {
   // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
   aggregation_stages.push({
     $project: {
+      recordDate: true,
+      recordVersion: true,
       actionId: true,
       typeFormId: true,
       typeFormName: true,
       componentUuid: true,
       componentName: true,
       workflowId: true,
-      validity: true,
       data: true,
     }
   })
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by the record version ... highest first
   // Then group the records by the action ID (i.e. each group contains all versions of the same action), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
+      recordDate: { '$first': '$recordDate' },
       actionId: { '$first': '$actionId' },
       typeFormId: { '$first': '$typeFormId' },
       typeFormName: { '$first': '$typeFormName' },
       componentUuid: { '$first': '$componentUuid' },
       componentName: { '$first': '$componentName' },
       workflowId: { '$first': '$workflowId' },
-      lastEditDate: { '$first': '$validity.startDate' },
       data: { '$first': '$data' },
     },
   });
 
-  // Re-sort the records by last edit date ... most recent first
-  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  // Re-sort the records by record date ... most recent first
+  aggregation_stages.push({ $sort: { recordDate: -1 } });
 
   // Limit the number of returned records to something reasonable ... this will be further reduced later on, but only after the optional filter on component type form ID has been applied if needed
   aggregation_stages.push({ $limit: 1000 });
@@ -511,10 +502,10 @@ async function boardRejectionCounts_byPartNumberAndLocation() {
   });
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by record version ... highest first
   // Then group the records by the component UUID (i.e. each group contains all versions of the same component), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -596,21 +587,21 @@ async function autoCompleteId(inputString, limit = 10) {
   aggregation_stages.push({ $match: match_condition });
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by record version ... highest first
   // Then group the records by the action ID (i.e. each group contains all versions of the same action), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
+      recordDate: { '$first': '$recordDate' },
       actionId: { '$first': '$actionId' },
       typeFormName: { '$first': '$typeFormName' },
-      lastEditDate: { '$first': '$validity.startDate' },
     },
   });
 
-  // Re-sort the records by last edit date ... most recent first
-  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  // Re-sort the records by record date ... most recent first
+  aggregation_stages.push({ $sort: { recordDate: -1 } });
 
   // Limit the number of returned matching records, just so the interface doesn't get too busy
   aggregation_stages.push({ $limit: limit });

--- a/app/lib/Admin_Functions.js
+++ b/app/lib/Admin_Functions.js
@@ -53,6 +53,22 @@ async function setSubmissionInfo_singleCollection(collection) {
 }
 
 
+async function removeValidityInsertion_singleCollection(collection) {
+  let result = await db.collection(collection)
+    .updateMany(
+      {},
+      [
+        { $unset: ['validity', 'insertion'] },
+      ]
+    )
+
+  if (result.ok === 0) throw new Error(`Admin_Functions::removeValidityInsertion_singleCollection() - failed to remove fields from the collection records!`);
+
+  return result;
+}
+
+
 module.exports = {
   setSubmissionInfo_singleCollection,
+  removeValidityInsertion_singleCollection,
 }

--- a/app/lib/Components.js
+++ b/app/lib/Components.js
@@ -71,16 +71,6 @@ async function save(input, req) {
   newRecord.userName = req.user.displayName;
   newRecord.userEmail = req.user.emails[0].value;
 
-  ///////////////////////////////
-  ////// DELETE THIS STUFF //////
-  // Generate and add an 'insertion' field to the new record
-  newRecord.insertion = commonSchema.insertion(req);
-
-  // Generate and add a 'validity' field to the new record, either from scratch for a new component, or via incrementing that from the existing component's record
-  newRecord.validity = commonSchema.validity(oldRecord);
-  newRecord.validity.ancestor_id = input._id;
-  ///////////////////////////////
-
   newRecord.data = input.data;
 
   // If saving a new component record, certain objects and fields need to be set up and populated
@@ -156,13 +146,13 @@ async function save(input, req) {
       newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300400003-${typeRecordNumber}-US200-010000`;
     } else if (newRecord.typeFormId === 'CEAdapterBoardBatch') {
-      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     } else if (newRecord.typeFormId === 'CRBoard') {
       newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300400001-${typeRecordNumber}-US200-010000`;
     } else if (newRecord.typeFormId === 'CRBoardBatch') {
-      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     } else if (newRecord.typeFormId === 'CableHarness') {
       if (newRecord.data.cableHarnessSide === 'a') {
@@ -182,7 +172,7 @@ async function save(input, req) {
       newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber}`;
       newRecord.data.dunePid = `D00300400002-${typeRecordNumber}-US200-010000`;
     } else if (newRecord.typeFormId === 'GBiasBoardBatch') {
-      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+      newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.subComponent_count}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
       newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
     } else if (newRecord.typeFormId === 'GeometryBoard') {
       newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.partString})`;
@@ -271,19 +261,19 @@ async function save(input, req) {
     newRecord.data.componentName = `${newRecord.typeFormName} (${name_apa1} + ${name_apa2})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'CEAdapterBoardShipment') {
-    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'CRBoardShipment') {
-    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'CableHarnessShipment') {
-    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'DWAComponentShipment') {
     newRecord.data.componentName = `${newRecord.typeFormName} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'GBiasBoardShipment') {
-    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'GeometryBoardShipment') {
     newRecord.data.componentName = `${newRecord.typeFormName} (${newRecord.data.boardUuiDs.length}.${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
@@ -298,7 +288,7 @@ async function save(input, req) {
     newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${utils.dictionary_locations[newRecord.data.originOfShipment]}.${utils.dictionary_locations[newRecord.data.destinationOfShipment]})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   } else if (newRecord.typeFormId === 'SHVBoardShipment') {
-    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.validity.startDate.toISOString().substring(0, 10)})`;
+    newRecord.data.componentName = `${newRecord.typeFormName} ${typeRecordNumber} (${newRecord.data.boardUuiDs.length}.${newRecord.recordDate.toISOString().substring(0, 10)})`;
     newRecord.data.dunePid = `D003MMMNNNNN-${typeRecordNumber}-COIII-010000`;
   }
 
@@ -516,7 +506,7 @@ async function retrieve(componentUuid, projection) {
   // Then sort any matching records such that the most recent version is first in the list
   let records = await db.collection('components')
     .find(match_condition, options)
-    .sort({ 'validity.version': -1 })
+    .sort({ 'recordVersion': -1 })
     .toArray();
 
   // If there is at least one matching record ...
@@ -551,7 +541,7 @@ async function versions(componentUuid) {
   // Then sort any matching records such that the most recent version is first in the list
   let records = await db.collection('components')
     .find(match_condition)
-    .sort({ 'validity.version': -1 })
+    .sort({ 'recordVersion': -1 })
     .toArray();
 
   // Convert the 'componentUuid' of each matching record from binary to string format, for better readability and consistent display
@@ -581,40 +571,41 @@ async function list(match_condition, options) {
   // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
   aggregation_stages.push({
     $project: {
+      recordDate: true,
+      recordVersion: true,
       componentUuid: true,
       typeFormId: true,
       typeFormName: true,
       data: true,
-      validity: true,
       location: true,
       locationDetail: true,
     }
   })
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by record version ... highest first
   // Then group the records by the component UUID (i.e. each group contains all versions of the same component), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
+      recordDate: { '$first': '$recordDate' },
       componentUuid: { '$first': '$componentUuid' },
       typeFormId: { '$first': '$typeFormId' },
       typeFormName: { '$first': '$typeFormName' },
       data: { '$first': '$data' },
       componentName: { '$first': '$data.componentName' },
-      lastEditDate: { '$first': '$validity.startDate' },
       location: { '$first': '$location' },
       locationDetail: { '$first': '$locationDetail' },
     },
   });
 
-  // Re-sort the records ... by (alphanumerical) component name for APA Frames, ASFs and Assembled APAs, or by last edit date (most recent first) for other component types
+  // Re-sort the records ... by (alphanumerical) component name for APA Frames, ASFs and Assembled APAs, or by record date (most recent first) for other component types
   if ((match_condition) && (match_condition.typeFormId) && (['APAFrame', 'APAShippingFrame', 'AssembledAPA'].includes(match_condition.typeFormId))) {
     aggregation_stages.push({ $sort: { componentName: -1 } });
   } else {
-    aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+    aggregation_stages.push({ $sort: { recordDate: -1 } });
   }
 
   // Add aggregation stages for any additionally specified options
@@ -706,18 +697,18 @@ async function boardCounts_byPartNumberAndLocation() {
   // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
   aggregation_stages.push({
     $project: {
+      recordVersion: true,
       componentUuid: true,
       data: true,
       location: true,
-      validity: true,
     }
   })
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by record version ... highest first
   // Then group the records by the component UUID (i.e. each group contains all versions of the same component), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -783,22 +774,22 @@ async function autoCompleteUuid(inputString, limit = 10) {
   aggregation_stages.push({ $match: match_condition });
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by record version ... highest first
   // Then group the records by the component UUID (i.e. each group contains all versions of the same component), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
+      recordDate: { '$first': '$recordDate' },
       componentUuid: { '$first': '$componentUuid' },
       typeFormName: { '$first': '$typeFormName' },
       componentName: { '$first': '$data.componentName' },
-      lastEditDate: { '$first': '$validity.startDate' },
     },
   });
 
-  // Re-sort the records by last edit date ... most recent first
-  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  // Re-sort the records by record date ... most recent first
+  aggregation_stages.push({ $sort: { recordDate: -1 } });
 
   // Limit the number of returned matching records, just so the interface doesn't get too busy
   aggregation_stages.push({ $limit: limit });

--- a/app/lib/Components_CollateInfo.js
+++ b/app/lib/Components_CollateInfo.js
@@ -200,13 +200,13 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
       section: { '$first': '$data.workflowSectionBeingQAed' },
       name: { '$first': '$data.personSigningOff' },
-      date: { '$first': '$validity.startDate' },
+      date: { '$first': '$recordDate' },
       actionId: { '$first': '$actionId' },
     },
   });
@@ -241,7 +241,7 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -267,7 +267,7 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -295,12 +295,12 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
       name: { '$first': '$data.closeUpSignoff' },
-      date: { '$first': '$validity.startDate' },
+      date: { '$first': '$recordDate' },
       actionId: { '$first': '$actionId' },
     },
   });
@@ -325,7 +325,7 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -351,7 +351,7 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -379,12 +379,12 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
       name: { '$first': '$data.personSigningOff' },
-      date: { '$first': '$validity.startDate' },
+      date: { '$first': '$recordDate' },
       actionId: { '$first': '$actionId' },
     },
   });
@@ -409,7 +409,7 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -435,7 +435,7 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -462,12 +462,12 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
       name: { '$first': '$data.personSigningOff' },
-      date: { '$first': '$validity.startDate' },
+      date: { '$first': '$recordDate' },
       actionId: { '$first': '$actionId' },
       fdhd: { '$first': '$data.fdhdTechCoordSigningOff' },
     },
@@ -500,7 +500,7 @@ async function forExecSummary(componentUUID) {
       }
     });
 
-    aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+    aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
     aggregation_stages.push({
       $group: {
         _id: { actionId: '$actionId' },
@@ -564,7 +564,7 @@ async function forExecSummary(componentUUID) {
       }
     });
 
-    aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+    aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
     aggregation_stages.push({
       $group: {
         _id: { actionId: '$actionId' },
@@ -605,7 +605,7 @@ async function forExecSummary(componentUUID) {
       }
     });
 
-    aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+    aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
     aggregation_stages.push({
       $group: {
         _id: { actionId: '$actionId' },
@@ -644,7 +644,7 @@ async function forExecSummary(componentUUID) {
     }
   });
 
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },

--- a/app/lib/Search_ActionsWorkflows.js
+++ b/app/lib/Search_ActionsWorkflows.js
@@ -38,7 +38,7 @@ async function workflowsByUUID(componentUUID) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { workflowId: '$workflowId' },
@@ -70,7 +70,7 @@ async function nonConformanceByComponentType(componentType, disposition, status)
 
   // Select the latest version of each record, and pass through only the fields required for later use
   // Then sort the records reverse alphabetically by the 'componentName' field
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -144,7 +144,7 @@ async function nonConformanceByUUID(componentUUID) {
 
   // Select the latest version of each record, and pass through only the fields required for later use
   // Then sort the records reverse alphabetically by the 'actionId' field
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -185,7 +185,7 @@ async function nonConformanceByUUID(componentUUID) {
     }
   }
 
-  // Return the list of  atching actions
+  // Return the list of matching actions
   return results;
 }
 
@@ -202,7 +202,7 @@ async function boardInstallByReferencedComponent(componentUUID) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -269,7 +269,7 @@ async function windingByReferencedComponent(componentUUID) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -317,7 +317,7 @@ async function boardRejectionByReferencedComponent(componentUUID) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -354,7 +354,7 @@ async function tensionComparisonAcrossLocations(componentUUID, wireLayer, origin
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },

--- a/app/lib/Search_GeoBoards.js
+++ b/app/lib/Search_GeoBoards.js
@@ -16,7 +16,7 @@ async function boardsByVisualInspection(disposition, issue) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  action_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  action_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   action_aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -69,7 +69,7 @@ async function boardsByVisualInspection(disposition, issue) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  comp_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  comp_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   comp_aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -136,7 +136,7 @@ async function boardsByVisualInspection(disposition, issue) {
       });
 
       // Order the records by the '_id' field (highest value first) - this ObjectId is generated sequentially for each record (higher ones for newer records) ... 
-      // ... this is a work-around for the fact that we don't save the record insertion dates as actual date objects which can be sorted, but instead as strings which are more tricky to order)
+      // ... this is a work-around for the fact that we previously didn't save the record dates as actual date objects which can be sorted, but instead as strings which are more tricky to order
       perBoard_action_aggregation_stages.push({ $sort: { _id: -1 } });
 
       // Query the 'actions' records collection using the aggregation stages defined above
@@ -206,7 +206,7 @@ async function boardsByOrderNumber(orderNumber) {
   // Select the latest version of each record, and pass through only the fields required for later use
   // Note that because the sub-component geometry board UUID structure is different between the two types of batches, we must attempt to pass both of them ...
   // ... the one that doesn't exist for the given batch type will just be an empty field
-  comp_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  comp_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   comp_aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -257,7 +257,7 @@ async function boardsByOrderNumber(orderNumber) {
     });
 
     // Select the latest version of each record, and pass through only the fields required for later use
-    action_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+    action_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
     action_aggregation_stages.push({
       $group: {
         _id: { actionId: '$actionId' },
@@ -271,7 +271,7 @@ async function boardsByOrderNumber(orderNumber) {
     // At this point, we have the latest version of every 'Visual Inspection' action performed on each board
     // Select the single action that was mostly recently performed on each board, and pass through only the fields required for later use
     // Note that this starts by ordering the records by the '_id' field (highest value first) - this ObjectId is generated sequentially for each record (higher ones for newer records) ... 
-    // ... this is a work-around for the fact that we don't save the record insertion dates as actual date objects which can be sorted, but instead as strings which are more tricky to order)
+    // ... this is a work-around for the fact that we previously didn't save the record dates as actual date objects which can be sorted, but instead as strings which are more tricky to order
     action_aggregation_stages.push({ $sort: { _id: -1 } });
     action_aggregation_stages.push({
       $group: {
@@ -351,7 +351,7 @@ async function boardsByAPA(apaUUID) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },

--- a/app/lib/Search_OtherComponents.js
+++ b/app/lib/Search_OtherComponents.js
@@ -24,13 +24,13 @@ async function geoBoardShipmentsByReceptionDetails(status, origin, destination, 
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  comp_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  comp_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   comp_aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
+      recordDate: { '$first': '$recordDate' },
       componentUuid: { '$first': '$componentUuid' },
       data: { '$first': '$data' },
-      startDate: { '$first': '$validity.startDate' },
     },
   });
 
@@ -58,7 +58,7 @@ async function geoBoardShipmentsByReceptionDetails(status, origin, destination, 
     });
 
     // Select the latest version of each record, and pass through only the fields required for later use
-    action_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+    action_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
     action_aggregation_stages.push({
       $group: {
         _id: { actionId: '$actionId' },
@@ -77,7 +77,7 @@ async function geoBoardShipmentsByReceptionDetails(status, origin, destination, 
     let shipment = {
       uuid: shipmentRecord.componentUuid,
       numberOfBoards: shipmentRecord.data.boardUuiDs.length,
-      creationDate: (shipmentRecord.startDate.toISOString().split('T'))[0],
+      creationDate: (shipmentRecord.recordDate.toISOString().split('T'))[0],
       origin: shipmentRecord.data.originOfShipment,
       destination: shipmentRecord.data.destinationOfShipment,
       receptionDate: '[n.a.]',
@@ -152,17 +152,17 @@ async function geoBoardShipmentsByBoardUUID(componentUUID) {
   aggregation_stages.push({ $match: { 'typeFormId': 'GeometryBoardShipment' } });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
+      recordDate: { '$first': '$recordDate' },
       componentUuid: { '$first': '$componentUuid' },
       typeFormId: { '$first': '$typeFormId' },
       typeFormName: { '$first': '$typeFormName' },
       data: { '$first': '$data' },
       location: { '$first': '$location' },
       dateAtLocation: { '$first': '$dateAtLocation' },
-      lastEditDate: { '$first': '$validity.startDate' },
     },
   });
 
@@ -196,7 +196,7 @@ async function apasByProductionLocationAndNumber(location, number) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -249,7 +249,7 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
 
   // Select the latest version of each record, and pass through only the fields required for later use
   // Then sort the records reverse alphabetically by the 'componentName' field
-  action_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  action_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   action_aggregation_stages.push({
     $group: {
       _id: { actionId: '$actionId' },
@@ -298,7 +298,7 @@ async function apasByProductionLocationAndAssemblyStep(location, assemblyStep) {
 
   // Select the latest version of each record, and pass through only the fields required for later use
   // Then sort the records reverse alphabetically by the 'componentName' field
-  comp_aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  comp_aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   comp_aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -330,7 +330,7 @@ async function apaShipmentsByAPAorASFUUID(componentUUID) {
   aggregation_stages.push({ $match: { 'typeFormId': 'AssembledAPAShipment' } });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -353,8 +353,8 @@ async function apaShipmentsByAPAorASFUUID(componentUUID) {
     }
   });
 
-  // Re-sort the records by last edit date ... most recent first
-  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  // Re-sort the records by the record date ... most recent first
+  aggregation_stages.push({ $sort: { recordDate: -1 } });
 
   // Query the 'components' records collection using the aggregation stages defined above
   let shipments = await db.collection('components')
@@ -376,7 +376,7 @@ async function componentsByDUNEPID(dunePID) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -407,7 +407,7 @@ async function componentsByTypeAndNumber(typeFormId, typeRecordNumber) {
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },
@@ -449,7 +449,7 @@ async function componentsByTypeAndLocation(typeFormId, location, toothStripStatu
   });
 
   // Select the latest version of each record, and pass through only the fields required for later use (dependent on the specified component type)
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
 
   if (typeFormId === 'GeometryBoard') {
     aggregation_stages.push({
@@ -718,7 +718,7 @@ async function componentsByTypeAndPartNumber(typeFormId, partNumber, acceptanceS
   }
 
   // Select the latest version of each record, and pass through only the fields required for later use
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { componentUuid: '$componentUuid' },

--- a/app/lib/Workflows.js
+++ b/app/lib/Workflows.js
@@ -64,16 +64,6 @@ async function save(input, req) {
   newRecord.userName = req.user.displayName;
   newRecord.userEmail = req.user.emails[0].value;
 
-  ///////////////////////////////
-  ////// DELETE THIS STUFF //////
-  // Generate and add an 'insertion' field to the new record
-  newRecord.insertion = commonSchema.insertion(req);
-
-  // Generate and add a 'validity' field to the new record, either from scratch (for a new record), or via incrementing that of the existing record (if editing)
-  newRecord.validity = commonSchema.validity(oldRecord);
-  newRecord.validity.ancestor_id = input._id;
-  ///////////////////////////////
-
   newRecord.data = input.data;
   newRecord.path = input.path;
   newRecord.completionStatus = input.completionStatus;
@@ -110,7 +100,7 @@ async function updatePathStep(workflowId, stepIndex, stepResult) {
       { 'workflowId': new ObjectId(workflowId) },
       update,
       {
-        sort: { 'validity.version': -1 },
+        sort: { 'recordVersion': -1 },
         returnNewDocument: true,
         includeResultMetadata: true,
       },
@@ -161,7 +151,7 @@ async function updateCompletionStatus(workflowId) {
         }
       },
       {
-        sort: { 'validity.version': -1 },
+        sort: { 'recordVersion': -1 },
         returnNewDocument: true,
         includeResultMetadata: true,
       },
@@ -196,7 +186,7 @@ async function retrieve(workflowId, projection) {
   // Then sort any matching records such that the most recent version is first in the list
   let records = await db.collection('workflows')
     .find(match_condition, options)
-    .sort({ 'validity.version': -1 })
+    .sort({ 'recordVersion': -1 })
     .toArray();
 
   // If there is at least one matching record ...
@@ -225,7 +215,7 @@ async function versions(workflowId) {
   // Then sort any matching records such that the most recent version is first in the list
   let records = await db.collection('workflows')
     .find(match_condition)
-    .sort({ 'validity.version': -1 })
+    .sort({ 'recordVersion': -1 })
     .toArray();
 
   // Return the entire list of matching records
@@ -243,36 +233,37 @@ async function list(match_condition, options) {
   // Keep only the minimal required fields from each record for subsequent aggregation stages (this reduces memory usage)
   aggregation_stages.push({
     $project: {
+      recordDate: true,
+      recordVersion: true,
       workflowId: true,
       typeFormId: true,
       typeFormName: true,
       path: true,
       completionStatus: true,
       firstIncompleteAction: true,
-      validity: true,
     }
   })
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by record version ... highest first
   // Then group the records by the workflow ID (i.e. each group contains all versions of the same workflow), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { workflowId: '$workflowId' },
-      workflowId: { '$first': '$workflowId' },
+      recordDate: { '$first': '$recordDate' },
       typeFormId: { '$first': '$typeFormId' },
       typeFormName: { '$first': '$typeFormName' },
+      workflowId: { '$first': '$workflowId' },
       path: { '$first': '$path' },
       completionStatus: { '$first': '$completionStatus' },
       firstIncompleteAction: { '$first': '$firstIncompleteAction' },
-      lastEditDate: { '$first': '$validity.startDate' },
     },
   });
 
-  // Re-sort the records by last edit date ... most recent first
-  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  // Re-sort the records by record date ... most recent first
+  aggregation_stages.push({ $sort: { recordDate: -1 } });
 
   // Add aggregation stages for any additionally specified options that should be dealt with at the MongoDB aggregation stage
   if (options) {
@@ -350,21 +341,21 @@ async function autoCompleteId(inputString, limit = 10) {
   aggregation_stages.push({ $match: match_condition });
 
   // Select only the latest version of each record
-  // First sort the matching records by validity ... highest version first
+  // First sort the matching records by record version ... highest first
   // Then group the records by the workflow ID (i.e. each group contains all versions of the same workflow), and select only the first (highest version number) entry in each group
   // Finally, set which fields in the first record are to be returned for use in subsequent aggregation stages
-  aggregation_stages.push({ $sort: { 'validity.version': -1 } });
+  aggregation_stages.push({ $sort: { 'recordVersion': -1 } });
   aggregation_stages.push({
     $group: {
       _id: { workflowId: '$workflowId' },
-      workflowId: { '$first': '$workflowId' },
+      recordDate: { '$first': '$recordDate' },
       typeFormName: { '$first': '$typeFormName' },
-      lastEditDate: { '$first': '$validity.startDate' },
+      workflowId: { '$first': '$workflowId' },
     },
   });
 
-  // Re-sort the records by last edit date ... most recent first
-  aggregation_stages.push({ $sort: { lastEditDate: -1 } });
+  // Re-sort the records by record date ... most recent first
+  aggregation_stages.push({ $sort: { recordDate: -1 } });
 
   // Limit the number of returned matching records, just so the interface doesn't get too busy
   aggregation_stages.push({ $limit: limit });

--- a/app/pug/action.pug
+++ b/app/pug/action.pug
@@ -46,14 +46,12 @@ block content
                 a(href = `/workflow/${action.workflowId}`, target = '_blank') #{action.workflowId}
 
             dt Current Action Version:
-            dd This is version #{action.validity.version} of the action.
+            dd This is version #{action.recordVersion} of the action.
               br
               | It was last performed on !{' '}
-              +dateTimeFormat(action.insertion.insertDate)
-
-              if action.insertion.user
-                |  by !{' '}
-                a(href = `mailto:${user_email(action.insertion.user)}`) #{action.insertion.user.displayName}
+              +dateTimeFormat(action.recordDate)
+              |  by !{' '}
+              a(href = `mailto:${action.userEmail}`) #{action.userName}
 
             .vert-space-x1
               .panel.panel-default
@@ -65,13 +63,11 @@ block content
                 ul
                   each v in actionVersions
                     li 
-                      a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
+                      a(href = `?version=${v.recordVersion}`) Version #{v.recordVersion}
                       |  on 
-                      +dateTimeFormat(v.insertion.insertDate)
-
-                      if v.insertion.user
-                        |  by !{' '}
-                        a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
+                      +dateTimeFormat(v.recordDate)
+                      |  by !{' '}
+                      a(href = `mailto:${v.userEmail}`) #{v.userName}
 
         .col-sm-4 
           .vert-space-x2.form-inline

--- a/app/pug/action_list.pug
+++ b/app/pug/action_list.pug
@@ -31,7 +31,7 @@ block content
                   a(href = `/component/${uuid}`) #{action.componentName}
                 td
                 td
-                  +dateTimeFormat(action.lastEditDate)
+                  +dateTimeFormat(action.recordDate)
                 td
                   a.btn-sm.btn-secondary(href = `/json/action/${action.actionId}`, target = '_blank')
                     img.small-icon(src = '/images/checklist_icon.svg')

--- a/app/pug/action_listOfSingleType.pug
+++ b/app/pug/action_listOfSingleType.pug
@@ -50,7 +50,7 @@ block content
                 td #{action.additionalInformation} 
 
                 td
-                  +dateTimeFormat(action.lastEditDate)
+                  +dateTimeFormat(action.recordDate)
                 td
                   a.btn-sm.btn-secondary(href = `/json/action/${action.actionId}`, target = '_blank')
                     img.small-icon(src = '/images/checklist_icon.svg')

--- a/app/pug/administratorUtility.pug
+++ b/app/pug/administratorUtility.pug
@@ -55,9 +55,9 @@ block content
 
           select.form-control#inputStringSelection
             option(value = '')
-            option(value = 'components') Components (Add Insertion and Validity Fields)
-            option(value = 'actions') Actions (Add Insertion and Validity Fields)
-            option(value = 'workflows') Workflows (Add Insertion and Validity Fields)
+            option(value = 'components') Components (Remove Insertion and Validity Fields)
+            option(value = 'actions') Actions (Remove Insertion and Validity Fields)
+            option(value = 'workflows') Workflows (Remove Insertion and Validity Fields)
 
           .vert-space-x2 
             button.btn-primary.btn-lg#confirmButton Confirm

--- a/app/pug/common.pug
+++ b/app/pug/common.pug
@@ -1,13 +1,4 @@
 block pugscripts
-  //- Return the appropriate boolean flag ('true' or 'false') based on the 'truthiness' of the user authentication
-  - const isAuthenticated = () => !!user;
-
-  //- Return the user's primary email address if the user is authenticated, or an error message if not
-  - function user_email(user) { if (isAuthenticated()) return (user.emails[0].value); return '[Login to see!]' };
-
-  //- Return the user's display name if the user is authenticated (or the email address if no display name has been set), or an error message if not
-  - function user_shortname(user) { if (isAuthenticated()) return (user.displayName || user_email(user)); return '[Login to see!]' };
-
   //- Return the ordinal of a given number when provided with the remainders of that number divided by 10 and 100
   - function get_ordinal(r10, r100) { if (r10 === 1 && r100 !== 100) return 'st'; if (r10 === 2 && r100 !== 12) return 'nd'; if (r10 === 3 && r100 !== 13) return 'rd'; return 'th'; }
 

--- a/app/pug/component.pug
+++ b/app/pug/component.pug
@@ -105,17 +105,15 @@ block content
                 a(href = `/action/${mostRecentAction.actionId}`, target = '_blank') #{mostRecentAction.typeFormName}
                 br
                 | This action was last edited on !{' '}
-                +dateTimeFormat(mostRecentAction.lastEditDate)
+                +dateTimeFormat(mostRecentAction.recordDate)
 
             dt Current Component Version:
-            dd This is version #{component.validity.version} of the component.
+            dd This is version #{component.recordVersion} of the component.
               br
               | It was last edited on !{' '}
-              +dateTimeFormat(component.insertion.insertDate)
-
-              if component.insertion.user
-                |  by !{' '}
-                a(href = `mailto:${user_email(component.insertion.user)}`) #{component.insertion.user.displayName}
+              +dateTimeFormat(component.recordDate)
+              |  by !{' '}
+              a(href = `mailto:${component.userEmail}`) #{component.userName}
 
             .vert-space-x1
               .panel.panel-default
@@ -127,13 +125,11 @@ block content
                 ul
                   each v in componentVersions
                     li 
-                      a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
+                      a(href = `?version=${v.recordVersion}`) Version #{v.recordVersion}
                       |  on 
-                      +dateTimeFormat(v.insertion.insertDate)
-
-                      if v.insertion.user
-                        |  by !{' '}
-                        a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
+                      +dateTimeFormat(v.recordDate)
+                      |  by !{' '}
+                      a(href = `mailto:${v.userEmail}`) #{v.userName}
 
         .col-sm-4
           .vert-space-x2.form-inline
@@ -480,7 +476,7 @@ block content
                     td 
                       a(href = `/action/${entry.actionId}`) #{entry.typeFormName}
 
-                  td #{entry.lastEditDate.toISOString().slice(0, 10)}
+                  td #{entry.recordDate.toISOString().slice(0, 10)}
                   td #{dictionary_locations[entry.data.originOfShipment]}
 
                   if entry.typeFormName === 'Geometry Board Shipment'
@@ -604,7 +600,7 @@ block content
                         a(href = `/action/${action.actionId}`) #{action.actionId}
 
                       td
-                        +dateTimeFormat(action.lastEditDate)
+                        +dateTimeFormat(action.recordDate)
 
         .col-sm-6
           if component.typeFormId === 'APAFrame'

--- a/app/pug/component_list.pug
+++ b/app/pug/component_list.pug
@@ -30,7 +30,7 @@ block content
                   a(href = `/component/${uuid}`) #{component.data.componentName}
 
                 td
-                  +dateTimeFormat(component.lastEditDate)
+                  +dateTimeFormat(component.recordDate)
                 
                 if component.typeFormId == 'AssembledAPA'
                   td

--- a/app/pug/component_listOfSingleType.pug
+++ b/app/pug/component_listOfSingleType.pug
@@ -71,7 +71,7 @@ block content
                   td #{component.additionalInformation}
 
                 td
-                  +dateTimeFormat(component.lastEditDate)
+                  +dateTimeFormat(component.recordDate)
 
                 if component.typeFormId == 'AssembledAPA'
                   td

--- a/app/pug/component_summary.pug
+++ b/app/pug/component_summary.pug
@@ -56,11 +56,9 @@ block allbody
       .vert-space-x1
         dl
           dt Current Version:
-          dd This is version #{component.validity.version} of the component, and it was last edited on !{' '}
-            +dateTimeFormat(component.insertion.insertDate)
-
-            if component.insertion.user
-              |  by !{' '} #{component.insertion.user.displayName}
+          dd This is version #{component.recordVersion} of the component, and it was last edited on !{' '}
+            +dateTimeFormat(component.recordDate)
+            |  by !{' '} #{component.userName}
 
       if component.typeFormId === 'APAFrameShipment'
         .vert-space-x1.border-success.border.rounded.p-2
@@ -241,11 +239,9 @@ block allbody
               dd #{action.actionId}
 
               dt Performance Data:
-              dd This is version #{action.validity.version} of the action, performed on !{' '}
-                +dateTimeFormat(action.insertion.insertDate)
-
-                if action.insertion.user
-                  |  by !{' '} #{action.insertion.user.displayName}
+              dd This is version #{action.recordVersion} of the action, performed on !{' '}
+                +dateTimeFormat(action.recordDate)
+                |  by !{' '} #{action.userName}
 
                 .vert-space-x1.border-success.border.rounded.p-2
                   .actiontypeform(data-record = action)
@@ -270,11 +266,9 @@ block allbody
               dd #{action.actionId}
 
               dt Performance Data:
-              dd This is version #{action.validity.version} of the action, performed on !{' '}
-                +dateTimeFormat(action.insertion.insertDate)
-
-                if action.insertion.user
-                  |  by !{' '} #{action.insertion.user.displayName}
+              dd This is version #{action.recordVersion} of the action, performed on !{' '}
+                +dateTimeFormat(action.recordDate)
+                |  by !{' '} #{action.userName}
 
                 .vert-space-x1.border-success.border.rounded.p-2
                   .actiontypeform(data-record = action)
@@ -299,11 +293,9 @@ block allbody
               dd #{action.actionId}
 
               dt Performance Data:
-              dd This is version #{action.validity.version} of the action, performed on !{' '}
-                +dateTimeFormat(action.insertion.insertDate)
-
-                if action.insertion.user
-                  |  by !{' '} #{action.insertion.user.displayName}
+              dd This is version #{action.recordVersion} of the action, performed on !{' '}
+                +dateTimeFormat(action.recordDate)
+                |  by !{' '} #{action.userName}
 
                 .vert-space-x1.border-success.border.rounded.p-2
                   .actiontypeform(data-record = action)

--- a/app/pug/workflow.pug
+++ b/app/pug/workflow.pug
@@ -56,14 +56,12 @@ block content
               td [Not Found!]
 
             dt Current Version:
-            dd This is version #{workflow.validity.version} of the workflow.
+            dd This is version #{workflow.recordVersion} of the workflow.
               br
               | It was last edited on !{' '}
-              +dateTimeFormat(workflow.insertion.insertDate)
-
-              if workflow.insertion.user
-                |  by !{' '}
-                a(href = `mailto:${user_email(workflow.insertion.user)}`) #{workflow.insertion.user.displayName}
+              +dateTimeFormat(workflow.recordDate)
+              |  by !{' '}
+              a(href = `mailto:${workflow.userEmail}`) #{workflow.userName}
 
             .vert-space-x1
               .panel.panel-default
@@ -75,13 +73,11 @@ block content
                 ul
                   each v in workflowVersions
                     li 
-                      a(href = `?version=${v.validity.version}`) Version #{v.validity.version}
+                      a(href = `?version=${v.recordVersion}`) Version #{v.recordVersion}
                       |  on 
-                      +dateTimeFormat(v.insertion.insertDate)
-
-                      if v.insertion.user
-                        |  by !{' '}
-                        a(href = `mailto:${user_email(v.insertion.user)}`) #{v.insertion.user.displayName}
+                      +dateTimeFormat(v.recordDate)
+                      |  by !{' '}
+                      a(href = `mailto:${v.userEmail}`) #{v.userName}
 
         .col-sm-4
           .vert-space-x2.form-inline

--- a/app/routes/actions.js
+++ b/app/routes/actions.js
@@ -16,7 +16,7 @@ router.get('/action/:actionId', permissions.checkPermission('actions:view'), asy
     // Set up a query object consisting of the specified action ID and a version number if one is provided (if not, the most recent version is assumed)
     let query = { actionId: req.params.actionId };
 
-    if (req.query.version) query['validity.version'] = parseInt(req.query.version, 10);
+    if (req.query.version) query['recordVersion'] = parseInt(req.query.version, 10);
 
     // Simultaneously retrieve the specified version and all versions of the record, and throw an error if there is no record corresponding to the action ID
     const [action, actionVersions] = await Promise.all([
@@ -67,13 +67,13 @@ router.get('/action/:actionId', permissions.checkPermission('actions:view'), asy
       let filteredVersions = [];
 
       for (const action of actionVersions) {
-        if ((action.insertion.user.displayName == 'M2M Client') && (action.validity.version <= versionNumber)) filteredVersions.push(action);
+        if ((action.userName == 'M2M Client') && (action.recordVersion <= versionNumber)) filteredVersions.push(action);
       }
 
       // If there are at least two matching versions of the action (i.e. so that some comparison can actually be made) ...
       if (filteredVersions.length > 1) {
         // Save the version numbers of the two most recent versions (these are the ones whose tension measurements will be compared)
-        retensionedWires_versions = [filteredVersions[0].validity.version, filteredVersions[1].validity.version];
+        retensionedWires_versions = [filteredVersions[0].recordVersion, filteredVersions[1].recordVersion];
 
         // Loop through the tension measurements on both sides, compare them across the versions, and save any that are different (including the wire or wire segment number)
         // Note that we can use a single loop here, since the number of wire (segments) is always the same on both sides
@@ -419,7 +419,7 @@ router.get(['/json/action/:actionId', '/api/action/:actionId'], permissions.chec
     // Set up a query object consisting of the specified action ID and a version number if one is provided (if not, the most recent version is assumed)
     let query = { actionId: req.params.actionId };
 
-    if (req.query.version) query['validity.version'] = parseInt(req.query.version, 10);
+    if (req.query.version) query['recordVersion'] = parseInt(req.query.version, 10);
 
     // Retrieve the specified version of the record
     // If there is no record corresponding to the ID, or the version number is not valid, this returns 'null'

--- a/app/routes/components.js
+++ b/app/routes/components.js
@@ -26,7 +26,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
     // Set up a query object consisting of the specified component UUID and a version number if one is provided (if not, the most recent version is assumed)
     let query = { componentUuid: req.params.uuid };
 
-    if (req.query.version) query['validity.version'] = parseInt(req.query.version, 10);
+    if (req.query.version) query['recordVersion'] = parseInt(req.query.version, 10);
 
     // Simultaneously retrieve the specified version and all versions of the record, and throw an error if there is no record corresponding to the component UUID
     const [component, componentVersions] = await Promise.all([
@@ -54,7 +54,7 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
 
     // If the specified component is a 'Geometry Board' type, retrieve some more detailed information about any shipments that the board has been part of
     // Add this information to the previously retrieved list of actions performed on the board, and make sure that all of the action entries contain the same (or equivalent) fields
-    // Add an entry for the board itself (again, containing the same fields as the action entries), and finally sort all entries in the combined array by the 'lastEditDate' field
+    // Add an entry for the board itself (again, containing the same fields as the action entries), and finally sort all entries in the combined array by the 'recordDate' field
     if (component.typeFormId === 'GeometryBoard') {
       geoBoardShipments = await Search_OtherComponents.geoBoardShipmentsByBoardUUID(req.params.uuid);
       actions = actions.concat(geoBoardShipments);
@@ -121,11 +121,11 @@ router.get('/component/:uuid', permissions.checkPermission('components:view'), a
       actions.push({
         'typeFormName': 'Board DB Record Created',
         'componentUuid': req.params.uuid,
-        'lastEditDate': new Date(componentVersions[componentVersions.length - 1].validity.startDate),
+        'recordDate': new Date(componentVersions[componentVersions.length - 1].recordDate),
         'data': { 'originOfShipment': 'lancaster' },
       });
 
-      actions.sort(utils.byField_increasing('lastEditDate'));
+      actions.sort(utils.byField_increasing('recordDate'));
     }
 
     // Set a variable to indicate if the specified component type is one that is the subject of a workflow
@@ -963,7 +963,7 @@ router.get(['/json/component/:uuid', '/api/component/:uuid'], permissions.checkP
     // Set up a query object consisting of the specified component UUID and a version number if one is provided (if not, the most recent version is assumed)
     let query = { componentUuid: req.params.uuid };
 
-    if (req.query.version) query['validity.version'] = parseInt(req.query.version, 10);
+    if (req.query.version) query['recordVersion'] = parseInt(req.query.version, 10);
 
     // Retrieve the specified version of the record
     // If there is no record corresponding to the UUID, or the version number is not valid, this returns 'null'

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -170,8 +170,8 @@ router.get(['/json/search/geoBoardShipmentsByBoardUUID/:uuid', '/api/search/geoB
     // Retrieve a list of geometry boards shipments that reference the specified component UUID
     const shipments = await Search_OtherComponents.geoBoardShipmentsByBoardUUID(req.params.uuid);
 
-    // Sort the shipments by increasing 'lastEditDate', i.e. the most recent shipment will be first in the list
-    shipments.sort(utils.byField_decreasing('lastEditDate'));
+    // Sort the shipments by increasing 'recordDate', i.e. the most recent shipment will be first in the list
+    shipments.sort(utils.byField_decreasing('recordDate'));
 
     // Return the list in JSON format
     return res.status(200).json(shipments);

--- a/app/routes/start.js
+++ b/app/routes/start.js
@@ -268,7 +268,7 @@ router.post(['/json/administratorUtility/:inputString', '/api/administratorUtili
   try {
     logger.info(req.body, `Submission to /json/administratorUtility/${req.params.inputString}`);
 
-    let result = await Admin_Functions.setSubmissionInfo_singleCollection(req.params.inputString);    // Change as appropriate for the required utility
+    let result = await Admin_Functions.removeValidityInsertion_singleCollection(req.params.inputString);    // Change as appropriate for the required utility
 
     return res.status(201).json(result);
   } catch (err) {

--- a/app/routes/workflows.js
+++ b/app/routes/workflows.js
@@ -14,7 +14,7 @@ router.get('/workflow/:workflowId', permissions.checkPermission('workflows:view'
     // Set up a query object consisting of the specified workflow ID and a version number if one is provided (if not, the most recent version is assumed)
     let query = { workflowId: req.params.workflowId };
 
-    if (req.query.version) query['validity.version'] = parseInt(req.query.version, 10);
+    if (req.query.version) query['recordVersion'] = parseInt(req.query.version, 10);
 
     // Simultaneously retrieve the specified version and all versions of the record, and throw an error if there is no record corresponding to the workflow ID
     const [workflow, workflowVersions] = await Promise.all([
@@ -273,7 +273,7 @@ router.get(['/json/workflow/:workflowId', '/api/workflow/:workflowId'], permissi
     // Set up a query object consisting of the specified workflow ID and a version number if one is provided (if not, the most recent version is assumed)
     let query = { workflowId: req.params.workflowId };
 
-    if (req.query.version) query['validity.version'] = parseInt(req.query.version, 10);
+    if (req.query.version) query['recordVersion'] = parseInt(req.query.version, 10);
 
     // Retrieve the specified version of the record
     // If there is no record corresponding to the ID, or the version number is not valid, this returns 'null'


### PR DESCRIPTION
- changing backend to use the new top-level fields (added using Administrator Utility)
- administrator utility changed to remove the now unused Validity and Insertion objects from all records

Changes have been tested on Staging.